### PR TITLE
Gson proguard rules fix

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -74,7 +74,7 @@
 #-keep class com.google.gson.stream.** { *; }
 
 # Application classes that will be serialized/deserialized over Gson
--keep class com.google.gson.examples.android.model.** { <fields>; }
+-keep class org.openedx.*.data.model.** { <fields>; }
 
 # Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
 # JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)


### PR DESCRIPTION
Keep classes that will be serialized/deserialized over Gson in proguard-rules.pro