### PR TITLE
fix: Update resume course navigation

### DIFF
--- a/app/src/main/java/org/openedx/app/AppRouter.kt
+++ b/app/src/main/java/org/openedx/app/AppRouter.kt
@@ -127,37 +127,50 @@ class AppRouter : AuthRouter, DiscoveryRouter, DashboardRouter, CourseRouter, Di
     override fun navigateToCourseSubsections(
         fm: FragmentManager,
         courseId: String,
-        blockId: String,
-        mode: CourseViewMode,
-        descendantId: String?
+        subSectionId: String,
+        unitId: String?,
+        componentId: String?,
+        mode: CourseViewMode
     ) {
         replaceFragmentWithBackStack(
             fm,
-            CourseSectionFragment.newInstance(courseId, blockId, mode, descendantId)
+            CourseSectionFragment.newInstance(courseId, subSectionId, mode, unitId, componentId)
         )
     }
 
     override fun navigateToCourseContainer(
         fm: FragmentManager,
-        blockId: String,
         courseId: String,
+        unitId: String,
+        componentId: String?,
         mode: CourseViewMode
     ) {
         replaceFragmentWithBackStack(
             fm,
-            CourseUnitContainerFragment.newInstance(blockId, courseId, mode)
+            CourseUnitContainerFragment.newInstance(
+                courseId,
+                unitId,
+                componentId,
+                mode
+            )
         )
     }
 
     override fun replaceCourseContainer(
         fm: FragmentManager,
-        blockId: String,
         courseId: String,
+        unitId: String,
+        componentId: String?,
         mode: CourseViewMode
     ) {
         replaceFragment(
             fm,
-            CourseUnitContainerFragment.newInstance(blockId, courseId, mode),
+            CourseUnitContainerFragment.newInstance(
+                courseId,
+                unitId,
+                componentId,
+                mode
+            ),
             FragmentTransaction.TRANSIT_FRAGMENT_FADE
         )
     }

--- a/app/src/main/java/org/openedx/app/AppRouter.kt
+++ b/app/src/main/java/org/openedx/app/AppRouter.kt
@@ -128,13 +128,19 @@ class AppRouter : AuthRouter, DiscoveryRouter, DashboardRouter, CourseRouter, Di
         fm: FragmentManager,
         courseId: String,
         subSectionId: String,
-        unitId: String?,
-        componentId: String?,
+        unitId: String,
+        componentId: String,
         mode: CourseViewMode
     ) {
         replaceFragmentWithBackStack(
             fm,
-            CourseSectionFragment.newInstance(courseId, subSectionId, mode, unitId, componentId)
+            CourseSectionFragment.newInstance(
+                courseId = courseId,
+                subSectionId = subSectionId,
+                unitId = unitId,
+                componentId = componentId,
+                mode = mode
+            )
         )
     }
 
@@ -142,16 +148,16 @@ class AppRouter : AuthRouter, DiscoveryRouter, DashboardRouter, CourseRouter, Di
         fm: FragmentManager,
         courseId: String,
         unitId: String,
-        componentId: String?,
+        componentId: String,
         mode: CourseViewMode
     ) {
         replaceFragmentWithBackStack(
             fm,
             CourseUnitContainerFragment.newInstance(
-                courseId,
-                unitId,
-                componentId,
-                mode
+                courseId = courseId,
+                unitId = unitId,
+                componentId = componentId,
+                mode = mode
             )
         )
     }
@@ -160,16 +166,16 @@ class AppRouter : AuthRouter, DiscoveryRouter, DashboardRouter, CourseRouter, Di
         fm: FragmentManager,
         courseId: String,
         unitId: String,
