### PR TITLE
Feature/add support for jwt tokens

### DIFF
--- a/app/src/main/java/org/openedx/app/data/networking/HeadersInterceptor.kt
+++ b/app/src/main/java/org/openedx/app/data/networking/HeadersInterceptor.kt
@@ -1,9 +1,9 @@
 package org.openedx.app.data.networking
 
-import org.openedx.core.ApiConstants
 import okhttp3.Interceptor
 import okhttp3.Response
 import org.openedx.core.data.storage.CorePreferences
+import org.openedx.core.BuildConfig.ACCESS_TOKEN_TYPE
 
 class HeadersInterceptor(private val preferencesManager: CorePreferences) : Interceptor {
 
@@ -14,7 +14,7 @@ class HeadersInterceptor(private val preferencesManager: CorePreferences) : Inte
                     val token = preferencesManager.accessToken
 
                     if (token.isNotEmpty()) {
-                        addHeader("Authorization", "${ApiConstants.TOKEN_TYPE_BEARER} $token")
+                        addHeader("Authorization", "$ACCESS_TOKEN_TYPE $token")
                     }
 
                     addHeader("Accept", "application/json")

--- a/app/src/main/java/org/openedx/app/data/networking/OauthRefreshTokenAuthenticator.kt
+++ b/app/src/main/java/org/openedx/app/data/networking/OauthRefreshTokenAuthenticator.kt
@@ -61,7 +61,7 @@ class OauthRefreshTokenAuthenticator(
                         if (newAuth != null) {
                             return response.request.newBuilder()
                                 .header(
-                                    "Authorization",
+                                    HEADER_AUTHORIZATION,
                                     ACCESS_TOKEN_TYPE + " " + newAuth.accessToken
                                 )
                                 .build()
@@ -70,14 +70,13 @@ class OauthRefreshTokenAuthenticator(
                             if (actualToken != accessToken) {
                                 return response.request.newBuilder()
                                     .header(
-                                        "Authorization",
+                                        HEADER_AUTHORIZATION,
                                         "$ACCESS_TOKEN_TYPE $actualToken"
                                     )
                                     .build()
                             }
                             return null
                         }
-
                     } catch (e: Exception) {
                         return null
                     }
@@ -88,12 +87,12 @@ class OauthRefreshTokenAuthenticator(
                     // request does not match the current access_token. This case can occur when
                     // asynchronous calls are made and are attempting to refresh the access_token where
                     // one call succeeds but the other fails. https://github.com/edx/edx-app-android/pull/834
-                    val authHeaders =
-                        response.request.headers["Authorization"]?.split(" ".toRegex())
+                    val authHeaders = response.request.headers[HEADER_AUTHORIZATION]
+                        ?.split(" ".toRegex())
                     if (authHeaders?.toTypedArray()?.getOrNull(1) != accessToken) {
                         return response.request.newBuilder()
                             .header(
-                                "Authorization",
+                                HEADER_AUTHORIZATION,
                                 "$ACCESS_TOKEN_TYPE $accessToken"
                             ).build()
                     }
@@ -141,16 +140,16 @@ class OauthRefreshTokenAuthenticator(
     private fun getErrorCode(responseBody: String): String? {
         try {
             val jsonObj = JSONObject(responseBody)
-            if (jsonObj.has("error_code")) {
-                return jsonObj.getString("error_code")
+            if (jsonObj.has(FIELD_ERROR_CODE)) {
+                return jsonObj.getString(FIELD_ERROR_CODE)
             } else {
                 return if (TOKEN_TYPE_JWT.equals(ACCESS_TOKEN_TYPE, ignoreCase = true)) {
-                    val errorType = if (jsonObj.has("detail")) "detail" else "developer_message"
+                    val errorType = if (jsonObj.has(FIELD_DETAIL)) FIELD_DETAIL else FIELD_DEVELOPER_MESSAGE
                     jsonObj.getString(errorType)
                 } else {
                     val errorCode = jsonObj
-                        .optJSONObject("developer_message")
-                        ?.optString("error_code", "") ?: ""
+                        .optJSONObject(FIELD_DEVELOPER_MESSAGE)
+                        ?.optString(FIELD_ERROR_CODE, "") ?: ""
                     if (errorCode != "") {
                         errorCode
                     } else {
@@ -165,6 +164,8 @@ class OauthRefreshTokenAuthenticator(
     }
 
     companion object {
+        private const val HEADER_AUTHORIZATION = "Authorization"
+
         private const val TOKEN_EXPIRED_ERROR_MESSAGE = "token_expired"
         private const val TOKEN_NONEXISTENT_ERROR_MESSAGE = "token_nonexistent"
         private const val TOKEN_INVALID_GRANT_ERROR_MESSAGE = "invalid_grant"
@@ -172,5 +173,9 @@ class OauthRefreshTokenAuthenticator(
         private const val JWT_TOKEN_EXPIRED = "Token has expired."
         private const val JWT_INVALID_TOKEN = "Invalid token."
         private const val JWT_DISABLED_USER_ERROR_MESSAGE = "User account is disabled."
+
+        private const val FIELD_ERROR_CODE = "error_code"
+        private const val FIELD_DETAIL = "detail"
+        private const val FIELD_DEVELOPER_MESSAGE = "developer_message"
     }
 }

--- a/app/src/main/java/org/openedx/app/data/networking/OauthRefreshTokenAuthenticator.kt
+++ b/app/src/main/java/org/openedx/app/data/networking/OauthRefreshTokenAuthenticator.kt
@@ -2,17 +2,19 @@ package org.openedx.app.data.networking
 
 import android.util.Log
 import com.google.gson.Gson
-import org.openedx.auth.data.api.AuthApi
-import org.openedx.auth.data.model.AuthResponse
-import org.openedx.core.ApiConstants
-import org.openedx.app.system.notifier.AppNotifier
-import org.openedx.app.system.notifier.LogoutEvent
 import kotlinx.coroutines.runBlocking
 import okhttp3.*
 import okhttp3.logging.HttpLoggingInterceptor
 import org.json.JSONException
 import org.json.JSONObject
+import org.openedx.app.system.notifier.AppNotifier
+import org.openedx.app.system.notifier.LogoutEvent
+import org.openedx.auth.data.api.AuthApi
+import org.openedx.auth.data.model.AuthResponse
+import org.openedx.core.ApiConstants
+import org.openedx.core.ApiConstants.TOKEN_TYPE_JWT
 import org.openedx.core.BuildConfig
+import org.openedx.core.BuildConfig.ACCESS_TOKEN_TYPE
 import org.openedx.core.data.storage.CorePreferences
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -53,14 +55,14 @@ class OauthRefreshTokenAuthenticator(
         val errorCode = getErrorCode(response.peekBody(200).string())
         if (errorCode != null) {
             when (errorCode) {
-                TOKEN_EXPIRED_ERROR_MESSAGE -> {
+                TOKEN_EXPIRED_ERROR_MESSAGE, JWT_TOKEN_EXPIRED -> {
                     try {
                         val newAuth = refreshAccessToken(refreshToken)
                         if (newAuth != null) {
                             return response.request.newBuilder()
                                 .header(
                                     "Authorization",
-                                    ApiConstants.TOKEN_TYPE_BEARER + " " + newAuth.accessToken
+                                    ACCESS_TOKEN_TYPE + " " + newAuth.accessToken
                                 )
                                 .build()
                         } else {
@@ -69,7 +71,7 @@ class OauthRefreshTokenAuthenticator(
                                 return response.request.newBuilder()
                                     .header(
                                         "Authorization",
-                                        ApiConstants.TOKEN_TYPE_BEARER + " " + actualToken
+                                        "$ACCESS_TOKEN_TYPE $actualToken"
                                     )
                                     .build()
                             }
@@ -80,7 +82,8 @@ class OauthRefreshTokenAuthenticator(
                         return null
                     }
                 }
-                TOKEN_NONEXISTENT_ERROR_MESSAGE, TOKEN_INVALID_GRANT_ERROR_MESSAGE -> {
+
+                TOKEN_NONEXISTENT_ERROR_MESSAGE, TOKEN_INVALID_GRANT_ERROR_MESSAGE, JWT_INVALID_TOKEN -> {
                     // Retry request with the current access_token if the original access_token used in
                     // request does not match the current access_token. This case can occur when
                     // asynchronous calls are made and are attempting to refresh the access_token where
@@ -91,7 +94,7 @@ class OauthRefreshTokenAuthenticator(
                         return response.request.newBuilder()
                             .header(
                                 "Authorization",
-                                ApiConstants.TOKEN_TYPE_BEARER + " " + accessToken
+                                "$ACCESS_TOKEN_TYPE $accessToken"
                             ).build()
                     }
 
@@ -99,7 +102,8 @@ class OauthRefreshTokenAuthenticator(
                         appNotifier.send(LogoutEvent())
                     }
                 }
-                DISABLED_USER_ERROR_MESSAGE -> {
+
+                DISABLED_USER_ERROR_MESSAGE, JWT_DISABLED_USER_ERROR_MESSAGE -> {
                     runBlocking {
                         appNotifier.send(LogoutEvent())
                     }
@@ -114,7 +118,8 @@ class OauthRefreshTokenAuthenticator(
         val response = authApi.refreshAccessToken(
             ApiConstants.TOKEN_TYPE_REFRESH,
             BuildConfig.CLIENT_ID,
-            refreshToken
+            refreshToken,
+            ACCESS_TOKEN_TYPE
         ).execute()
         val authResponse = response.body()
         if (response.isSuccessful && authResponse != null) {
@@ -136,17 +141,21 @@ class OauthRefreshTokenAuthenticator(
     private fun getErrorCode(responseBody: String): String? {
         try {
             val jsonObj = JSONObject(responseBody)
-            var errorCode = jsonObj.optString("error_code", "")
-            return if (errorCode != "") {
-                errorCode
+            if (jsonObj.has("error_code")) {
+                return jsonObj.getString("error_code")
             } else {
-                errorCode = jsonObj
-                    .optJSONObject("developer_message")
-                    ?.optString("error_code", "") ?: ""
-                if (errorCode != "") {
-                    errorCode
+                return if (TOKEN_TYPE_JWT.equals(ACCESS_TOKEN_TYPE, ignoreCase = true)) {
+                    val errorType = if (jsonObj.has("detail")) "detail" else "developer_message"
+                    jsonObj.getString(errorType)
                 } else {
-                    null
+                    val errorCode = jsonObj
+                        .optJSONObject("developer_message")
+                        ?.optString("error_code", "") ?: ""
+                    if (errorCode != "") {
+                        errorCode
+                    } else {
+                        null
+                    }
                 }
             }
         } catch (ex: JSONException) {
@@ -160,5 +169,8 @@ class OauthRefreshTokenAuthenticator(
         private const val TOKEN_NONEXISTENT_ERROR_MESSAGE = "token_nonexistent"
         private const val TOKEN_INVALID_GRANT_ERROR_MESSAGE = "invalid_grant"
         private const val DISABLED_USER_ERROR_MESSAGE = "user_is_disabled"
+        private const val JWT_TOKEN_EXPIRED = "Token has expired."
+        private const val JWT_INVALID_TOKEN = "Invalid token."
+        private const val JWT_DISABLED_USER_ERROR_MESSAGE = "User account is disabled."
     }
 }

--- a/auth/src/main/java/org/openedx/auth/data/api/AuthApi.kt
+++ b/auth/src/main/java/org/openedx/auth/data/api/AuthApi.kt
@@ -14,14 +14,12 @@ interface AuthApi {
     @FormUrlEncoded
     @POST(ApiConstants.URL_ACCESS_TOKEN)
     suspend fun getAccessToken(
-        @Field("grant_type")
-        grantType: String,
-        @Field("client_id")
-        clientId: String,
-        @Field("username")
-        username: String,
-        @Field("password")
-        password: String,
+        @Field("grant_type") grantType: String,
+        @Field("client_id") clientId: String,
+        @Field("username") username: String,
+        @Field("password") password: String,
+        @Field("token_type") tokenType: String,
+        @Field("asymmetric_jwt") isAsymmetricJwt: Boolean = true,
     ): AuthResponse
 
     @FormUrlEncoded
@@ -30,6 +28,8 @@ interface AuthApi {
         @Field("grant_type") grantType: String,
         @Field("client_id") clientId: String,
         @Field("refresh_token") refreshToken: String,
+        @Field("token_type") tokenType: String,
+        @Field("asymmetric_jwt") isAsymmetricJwt: Boolean = true,
     ): Call<AuthResponse>
 
     @GET(ApiConstants.URL_REGISTRATION_FIELDS)

--- a/auth/src/main/java/org/openedx/auth/data/repository/AuthRepository.kt
+++ b/auth/src/main/java/org/openedx/auth/data/repository/AuthRepository.kt
@@ -20,7 +20,8 @@ class AuthRepository(
             ApiConstants.GRANT_TYPE_PASSWORD,
             org.openedx.core.BuildConfig.CLIENT_ID,
             username,
-            password
+            password,
+            org.openedx.core.BuildConfig.ACCESS_TOKEN_TYPE
         )
         if (authResponse.error != null) {
             throw EdxError.UnknownException(authResponse.error!!)

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,4 @@
+#Set of environments
 environments:
   DEV:
     URLS:
@@ -38,5 +39,8 @@ environments:
       APPLICATION_ID: ""
       API_KEY: ""
       GCM_SENDER_ID: ""
+#Platform names
 platformName: "OpenEdX"
 platformFullName: "OpenEdX"
+#tokenType enum accepts JWT and BEARER only
+tokenType: "JWT"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -29,6 +29,8 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
+
+        buildConfigField "String", "ACCESS_TOKEN_TYPE", "\"${config.tokenType}\""
     }
 
     namespace 'org.openedx.core'

--- a/core/src/main/java/org/openedx/core/ApiConstants.kt
+++ b/core/src/main/java/org/openedx/core/ApiConstants.kt
@@ -12,10 +12,9 @@ object ApiConstants {
 
     const val GRANT_TYPE_PASSWORD = "password"
 
-    const val TOKEN_TYPE_REFRESH = "refresh_token"
-
     const val TOKEN_TYPE_BEARER = "Bearer"
     const val TOKEN_TYPE_JWT = "jwt"
+    const val TOKEN_TYPE_REFRESH = "refresh_token"
 
     const val EMAIL = "email"
     const val PASSWORD = "password"

--- a/core/src/main/java/org/openedx/core/ApiConstants.kt
+++ b/core/src/main/java/org/openedx/core/ApiConstants.kt
@@ -15,6 +15,7 @@ object ApiConstants {
     const val TOKEN_TYPE_REFRESH = "refresh_token"
 
     const val TOKEN_TYPE_BEARER = "Bearer"
+    const val TOKEN_TYPE_JWT = "jwt"
 
     const val EMAIL = "email"
     const val PASSWORD = "password"


### PR DESCRIPTION
By default, access tokens are now in JWT format.
The type of access token can be changed in the [config.yaml](https://github.com/openedx/openedx-app-android/blob/feature/add_support_for_jwt_tokens/config.yaml#L46) file.