### PR TITLE
feat: Add Token Refresh Implementation to Network Layer

### DIFF
--- a/app/src/main/java/org/openedx/app/data/storage/PreferencesManager.kt
+++ b/app/src/main/java/org/openedx/app/data/storage/PreferencesManager.kt
@@ -3,25 +3,35 @@ package org.openedx.app.data.storage
 import android.content.Context
 import com.google.gson.Gson
 import org.openedx.app.BuildConfig
-import org.openedx.core.data.storage.CorePreferences
-import org.openedx.profile.data.model.Account
 import org.openedx.core.data.model.User
+import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.data.storage.InAppReviewPreferences
 import org.openedx.core.domain.model.VideoSettings
+import org.openedx.profile.data.model.Account
 import org.openedx.profile.data.storage.ProfilePreferences
 import org.openedx.whatsnew.data.storage.WhatsNewPreferences
 
-class PreferencesManager(context: Context) : CorePreferences, ProfilePreferences, WhatsNewPreferences,
-    InAppReviewPreferences {
+class PreferencesManager(context: Context) : CorePreferences, ProfilePreferences,
+    WhatsNewPreferences, InAppReviewPreferences {
 
-    private val sharedPreferences = context.getSharedPreferences(BuildConfig.APPLICATION_ID, Context.MODE_PRIVATE)
+    private val sharedPreferences =
+        context.getSharedPreferences(BuildConfig.APPLICATION_ID, Context.MODE_PRIVATE)
 
     private fun saveString(key: String, value: String) {
         sharedPreferences.edit().apply {
             putString(key, value)
         }.apply()
     }
+
     private fun getString(key: String): String = sharedPreferences.getString(key, "") ?: ""
+
+    private fun saveLong(key: String, value: Long) {
+        sharedPreferences.edit().apply {
+            putLong(key, value)
+        }.apply()
+    }
+
+    private fun getLong(key: String): Long = sharedPreferences.getLong(key, 0L)
 
     private fun saveBoolean(key: String, value: Boolean) {
         sharedPreferences.edit().apply {
@@ -36,6 +46,7 @@ class PreferencesManager(context: Context) : CorePreferences, ProfilePreferences
             remove(ACCESS_TOKEN)
             remove(REFRESH_TOKEN)
             remove(USER)
+            remove(EXPIRES_IN)
         }.apply()
     }
 
@@ -50,6 +61,12 @@ class PreferencesManager(context: Context) : CorePreferences, ProfilePreferences
             saveString(REFRESH_TOKEN, value)
         }
         get() = getString(REFRESH_TOKEN)
+
+    override var accessTokenExpiresAt: Long
+        set(value) {
+            saveLong(EXPIRES_IN, value)
+        }
+        get() = getLong(EXPIRES_IN)
 
     override var user: User?
         set(value) {
@@ -95,7 +112,10 @@ class PreferencesManager(context: Context) : CorePreferences, ProfilePreferences
         }
         get() {
             val versionNameString = getString(LAST_REVIEW_VERSION)
-            return Gson().fromJson(versionNameString, InAppReviewPreferences.VersionName::class.java)
+            return Gson().fromJson(
+                versionNameString,
+                InAppReviewPreferences.VersionName::class.java
+            )
                 ?: InAppReviewPreferences.VersionName.default
         }
 
@@ -109,6 +129,7 @@ class PreferencesManager(context: Context) : CorePreferences, ProfilePreferences
     companion object {
         private const val ACCESS_TOKEN = "access_token"
         private const val REFRESH_TOKEN = "refresh_token"
+        private const val EXPIRES_IN = "expires_in"
         private const val USER = "user"
         private const val ACCOUNT = "account"
         private const val VIDEO_SETTINGS = "video_settings"

--- a/app/src/main/java/org/openedx/app/di/NetworkingModule.kt
+++ b/app/src/main/java/org/openedx/app/di/NetworkingModule.kt
@@ -31,6 +31,7 @@ val networkingModule = module {
             }
             addInterceptor(HandleErrorInterceptor(get()))
             addInterceptor(AppUpgradeInterceptor(get()))
+            addInterceptor(get<OauthRefreshTokenAuthenticator>())
             authenticator(get<OauthRefreshTokenAuthenticator>())
         }.build()
     }

--- a/auth/src/main/java/org/openedx/auth/data/model/AuthResponse.kt
+++ b/auth/src/main/java/org/openedx/auth/data/model/AuthResponse.kt
@@ -16,4 +16,3 @@ data class AuthResponse(
     @SerializedName("refresh_token")
     var refreshToken: String?,
 )
-

--- a/auth/src/main/java/org/openedx/auth/data/model/AuthResponse.kt
+++ b/auth/src/main/java/org/openedx/auth/data/model/AuthResponse.kt
@@ -1,6 +1,7 @@
 package org.openedx.auth.data.model
 
 import com.google.gson.annotations.SerializedName