-        componentId: String?,
+        componentId: String,
         mode: CourseViewMode
     ) {
         replaceFragment(
             fm,
             CourseUnitContainerFragment.newInstance(
-                courseId,
-                unitId,
-                componentId,
-                mode
+                courseId = courseId,
+                unitId = unitId,
+                componentId = componentId,
+                mode = mode
             ),
             FragmentTransaction.TRANSIT_FRAGMENT_FADE
         )

--- a/core/src/main/java/org/openedx/core/domain/model/CourseStructure.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/CourseStructure.kt
@@ -19,11 +19,17 @@ data class CourseStructure(
     val certificate: Certificate?,
     val isSelfPaced: Boolean
 ) {
-    fun getVerticalBlocks(): List<Block> {
-        return blockData.filter { it.type == BlockType.VERTICAL }
-    }
+    val getVerticalBlocks: List<Block>
+        get() = blockData.getVerticalBlocks()
 
-    fun getSequentialBlocks(): List<Block> {
-        return blockData.filter { it.type == BlockType.SEQUENTIAL }
-    }
+    val getSequentialBlocks: List<Block>
+        get() = blockData.getSequentialBlocks()
+}
+
+fun List<Block>.getVerticalBlocks(): List<Block> {
+    return this.filter { it.type == BlockType.VERTICAL }
+}
+
+fun List<Block>.getSequentialBlocks(): List<Block> {
+    return this.filter { it.type == BlockType.SEQUENTIAL }
 }

--- a/core/src/main/java/org/openedx/core/domain/model/CourseStructure.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/CourseStructure.kt
@@ -1,6 +1,5 @@
 package org.openedx.core.domain.model
 
-import org.openedx.core.BlockType
 import java.util.Date
 
 data class CourseStructure(
@@ -18,18 +17,4 @@ data class CourseStructure(
     val media: Media?,
     val certificate: Certificate?,
     val isSelfPaced: Boolean
-) {
-    val getVerticalBlocks: List<Block>
-        get() = blockData.getVerticalBlocks()
-
-    val getSequentialBlocks: List<Block>
-        get() = blockData.getSequentialBlocks()
-}
-
-fun List<Block>.getVerticalBlocks(): List<Block> {
-    return this.filter { it.type == BlockType.VERTICAL }
-}
-
-fun List<Block>.getSequentialBlocks(): List<Block> {
-    return this.filter { it.type == BlockType.SEQUENTIAL }
-}
+)

--- a/core/src/main/java/org/openedx/core/extension/ListExt.kt
+++ b/core/src/main/java/org/openedx/core/extension/ListExt.kt
@@ -1,5 +1,8 @@
 package org.openedx.core.extension
 
+import org.openedx.core.BlockType
+import org.openedx.core.domain.model.Block
+
 inline fun <T> List<T>.indexOfFirstFromIndex(startIndex: Int, predicate: (T) -> Boolean): Int {
     var index = 0
     for ((i, item) in this.withIndex()) {
@@ -22,4 +25,12 @@ fun <T> MutableList<T>.clearAndAddAll(collection: Collection<T>): MutableList<T>
     this.clear()
     this.addAll(collection)
     return this
+}
+
+fun List<Block>.getVerticalBlocks(): List<Block> {
+    return this.filter { it.type == BlockType.VERTICAL }
+}
+
+fun List<Block>.getSequentialBlocks(): List<Block> {
+    return this.filter { it.type == BlockType.SEQUENTIAL }
 }

--- a/course/src/main/java/org/openedx/course/presentation/CourseRouter.kt
+++ b/course/src/main/java/org/openedx/course/presentation/CourseRouter.kt
@@ -24,22 +24,25 @@ interface CourseRouter {
     fun navigateToCourseSubsections(
         fm: FragmentManager,
         courseId: String,
-        blockId: String,
-        mode: CourseViewMode,
-        descendantId: String? = ""
+        subSectionId: String,
+        unitId: String? = "",
+        componentId: String? = "",
+        mode: CourseViewMode
     )
 
     fun navigateToCourseContainer(
         fm: FragmentManager,
-        blockId: String,
         courseId: String,
+        unitId: String,
+        componentId: String? = "",
         mode: CourseViewMode
     )
 
     fun replaceCourseContainer(
         fm: FragmentManager,
-        blockId: String,
         courseId: String,
+        unitId: String,
+        componentId: String? = "",
         mode: CourseViewMode
     )
 

--- a/course/src/main/java/org/openedx/course/presentation/CourseRouter.kt
+++ b/course/src/main/java/org/openedx/course/presentation/CourseRouter.kt
@@ -25,8 +25,8 @@ interface CourseRouter {
         fm: FragmentManager,
         courseId: String,
         subSectionId: String,
-        unitId: String? = "",
-        componentId: String? = "",
+        unitId: String = "",
+        componentId: String = "",
         mode: CourseViewMode
     )
 
@@ -34,7 +34,7 @@ interface CourseRouter {
         fm: FragmentManager,
         courseId: String,
         unitId: String,
-        componentId: String? = "",
+        componentId: String = "",
         mode: CourseViewMode
     )
 
@@ -42,7 +42,7 @@ interface CourseRouter {
         fm: FragmentManager,
         courseId: String,
         unitId: String,
-        componentId: String? = "",
+        componentId: String = "",
         mode: CourseViewMode
     )
 

--- a/course/src/main/java/org/openedx/course/presentation/dates/CourseDatesFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/dates/CourseDatesFragment.kt
@@ -148,11 +148,11 @@ class CourseDatesFragment : Fragment() {
                                 viewModel.getSequentialBlock(verticalBlock.id)
                                     ?.let { sequentialBlock ->
                                         router.navigateToCourseSubsections(
-                                            requireActivity().supportFragmentManager,
-                                            blockId = sequentialBlock.id,
+                                            fm = requireActivity().supportFragmentManager,
+                                            subSectionId = sequentialBlock.id,
                                             courseId = viewModel.courseId,
-                                            mode = CourseViewMode.FULL,
-                                            descendantId = verticalBlock.id
+                                            unitId = verticalBlock.id,
+                                            mode = CourseViewMode.FULL
                                         )
                                     }
                             }

--- a/course/src/main/java/org/openedx/course/presentation/dates/CourseDatesViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/dates/CourseDatesViewModel.kt
@@ -9,6 +9,8 @@ import org.openedx.core.R
 import org.openedx.core.SingleEventLiveData
 import org.openedx.core.UIMessage
 import org.openedx.core.domain.model.Block
+import org.openedx.core.extension.getSequentialBlocks
+import org.openedx.core.extension.getVerticalBlocks
 import org.openedx.core.extension.isInternetError
 import org.openedx.core.system.ResourceManager
 import org.openedx.core.system.connection.NetworkConnection
@@ -73,7 +75,7 @@ class CourseDatesViewModel(
     fun getVerticalBlock(blockId: String): Block? {
         return try {
             val courseStructure = interactor.getCourseStructureFromCache()
-            courseStructure.getVerticalBlocks.find { it.descendants.contains(blockId) }
+            courseStructure.blockData.getVerticalBlocks().find { it.descendants.contains(blockId) }
         } catch (e: Exception) {
             null
         }
@@ -82,7 +84,8 @@ class CourseDatesViewModel(
     fun getSequentialBlock(blockId: String): Block? {
         return try {
             val courseStructure = interactor.getCourseStructureFromCache()
-            courseStructure.getSequentialBlocks.find { it.descendants.contains(blockId) }
+            courseStructure.blockData.getSequentialBlocks()
+                .find { it.descendants.contains(blockId) }
         } catch (e: Exception) {
             null
         }

--- a/course/src/main/java/org/openedx/course/presentation/dates/CourseDatesViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/dates/CourseDatesViewModel.kt
@@ -73,7 +73,7 @@ class CourseDatesViewModel(
     fun getVerticalBlock(blockId: String): Block? {
         return try {
             val courseStructure = interactor.getCourseStructureFromCache()
-            courseStructure.getVerticalBlocks().find { it.descendants.contains(blockId) }
+            courseStructure.getVerticalBlocks.find { it.descendants.contains(blockId) }
         } catch (e: Exception) {
             null
         }
@@ -82,7 +82,7 @@ class CourseDatesViewModel(
     fun getSequentialBlock(blockId: String): Block? {
         return try {
             val courseStructure = interactor.getCourseStructureFromCache()
-            courseStructure.getSequentialBlocks().find { it.descendants.contains(blockId) }
+            courseStructure.getSequentialBlocks.find { it.descendants.contains(blockId) }
         } catch (e: Exception) {
             null
         }

--- a/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineFragment.kt
@@ -97,21 +97,25 @@ class CourseOutlineFragment : Fragment() {
                     onItemClick = { block ->
                         viewModel.sequentialClickedEvent(block.blockId, block.displayName)
                         router.navigateToCourseSubsections(
-                            requireActivity().supportFragmentManager,
+                            fm = requireActivity().supportFragmentManager,
                             courseId = viewModel.courseId,
-                            blockId = block.id,
+                            subSectionId = block.id,
                             mode = CourseViewMode.FULL
                         )
                     },
-                    onResumeClick = { blockId ->
-                        viewModel.resumeSectionBlock?.let { sequential ->
-                            viewModel.resumeCourseTappedEvent(sequential.blockId)
-                            router.navigateToCourseSubsections(
-                                requireActivity().supportFragmentManager,
-                                viewModel.courseId,
-                                sequential.id,
-                                CourseViewMode.FULL
-                            )
+                    onResumeClick = { componentId ->
+                        viewModel.resumeSectionBlock?.let { subSection ->
+                            viewModel.resumeCourseTappedEvent(subSection.id)
+                            viewModel.resumeVerticalBlock?.let { unit ->
+                                router.navigateToCourseSubsections(
+                                    requireActivity().supportFragmentManager,
+                                    courseId = viewModel.courseId,
+                                    subSectionId = subSection.id,
+                                    mode = CourseViewMode.FULL,
+                                    unitId = unit.id,
+                                    componentId = componentId
+                                )
+                            }
                         }
                     },
                     onBackClick = {
@@ -290,18 +294,18 @@ internal fun CourseOutlineScreen(
                                             courseName = uiState.courseStructure.name
                                         )
                                     }
-                                    if (uiState.resumeBlock != null) {
+                                    if (uiState.resumeComponent != null) {
                                         item {
                                             Spacer(Modifier.height(28.dp))
                                             Box(listPadding) {
                                                 if (windowSize.isTablet) {
                                                     ResumeCourseTablet(
-                                                        block = uiState.resumeBlock,
+                                                        block = uiState.resumeComponent,
                                                         onResumeClick = onResumeClick
                                                     )
                                                 } else {
                                                     ResumeCourse(
-                                                        block = uiState.resumeBlock,
+                                                        block = uiState.resumeComponent,
                                                         onResumeClick = onResumeClick
                                                     )
                                                 }

--- a/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineUIState.kt
+++ b/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineUIState.kt
@@ -8,7 +8,7 @@ sealed class CourseOutlineUIState {
     data class CourseData(
         val courseStructure: CourseStructure,
         val downloadedState: Map<String, DownloadedState>,
-        val resumeBlock: Block?
+        val resumeComponent: Block?
     ) : CourseOutlineUIState()
 
     object Loading : CourseOutlineUIState()

--- a/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineViewModel.kt
@@ -13,6 +13,8 @@ import org.openedx.core.config.Config
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.Block
 import org.openedx.core.domain.model.CourseComponentStatus
+import org.openedx.core.domain.model.getSequentialBlocks
+import org.openedx.core.domain.model.getVerticalBlocks
 import org.openedx.core.extension.isInternetError
 import org.openedx.core.module.DownloadWorkerController
 import org.openedx.core.module.db.DownloadDao
@@ -81,7 +83,7 @@ class CourseOutlineViewModel(
                     _uiState.value = CourseOutlineUIState.CourseData(
                         courseStructure = state.courseStructure,
                         downloadedState = it.toMap(),
-                        resumeBlock = state.resumeBlock
+                        resumeComponent = state.resumeComponent
                     )
                 }
             }
@@ -137,7 +139,7 @@ class CourseOutlineViewModel(
                 _uiState.value = CourseOutlineUIState.CourseData(
                     courseStructure = courseStructure,
                     downloadedState = getDownloadModelsStatus(),
-                    resumeBlock = getResumeBlock(blocks, courseStatus.lastVisitedBlockId)
+                    resumeComponent = getResumeBlock(blocks, courseStatus.lastVisitedBlockId)
                 )
             } catch (e: Exception) {
                 if (e.isInternetError()) {
@@ -176,13 +178,11 @@ class CourseOutlineViewModel(
         continueBlockId: String
     ): Block? {
         val resumeBlock = blocks.firstOrNull { it.id == continueBlockId }
-        resumeVerticalBlock = blocks.find {
-            it.descendants.contains(resumeBlock?.id) && it.type == BlockType.VERTICAL
-        }
-        resumeSectionBlock = blocks.find {
-            it.descendants.contains(resumeVerticalBlock?.id) && it.type == BlockType.SEQUENTIAL
-        }
-        return resumeVerticalBlock
+        resumeVerticalBlock =
+            blocks.getVerticalBlocks().find { it.descendants.contains(resumeBlock?.id) }
+        resumeSectionBlock =
+            blocks.getSequentialBlocks().find { it.descendants.contains(resumeVerticalBlock?.id) }
+        return resumeBlock
     }
 
     fun resumeCourseTappedEvent(blockId: String) {

--- a/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineViewModel.kt
@@ -13,8 +13,8 @@ import org.openedx.core.config.Config
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.Block
 import org.openedx.core.domain.model.CourseComponentStatus
-import org.openedx.core.domain.model.getSequentialBlocks
-import org.openedx.core.domain.model.getVerticalBlocks
+import org.openedx.core.extension.getSequentialBlocks
+import org.openedx.core.extension.getVerticalBlocks
 import org.openedx.core.extension.isInternetError
 import org.openedx.core.module.DownloadWorkerController
 import org.openedx.core.module.db.DownloadDao

--- a/course/src/main/java/org/openedx/course/presentation/section/CourseSectionFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/section/CourseSectionFragment.kt
@@ -171,9 +171,9 @@ class CourseSectionFragment : Fragment() {
         fun newInstance(
             courseId: String,
             subSectionId: String,
-            mode: CourseViewMode,
             unitId: String?,
             componentId: String?,
+            mode: CourseViewMode,
         ): CourseSectionFragment {
             val fragment = CourseSectionFragment()
             fragment.arguments = bundleOf(

--- a/course/src/main/java/org/openedx/course/presentation/section/CourseSectionFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/section/CourseSectionFragment.kt
@@ -93,9 +93,9 @@ class CourseSectionFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         lifecycle.addObserver(viewModel)
-        val blockId = requireArguments().getString(ARG_BLOCK_ID, "")
+        val subSectionId = requireArguments().getString(ARG_SUBSECTION_ID, "")
         viewModel.mode = requireArguments().serializable(ARG_MODE)!!
-        viewModel.getBlocks(blockId, viewModel.mode)
+        viewModel.getBlocks(subSectionId, viewModel.mode)
     }
 
     override fun onCreateView(
@@ -121,9 +121,9 @@ class CourseSectionFragment : Fragment() {
                         if (block.descendants.isNotEmpty()) {
                             viewModel.verticalClickedEvent(block.blockId, block.displayName)
                             router.navigateToCourseContainer(
-                                requireActivity().supportFragmentManager,
-                                block.id,
+                                fm = requireActivity().supportFragmentManager,
                                 courseId = viewModel.courseId,
+                                unitId = block.id,
                                 mode = viewModel.mode
                             )
                         }
@@ -146,15 +146,16 @@ class CourseSectionFragment : Fragment() {
                 )
 
                 LaunchedEffect(rememberSaveable { true }) {
-                    val descendantId = requireArguments().getString(ARG_DESCENDANT_ID, "")
-                    if (descendantId.isNotEmpty()) {
+                    val unitId = requireArguments().getString(ARG_UNIT_ID, "")
+                    if (unitId.isNotEmpty()) {
                         router.navigateToCourseContainer(
-                            requireActivity().supportFragmentManager,
-                            descendantId,
+                            fm = requireActivity().supportFragmentManager,
                             courseId = viewModel.courseId,
+                            unitId = unitId,
+                            componentId = requireArguments().getString(ARG_COMPONENT_ID, ""),
                             mode = viewModel.mode
                         )
-                        requireArguments().putString(ARG_DESCENDANT_ID, "")
+                        requireArguments().putString(ARG_UNIT_ID, "")
                     }
                 }
             }
@@ -163,20 +164,23 @@ class CourseSectionFragment : Fragment() {
 
     companion object {
         private const val ARG_COURSE_ID = "courseId"
-        private const val ARG_BLOCK_ID = "blockId"
-        private const val ARG_DESCENDANT_ID = "descendantId"
+        private const val ARG_SUBSECTION_ID = "subSectionId"
+        private const val ARG_UNIT_ID = "unitId"
+        private const val ARG_COMPONENT_ID = "componentId"
         private const val ARG_MODE = "mode"
         fun newInstance(
             courseId: String,
-            blockId: String,
+            subSectionId: String,
             mode: CourseViewMode,
-            descendantId: String?,
+            unitId: String?,
+            componentId: String?,
         ): CourseSectionFragment {
             val fragment = CourseSectionFragment()
             fragment.arguments = bundleOf(
                 ARG_COURSE_ID to courseId,
-                ARG_BLOCK_ID to blockId,
-                ARG_DESCENDANT_ID to descendantId,
+                ARG_SUBSECTION_ID to subSectionId,
+                ARG_UNIT_ID to unitId,
+                ARG_COMPONENT_ID to componentId,
                 ARG_MODE to mode
             )
             return fragment

--- a/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerFragment.kt
@@ -113,7 +113,7 @@ class CourseUnitContainerFragment : Fragment(R.layout.fragment_course_unit_conta
         CastButtonFactory.setUpMediaRouteButton(requireContext(), binding.mediaRouteButton)
 
         initViewPager()
-        if (savedInstanceState == null) {
+        if (savedInstanceState == null && componentId.isEmpty()) {
             val currentBlockIndex = viewModel.getUnitBlocks().indexOfFirst {
                 viewModel.getCurrentBlock().id == it.id
             }

--- a/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerFragment.kt
@@ -2,11 +2,13 @@ package org.openedx.course.presentation.unit.container
 
 import android.content.res.Configuration
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.os.SystemClock
 import android.view.LayoutInflater
 import android.view.View
-import androidx.compose.foundation.layout.statusBarsPadding
 import android.view.ViewGroup
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.getValue
@@ -42,6 +44,7 @@ import org.openedx.course.presentation.ui.NavigationUnitsButtons
 import org.openedx.course.presentation.ui.VerticalPageIndicator
 import org.openedx.course.presentation.ui.VideoTitle
 
+
 class CourseUnitContainerFragment : Fragment(R.layout.fragment_course_unit_container) {
 
     private val binding: FragmentCourseUnitContainerBinding
@@ -55,6 +58,7 @@ class CourseUnitContainerFragment : Fragment(R.layout.fragment_course_unit_conta
     private val router by inject<CourseRouter>()
 
     private var blockId: String = ""
+    private var componentId: String = ""
 
     private lateinit var adapter: CourseUnitContainerAdapter
 
@@ -76,9 +80,10 @@ class CourseUnitContainerFragment : Fragment(R.layout.fragment_course_unit_conta
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         lifecycle.addObserver(viewModel)
-        blockId = requireArguments().getString(ARG_BLOCK_ID, "")
+        blockId = requireArguments().getString(UNIT_ID, "")
+        componentId = requireArguments().getString(ARG_COMPONENT_ID, "")
         viewModel.loadBlocks(requireArguments().serializable(ARG_MODE)!!)
-        viewModel.setupCurrentIndex(blockId)
+        viewModel.setupCurrentIndex(blockId, componentId)
     }
 
     override fun onCreateView(
@@ -115,6 +120,13 @@ class CourseUnitContainerFragment : Fragment(R.layout.fragment_course_unit_conta
             if (currentBlockIndex != -1) {
                 binding.viewPager.currentItem = currentBlockIndex
             }
+        }
+        if (componentId.isEmpty().not()) {
+            Handler(Looper.getMainLooper()).post {
+                binding.viewPager.setCurrentItem(viewModel.indexInContainer.value!!, true)
+            }
+            requireArguments().putString(ARG_COMPONENT_ID, "")
+            componentId = ""
         }
 
         binding.cvVideoTitle?.setContent {
@@ -290,10 +302,10 @@ class CourseUnitContainerFragment : Fragment(R.layout.fragment_course_unit_conta
                             )
                             if (it.type.isContainer()) {
                                 router.replaceCourseContainer(
-                                    requireActivity().supportFragmentManager,
-                                    it.id,
-                                    viewModel.courseId,
-                                    requireArguments().serializable(ARG_MODE)!!
+                                    fm = requireActivity().supportFragmentManager,
+                                    courseId = viewModel.courseId,
+                                    unitId = it.id,
+                                    mode = requireArguments().serializable(ARG_MODE)!!
                                 )
                             }
                         }
@@ -313,19 +325,22 @@ class CourseUnitContainerFragment : Fragment(R.layout.fragment_course_unit_conta
 
     companion object {
 
-        private const val ARG_BLOCK_ID = "blockId"
         private const val ARG_COURSE_ID = "courseId"
+        private const val UNIT_ID = "unitId"
+        private const val ARG_COMPONENT_ID = "componentId"
         private const val ARG_MODE = "mode"
 
         fun newInstance(
-            blockId: String,
             courseId: String,
+            unitId: String,
+            componentId: String?,
             mode: CourseViewMode,
         ): CourseUnitContainerFragment {
             val fragment = CourseUnitContainerFragment()
             fragment.arguments = bundleOf(
-                ARG_BLOCK_ID to blockId,
                 ARG_COURSE_ID to courseId,
+                UNIT_ID to unitId,
+                ARG_COMPONENT_ID to componentId,
                 ARG_MODE to mode
             )
             return fragment

--- a/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModel.kt
@@ -3,6 +3,10 @@ package org.openedx.course.presentation.unit.container
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import org.openedx.core.BaseViewModel
 import org.openedx.core.BlockType
 import org.openedx.core.domain.model.Block
@@ -15,10 +19,6 @@ import org.openedx.core.system.notifier.CourseNotifier
 import org.openedx.core.system.notifier.CourseSectionChanged
 import org.openedx.course.domain.interactor.CourseInteractor
 import org.openedx.course.presentation.CourseAnalytics
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 
 class CourseUnitContainerViewModel(
     private val interactor: CourseInteractor,
@@ -79,7 +79,7 @@ class CourseUnitContainerViewModel(
         _indexInContainer.value = 0
     }
 
-    fun setupCurrentIndex(blockId: String) {
+    fun setupCurrentIndex(blockId: String, componentId: String = "") {
         if (currentSectionIndex != -1) {
             return
         }
@@ -99,6 +99,11 @@ class CourseUnitContainerViewModel(
                 }
                 if (block.descendants.isNotEmpty()) {
                     _currentBlock.value = blocks.first { it.id == block.descendants.first() }
+                }
+                if(componentId.isNotEmpty()){
+                    _currentBlock.value = blocks.first { it.id == componentId }
+                    _indexInContainer.value = descendants.indexOf(componentId)
+                    currentIndex = descendants.indexOf(componentId)
                 }
                 return
             }

--- a/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModel.kt
@@ -100,7 +100,7 @@ class CourseUnitContainerViewModel(
                 if (block.descendants.isNotEmpty()) {
                     _currentBlock.value = blocks.first { it.id == block.descendants.first() }
                 }
-                if(componentId.isNotEmpty()){
+                if (componentId.isNotEmpty()) {
                     _currentBlock.value = blocks.first { it.id == componentId }
                     _indexInContainer.value = descendants.indexOf(componentId)
                     currentIndex = descendants.indexOf(componentId)

--- a/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModel.kt
@@ -79,12 +79,12 @@ class CourseUnitContainerViewModel(
         _indexInContainer.value = 0
     }
 
-    fun setupCurrentIndex(blockId: String, componentId: String = "") {
+    fun setupCurrentIndex(unitId: String, componentId: String = "") {
         if (currentSectionIndex != -1) {
             return
         }
         blocks.forEachIndexed { index, block ->
-            if (block.id == blockId) {
+            if (block.id == unitId) {
                 currentVerticalIndex = index
                 currentSectionIndex = blocks.indexOfFirst {
                     it.descendants.contains(blocks[currentVerticalIndex].id)

--- a/course/src/main/java/org/openedx/course/presentation/videos/CourseVideosFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/videos/CourseVideosFragment.kt
@@ -94,7 +94,7 @@ class CourseVideosFragment : Fragment() {
                     },
                     onItemClick = { block ->
                         router.navigateToCourseSubsections(
-                            requireActivity().supportFragmentManager,
+                            fm = requireActivity().supportFragmentManager,
                             courseId = viewModel.courseId,
                             subSectionId = block.id,
                             mode = CourseViewMode.VIDEOS

--- a/course/src/main/java/org/openedx/course/presentation/videos/CourseVideosFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/videos/CourseVideosFragment.kt
@@ -96,7 +96,7 @@ class CourseVideosFragment : Fragment() {
                         router.navigateToCourseSubsections(
                             requireActivity().supportFragmentManager,
                             courseId = viewModel.courseId,
-                            blockId = block.id,
+                            subSectionId = block.id,
                             mode = CourseViewMode.VIDEOS
                         )
                     },


### PR DESCRIPTION
### Description:

- Update navigation for the resume component
- Code improvement & optimization


| Current implementation  | New Implementation |
| ------------- | ------------- |
| When the user taps on the resume course, it navigates to the `subSection` screen.  | The user will navigate to the last visited component   |
| <video src="https://github.com/openedx/openedx-app-android/assets/30689349/79453509-f7ce-44ba-ad3b-6bd00737962b" />  |<video src="https://github.com/openedx/openedx-app-android/assets/30689349/74630fa1-59d4-490a-a0ff-6fd812084489"/>  |







