### PR TITLE
feat: Add support for browser-based logins

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,17 @@ Modern vision of the mobile application for the Open EdX platform from Raccoon G
 3. Choose ``educationx-app-android``.
 
 4. Configure the [config.yaml](config.yaml) with URLs and OAuth credentials for your Open edX instance.
+   You can customise the location of this file using the `OPENEDX_ANDROID_CFG_FILE` environment variable.
 
 5. Select the build variant ``develop``, ``stage``, or ``prod``.
 
 6. Click the **Run** button.
+
+## Customising
+
+To customise assets used in the Android app, you can specify a resource override directory in
+`RES_DIR` in the `config.yaml` file. Any assets in this directory will override assets of the
+same name in this repository.
 
 ## API plugin
 This project uses custom APIs to improve performance and reduce the number of requests to the server.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,12 @@
+import org.yaml.snakeyaml.Yaml
+
+buildscript {
+
+    dependencies {
+        classpath 'org.yaml:snakeyaml:1.33'
+    }
+}
+
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
@@ -5,6 +14,8 @@ plugins {
     id 'kotlin-kapt'
     id "com.google.firebase.crashlytics"
 }
+
+def config = new Yaml().load(new File("config.yaml").newInputStream())
 
 android {
     compileSdk 34
@@ -33,6 +44,26 @@ android {
         }
         stage {
             dimension 'env'
+        }
+    }
+    sourceSets {
+        prod {
+            def envMap = config.environments.find { it.key == "PROD" }
+            if (envMap.value.RES_DIR) {
+                res.srcDirs = [envMap.value.RES_DIR]
+            }
+        }
+        develop {
+            def envMap = config.environments.find { it.key == "DEV" }
+            if (envMap.value.RES_DIR) {
+                res.srcDirs = [envMap.value.RES_DIR]
+            }
+        }
+        stage {
+            def envMap = config.environments.find { it.key == "STAGE" }
+            if (envMap.value.RES_DIR) {
+                res.srcDirs = [envMap.value.RES_DIR]
+            }
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,6 +12,7 @@ plugins {
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-parcelize'
     id 'kotlin-kapt'
+    id 'com.google.gms.google-services'
     id "com.google.firebase.crashlytics"
 }
 
@@ -128,4 +129,12 @@ dependencies {
     testImplementation "io.mockk:mockk-android:$mockk_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
     testImplementation "androidx.arch.core:core-testing:$android_arch_version"
+
+    // Import the Firebase BoM
+    implementation(platform("com.google.firebase:firebase-bom:32.2.3"))
+
+    // When using the BoM, you don't specify versions in Firebase library dependencies
+
+    // Add the dependency for the Firebase SDK for Google Analytics
+    implementation("com.google.firebase:firebase-analytics")
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,9 +42,11 @@ android {
         }
         develop {
             dimension 'env'
+            applicationIdSuffix '.dev'
         }
         stage {
             dimension 'env'
+            applicationIdSuffix '.stage'
         }
     }
     sourceSets {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,8 @@ plugins {
     id "com.google.firebase.crashlytics"
 }
 
-def config = new Yaml().load(new File("config.yaml").newInputStream())
+def config_file = System.getenv("OPENEDX_ANDROID_CFG_FILE") ?: "config.yaml"
+def config = new Yaml().load(new File(config_file).newInputStream())
 
 android {
     compileSdk 34

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ android {
     compileSdk 34
 
     defaultConfig {
-        applicationId "org.openedx.app"
+        applicationId config?.application_id ?: "org.openedx.app"
         minSdk 24
         targetSdk 34
         versionCode 1

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -61,6 +61,14 @@
 -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
 
 #===============/////GSON RULES \\\\\\\============
+
+# Keep Data models from being obfuscated/minimized
+-keep class org.openedx.auth.data.model.** { *; }
+-keep class org.openedx.core.data.model.** { *; }
+-keep class org.openedx.profile.data.model.** { *; }
+-keep class org.openedx.profile.domain.model.** { *; }
+-keep class org.openedx.discussion.data.model.** { *; }
+
 ##---------------Begin: proguard configuration for Gson  ----------
 # Gson uses generic type information stored in a class file when working with fields. Proguard
 # removes such information by default, so configure it to keep all of it.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,6 +35,12 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="${applicationId}"  />
+            </intent-filter>
         </activity>
 
         <provider

--- a/app/src/main/java/org/openedx/app/AppActivity.kt
+++ b/app/src/main/java/org/openedx/app/AppActivity.kt
@@ -3,6 +3,7 @@ package org.openedx.app
 import android.content.pm.ActivityInfo
 import android.content.res.Configuration
 import android.graphics.Color
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.view.WindowManager
@@ -48,6 +49,15 @@ class AppActivity : AppCompatActivity(), InsetHolder, WindowSizeHolder, AppDataH
     private var _insetBottom = 0
 
     private var _windowSize = WindowSize(WindowType.Compact, WindowType.Compact)
+
+    private val authCode: String?
+        get() {
+            val data = intent?.data
+            if (data is Uri && data.scheme == BuildConfig.APPLICATION_ID && data.host == "oauth2Callback") {
+                return data.getQueryParameter("code")
+            }
+            return null
+        }
 
     override fun onSaveInstanceState(outState: Bundle) {
         outState.putInt(TOP_INSET, topInset)
@@ -103,8 +113,12 @@ class AppActivity : AppCompatActivity(), InsetHolder, WindowSizeHolder, AppDataH
                     .add(R.id.container, MainFragment())
                     .commit()
             } else {
+                val fragment = SignInFragment()
+                val bundle = Bundle()
+                bundle.putString("auth_code", authCode)
+                fragment.arguments = bundle
                 supportFragmentManager.beginTransaction()
-                    .add(R.id.container, SignInFragment())
+                    .add(R.id.container, fragment)
                     .commit()
             }
         }

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -54,6 +54,7 @@ android {
 
 dependencies {
     implementation project(path: ':core')
+    implementation 'androidx.browser:browser:1.6.0'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/auth/src/main/java/org/openedx/auth/data/api/AuthApi.kt
+++ b/auth/src/main/java/org/openedx/auth/data/api/AuthApi.kt
@@ -26,6 +26,17 @@ interface AuthApi {
 
     @FormUrlEncoded
     @POST(ApiConstants.URL_ACCESS_TOKEN)
+    suspend fun getAccessToken(
+        @Field("grant_type")
+        grantType: String,
+        @Field("client_id")
+        clientId: String,
+        @Field("code")
+        username: String,
+    ): AuthResponse
+
+    @FormUrlEncoded
+    @POST(ApiConstants.URL_ACCESS_TOKEN)
     fun refreshAccessToken(
         @Field("grant_type") grantType: String,
         @Field("client_id") clientId: String,

--- a/auth/src/main/java/org/openedx/auth/domain/interactor/AuthInteractor.kt
+++ b/auth/src/main/java/org/openedx/auth/domain/interactor/AuthInteractor.kt
@@ -13,6 +13,10 @@ class AuthInteractor(private val repository: AuthRepository) {
         repository.login(username, password)
     }
 
+    suspend fun login(code: String) {
+        repository.login(code)
+    }
+
     suspend fun getRegistrationFields(): List<RegistrationField> {
         return repository.getRegistrationFields()
     }

--- a/auth/src/main/java/org/openedx/auth/presentation/signin/SignInFragment.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signin/SignInFragment.kt
@@ -1,10 +1,10 @@
 package org.openedx.auth.presentation.signin
 
+import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.content.res.Configuration.UI_MODE_NIGHT_NO
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
 import android.net.Uri
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.browser.customtabs.CustomTabsIntent
@@ -70,7 +70,6 @@ class SignInFragment : Fragment() {
                 val uiMessage by viewModel.uiMessage.observeAsState()
                 val loginSuccess by viewModel.loginSuccess.observeAsState(initial = false)
 
-                Log.d("TEST111", context.packageName)
                 LoginScreen(
                     windowSize = windowSize,
                     showProgress = showProgress,
@@ -98,8 +97,8 @@ class SignInFragment : Fragment() {
                             .setUrlBarHidingEnabled(true)
                             .setShowTitle(true)
                             .build()
+                        intent.intent.setFlags(FLAG_ACTIVITY_NEW_TASK);
                         intent.launchUrl(context, uri)
-
                     }
                 )
 

--- a/auth/src/main/java/org/openedx/auth/presentation/signin/SignInViewModel.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signin/SignInViewModel.kt
@@ -72,6 +72,30 @@ class SignInViewModel(
         }
     }
 
+    fun login(code: String) {
+        viewModelScope.launch {
+            try {
+                interactor.login(code)
+                _loginSuccess.value = true
+                setUserId()
+                analytics.userLoginEvent(LoginMethod.BROWSER.methodName)
+            } catch (e: Exception) {
+                if (e is EdxError.InvalidGrantException) {
+                    _uiMessage.value =
+                        UIMessage.SnackBarMessage(resourceManager.getString(CoreRes.string.core_error_invalid_grant))
+                } else if (e.isInternetError()) {
+                    _uiMessage.value =
+                        UIMessage.SnackBarMessage(resourceManager.getString(CoreRes.string.core_error_no_connection))
+                } else {
+                    _uiMessage.value =
+                        UIMessage.SnackBarMessage(resourceManager.getString(CoreRes.string.core_error_unknown_error))
+                }
+            }
+            _showProgress.value = false
+        }
+
+    }
+
     fun signUpClickedEvent() {
         analytics.signUpClickedEvent()
     }
@@ -91,6 +115,7 @@ private enum class LoginMethod(val methodName: String) {
     PASSWORD("Password"),
     FACEBOOK("Facebook"),
     GOOGLE("Google"),
-    MICROSOFT("Microsoft")
+    MICROSOFT("Microsoft"),
+    BROWSER("Browser"),
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ ext {
     firebase_version = "32.1.0"
 
     retrofit_version = '2.9.0'
-    logginginterceptor_version = '4.9.1'
+    logginginterceptor_version = '4.11.0'
 
     koin_version = '3.2.0'
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,6 @@
 environments:
   DEV:
+    # RES_DIR: /path/to/custom/resources
     URLS:
       API_HOST_URL: "https://dev-example.com/"
       privacyPolicy: "https://dev-example.com/privacy"
@@ -13,6 +14,7 @@ environments:
       API_KEY: ""
       GCM_SENDER_ID: ""
   STAGE:
+    # RES_DIR: /path/to/custom/resources
     URLS:
       API_HOST_URL: "http://stage-example.com/"
       privacyPolicy: "http://stage-example.com/privacy"
@@ -26,6 +28,7 @@ environments:
       API_KEY: ""
       GCM_SENDER_ID: ""
   PROD:
+    # RES_DIR: /path/to/custom/resources
     URLS:
       API_HOST_URL: "https://example.com/"
       privacyPolicy: "https://example.com/privacy"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -49,6 +49,7 @@ android {
             buildConfigField "String", "FIREBASE_PROJECT_ID", "\"${firebase.projectId}\""
             buildConfigField "String", "FIREBASE_API_KEY", "\"${firebase.apiKey}\""
             buildConfigField "String", "FIREBASE_GCM_SENDER_ID", "\"${firebase.gcmSenderId}\""
+            buildConfigField "boolean", "BROWSER_LOGIN", "${ envMap.value.LOGIN_VIA_BROWSER }"
             resValue "string", "google_app_id", firebase.appId
             resValue "string", "platform_name", config.platformName
             resValue "string", "platform_full_name", config.platformFullName
@@ -70,6 +71,7 @@ android {
             buildConfigField "String", "FIREBASE_PROJECT_ID", "\"${firebase.projectId}\""
             buildConfigField "String", "FIREBASE_API_KEY", "\"${firebase.apiKey}\""
             buildConfigField "String", "FIREBASE_GCM_SENDER_ID", "\"${firebase.gcmSenderId}\""
+            buildConfigField "boolean", "BROWSER_LOGIN", "${ envMap.value.LOGIN_VIA_BROWSER }"
             resValue "string", "google_app_id", firebase.appId
             resValue "string", "platform_name", config.platformName
             resValue "string", "platform_full_name", config.platformFullName
@@ -91,6 +93,7 @@ android {
             buildConfigField "String", "FIREBASE_PROJECT_ID", "\"${firebase.projectId}\""
             buildConfigField "String", "FIREBASE_API_KEY", "\"${firebase.apiKey}\""
             buildConfigField "String", "FIREBASE_GCM_SENDER_ID", "\"${firebase.gcmSenderId}\""
+            buildConfigField "boolean", "BROWSER_LOGIN", "${ envMap.value.LOGIN_VIA_BROWSER }"
             resValue "string", "google_app_id", firebase.appId
             resValue "string", "platform_name", config.platformName
             resValue "string", "platform_full_name", config.platformFullName

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -18,7 +18,8 @@ plugins {
 }
 
 
-def config = new Yaml().load(new File("config.yaml").newInputStream())
+def config_file = System.getenv("OPENEDX_ANDROID_CFG_FILE") ?: "config.yaml"
+def config = new Yaml().load(new File(config_file).newInputStream())
 
 android {
     compileSdk 34

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -100,6 +100,27 @@ android {
         }
     }
 
+    sourceSets {
+        prod {
+            def envMap = config.environments.find { it.key == "PROD" }
+            if (envMap.value.RES_DIR) {
+                res.srcDirs = [envMap.value.RES_DIR]
+            }
+        }
+        develop {
+            def envMap = config.environments.find { it.key == "DEV" }
+            if (envMap.value.RES_DIR) {
+                res.srcDirs = [envMap.value.RES_DIR]
+            }
+        }
+        stage {
+            def envMap = config.environments.find { it.key == "STAGE" }
+            if (envMap.value.RES_DIR) {
+                res.srcDirs = [envMap.value.RES_DIR]
+            }
+        }
+    }
+
     buildTypes {
         release {
             minifyEnabled true

--- a/core/proguard-rules.pro
+++ b/core/proguard-rules.pro
@@ -19,3 +19,5 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-dontwarn java.lang.invoke.StringConcatFactory

--- a/core/src/main/java/org/openedx/core/ApiConstants.kt
+++ b/core/src/main/java/org/openedx/core/ApiConstants.kt
@@ -11,6 +11,7 @@ object ApiConstants {
     const val URL_PASSWORD_RESET = "/password_reset/"
 
     const val GRANT_TYPE_PASSWORD = "password"
+    const val GRANT_TYPE_CODE = "authorization_code"
 
     const val TOKEN_TYPE_REFRESH = "refresh_token"
 

--- a/course/proguard-rules.pro
+++ b/course/proguard-rules.pro
@@ -19,3 +19,6 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-dontwarn java.lang.invoke.StringConcatFactory
+-dontwarn org.openedx.core.R$string

--- a/dashboard/proguard-rules.pro
+++ b/dashboard/proguard-rules.pro
@@ -19,3 +19,6 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-dontwarn java.lang.invoke.StringConcatFactory
+-dontwarn org.openedx.core.R$string

--- a/discussion/proguard-rules.pro
+++ b/discussion/proguard-rules.pro
@@ -19,3 +19,6 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-dontwarn java.lang.invoke.StringConcatFactory
+-dontwarn org.openedx.core.R$string

--- a/profile/build.gradle
+++ b/profile/build.gradle
@@ -55,6 +55,7 @@ android {
 
 dependencies {
     implementation project(path: ":core")
+    implementation 'androidx.browser:browser:1.6.0'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/profile/proguard-rules.pro
+++ b/profile/proguard-rules.pro
@@ -19,3 +19,6 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-dontwarn java.lang.invoke.StringConcatFactory
+-dontwarn org.openedx.core.R$string

--- a/profile/src/main/java/org/openedx/profile/presentation/profile/ProfileFragment.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/profile/ProfileFragment.kt
@@ -2,9 +2,11 @@ package org.openedx.profile.presentation.profile
 
 import android.content.res.Configuration.UI_MODE_NIGHT_NO
 import android.content.res.Configuration.UI_MODE_NIGHT_YES
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
@@ -41,6 +43,7 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.openedx.core.BuildConfig
 import org.openedx.core.R
 import org.openedx.core.UIMessage
 import org.openedx.profile.domain.model.Account
@@ -87,6 +90,16 @@ class ProfileFragment : Fragment() {
                     appData = (requireActivity() as AppDataHolder).appData,
                     refreshing = refreshing,
                     logout = {
+                        if (BuildConfig.BROWSER_LOGIN) {
+                            val uri = Uri.parse("${BuildConfig.BASE_URL}logout")
+                                .buildUpon()
+                                .appendQueryParameter("next", "/custom-logout-page").build()
+                            val intent = CustomTabsIntent.Builder()
+                                .setUrlBarHidingEnabled(true)
+                                .setShowTitle(true)
+                                .build()
+                            intent.launchUrl(context, uri)
+                        }
                         viewModel.logout()
                     },
                     editAccountClicked = {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,15 @@
 pluginManagement {
+    buildscript {
+        repositories {
+            mavenCentral()
+            maven {
+                url = uri("https://storage.googleapis.com/r8-releases/raw")
+            }
+        }
+        dependencies {
+            classpath("com.android.tools:r8:8.2.24")
+        }
+    }
     repositories {
         gradlePluginPortal()
         google()


### PR DESCRIPTION
For sites that only support logging in using a third-party login provider, allow logging in via a browser.
This new flow will open a custom tab where a user can log in using the supported mechanisms of the site,
then have the client id redirect back to to the app using a callback URL.

The auth code returned by the callback URL can then be used instead of a username and password to log in.