+import org.openedx.auth.domain.model.AuthResponse
 
 data class AuthResponse(
     @SerializedName("access_token")
@@ -15,4 +16,15 @@ data class AuthResponse(
     var error: String?,
     @SerializedName("refresh_token")
     var refreshToken: String?,
-)
+) {
+    fun mapToDomain(): AuthResponse {
+        return AuthResponse(
+            accessToken = accessToken,
+            tokenType = tokenType,
+            expiresIn = expiresIn?.times(1000),
+            scope = scope,
+            error = error,
+            refreshToken = refreshToken,
+        )
+    }
+}

--- a/auth/src/main/java/org/openedx/auth/data/repository/AuthRepository.kt
+++ b/auth/src/main/java/org/openedx/auth/data/repository/AuthRepository.kt
@@ -6,6 +6,7 @@ import org.openedx.core.ApiConstants
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.RegistrationField
 import org.openedx.core.system.EdxError
+import org.openedx.core.utils.TimeUtils
 
 class AuthRepository(
     private val api: AuthApi,
@@ -28,6 +29,8 @@ class AuthRepository(
         }
         preferencesManager.accessToken = authResponse.accessToken ?: ""
         preferencesManager.refreshToken = authResponse.refreshToken ?: ""
+        preferencesManager.accessTokenExpiresAt =
+            (authResponse.expiresIn ?: 0L) + TimeUtils.getCurrentTimeInSeconds()
         val user = api.getProfile()
         preferencesManager.user = user
     }

--- a/auth/src/main/java/org/openedx/auth/domain/model/AuthResponse.kt
+++ b/auth/src/main/java/org/openedx/auth/domain/model/AuthResponse.kt
@@ -1,0 +1,19 @@
+package org.openedx.auth.domain.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import org.openedx.core.utils.TimeUtils
+
+@Parcelize
+data class AuthResponse(
+    var accessToken: String?,
+    var tokenType: String?,
+    var expiresIn: Long?,
+    var scope: String?,
+    var error: String?,
+    var refreshToken: String?,
+) : Parcelable {
+    fun getTokenExpiryTime(): Long {
+        return (expiresIn ?: 0L) + TimeUtils.getCurrentTime()
+    }
+}

--- a/core/src/main/java/org/openedx/core/data/storage/CorePreferences.kt
+++ b/core/src/main/java/org/openedx/core/data/storage/CorePreferences.kt
@@ -6,6 +6,7 @@ import org.openedx.core.domain.model.VideoSettings
 interface CorePreferences {
     var accessToken: String
     var refreshToken: String
+    var accessTokenExpiresAt: Long
     var user: User?
     var videoSettings: VideoSettings
 

--- a/core/src/main/java/org/openedx/core/utils/TimeUtils.kt
+++ b/core/src/main/java/org/openedx/core/utils/TimeUtils.kt
@@ -12,7 +12,6 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
-import java.util.concurrent.TimeUnit
 
 object TimeUtils {
 
@@ -24,8 +23,8 @@ object TimeUtils {
 
     private const val SEVEN_DAYS_IN_MILLIS = 604800000L
 
-    fun getCurrentTimeInSeconds(): Long {
-        return TimeUnit.MILLISECONDS.toSeconds(Calendar.getInstance().timeInMillis)
+    fun getCurrentTime(): Long {
+        return Calendar.getInstance().timeInMillis
     }
 
     fun iso8601ToDate(text: String): Date? {

--- a/core/src/main/java/org/openedx/core/utils/TimeUtils.kt
+++ b/core/src/main/java/org/openedx/core/utils/TimeUtils.kt
@@ -9,8 +9,10 @@ import org.openedx.core.system.ResourceManager
 import java.text.ParseException
 import java.text.ParsePosition
 import java.text.SimpleDateFormat
+import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+import java.util.concurrent.TimeUnit
 
 object TimeUtils {
 
@@ -21,6 +23,10 @@ object TimeUtils {
     const val FORMAT_DATE_TAB = "EEE, MMM dd, yyyy"
 
     private const val SEVEN_DAYS_IN_MILLIS = 604800000L
+
+    fun getCurrentTimeInSeconds(): Long {
+        return TimeUnit.MILLISECONDS.toSeconds(Calendar.getInstance().timeInMillis)
+    }
 
     fun iso8601ToDate(text: String): Date? {
         return try {


### PR DESCRIPTION
It applies token authentication to the network requests before a network call is made. The expiry duration is saved and it is applied before a network request is queued.

**Authentication:**
- [ ] Token authentication before a network request
- [ ] Refresh expired token **before** making a network request
- [ ] Only one token refresh call for all async network requests
- [ ] Only one token refresh call for all sync network requests
- [ ] No looping of network calls during network problem
