### PR TITLE
feat: Pre-login Exploration Enrolment Handling

### DIFF
--- a/app/src/main/java/org/openedx/app/AppActivity.kt
+++ b/app/src/main/java/org/openedx/app/AppActivity.kt
@@ -120,7 +120,7 @@ class AppActivity : AppCompatActivity(), InsetHolder, WindowSizeHolder {
                 }
 
                 whatsNewManager.shouldShowWhatsNew() -> {
-                    addFragment(WhatsNewFragment())
+                    addFragment(WhatsNewFragment.newInstance())
                 }
 
                 corePreferencesManager.user != null -> {

--- a/app/src/main/java/org/openedx/app/AppActivity.kt
+++ b/app/src/main/java/org/openedx/app/AppActivity.kt
@@ -124,7 +124,7 @@ class AppActivity : AppCompatActivity(), InsetHolder, WindowSizeHolder {
                 }
 
                 corePreferencesManager.user != null -> {
-                    addFragment(MainFragment())
+                    addFragment(MainFragment.newInstance())
                 }
             }
         }

--- a/app/src/main/java/org/openedx/app/AppRouter.kt
+++ b/app/src/main/java/org/openedx/app/AppRouter.kt
@@ -53,23 +53,23 @@ class AppRouter : AuthRouter, DiscoveryRouter, DashboardRouter, CourseRouter, Di
     ProfileRouter, AppUpgradeRouter, WhatsNewRouter {
 
     //region AuthRouter
-    override fun navigateToMain(fm: FragmentManager) {
+    override fun navigateToMain(fm: FragmentManager, courseId: String?) {
         fm.popBackStack()
         fm.beginTransaction()
-            .replace(R.id.container, MainFragment())
+            .replace(R.id.container, MainFragment.newInstance(courseId))
             .commit()
     }
 
-    override fun navigateToSignIn(fm: FragmentManager) {
-        replaceFragmentWithBackStack(fm, SignInFragment())
+    override fun navigateToSignIn(fm: FragmentManager, courseId: String?) {
+        replaceFragmentWithBackStack(fm, SignInFragment.newInstance(courseId))
     }
 
-    override fun navigateToSignUp(fm: FragmentManager) {
-        replaceFragmentWithBackStack(fm, SignUpFragment())
+    override fun navigateToSignUp(fm: FragmentManager, courseId: String?) {
+        replaceFragmentWithBackStack(fm, SignUpFragment.newInstance(courseId))
     }
 
-    override fun navigateToLogistration(fm: FragmentManager) {
-        replaceFragmentWithBackStack(fm, LogistrationFragment())
+    override fun navigateToLogistration(fm: FragmentManager, courseId: String?) {
+        replaceFragmentWithBackStack(fm, LogistrationFragment.newInstance(courseId))
     }
 
     override fun navigateToRestorePassword(fm: FragmentManager) {
@@ -85,6 +85,14 @@ class AppRouter : AuthRouter, DiscoveryRouter, DashboardRouter, CourseRouter, Di
         fm.beginTransaction()
             .replace(R.id.container, WhatsNewFragment())
             .commit()
+    }
+
+    override fun clearBackStack(fm: FragmentManager) {
+        fm.apply {
+            for (fragment in fragments) {
+                beginTransaction().remove(fragment).commit()
+            }
+        }
     }
     //endregion
 
@@ -330,9 +338,7 @@ class AppRouter : AuthRouter, DiscoveryRouter, DashboardRouter, CourseRouter, Di
 
     override fun restartApp(fm: FragmentManager, isLogistrationEnabled: Boolean) {
         fm.apply {
-            for (fragment in fragments) {
-                beginTransaction().remove(fragment).commit()
-            }
+            clearBackStack(this)
             popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
             if (isLogistrationEnabled) {
                 replaceFragment(fm, LogistrationFragment())

--- a/app/src/main/java/org/openedx/app/AppRouter.kt
+++ b/app/src/main/java/org/openedx/app/AppRouter.kt
@@ -80,10 +80,10 @@ class AppRouter : AuthRouter, DiscoveryRouter, DashboardRouter, CourseRouter, Di
         replaceFragmentWithBackStack(fm, NativeDiscoveryFragment.newInstance(querySearch))
     }
 
-    override fun navigateToWhatsNew(fm: FragmentManager) {
+    override fun navigateToWhatsNew(fm: FragmentManager, courseId: String?) {
         fm.popBackStack()
         fm.beginTransaction()
-            .replace(R.id.container, WhatsNewFragment())
+            .replace(R.id.container, WhatsNewFragment.newInstance(courseId))
             .commit()
     }
 

--- a/app/src/main/java/org/openedx/app/AppRouter.kt
+++ b/app/src/main/java/org/openedx/app/AppRouter.kt
@@ -68,6 +68,10 @@ class AppRouter : AuthRouter, DiscoveryRouter, DashboardRouter, CourseRouter, Di
         replaceFragmentWithBackStack(fm, SignUpFragment())
     }
 
+    override fun navigateToLogistration(fm: FragmentManager) {
+        replaceFragmentWithBackStack(fm, LogistrationFragment())
+    }
+
     override fun navigateToRestorePassword(fm: FragmentManager) {
         replaceFragmentWithBackStack(fm, RestorePasswordFragment())
     }

--- a/app/src/main/java/org/openedx/app/AppRouter.kt
+++ b/app/src/main/java/org/openedx/app/AppRouter.kt
@@ -92,6 +92,7 @@ class AppRouter : AuthRouter, DiscoveryRouter, DashboardRouter, CourseRouter, Di
             for (fragment in fragments) {
                 beginTransaction().remove(fragment).commit()
             }
+            popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
         }
     }
     //endregion
@@ -339,7 +340,6 @@ class AppRouter : AuthRouter, DiscoveryRouter, DashboardRouter, CourseRouter, Di
     override fun restartApp(fm: FragmentManager, isLogistrationEnabled: Boolean) {
         fm.apply {
             clearBackStack(this)
-            popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
             if (isLogistrationEnabled) {
                 replaceFragment(fm, LogistrationFragment())
             } else {

--- a/app/src/main/java/org/openedx/app/MainFragment.kt
+++ b/app/src/main/java/org/openedx/app/MainFragment.kt
@@ -2,6 +2,7 @@ package org.openedx.app
 
 import android.os.Bundle
 import android.view.View
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.setFragmentResultListener
 import androidx.viewpager2.widget.ViewPager2
@@ -13,6 +14,7 @@ import org.openedx.core.presentation.global.app_upgrade.UpgradeRequiredFragment
 import org.openedx.core.presentation.global.viewBinding
 import org.openedx.dashboard.presentation.DashboardFragment
 import org.openedx.discovery.presentation.DiscoveryNavigator
+import org.openedx.discovery.presentation.DiscoveryRouter
 import org.openedx.profile.presentation.profile.ProfileFragment
 
 class MainFragment : Fragment(R.layout.fragment_main) {
@@ -20,6 +22,7 @@ class MainFragment : Fragment(R.layout.fragment_main) {
     private val binding by viewBinding(FragmentMainBinding::bind)
     private val analytics by inject<AppAnalytics>()
     private val viewModel by viewModel<MainViewModel>()
+    private val router by inject<DiscoveryRouter>()
 
     private lateinit var adapter: MainNavigationFragmentAdapter
 
@@ -64,6 +67,13 @@ class MainFragment : Fragment(R.layout.fragment_main) {
         viewModel.isBottomBarEnabled.observe(viewLifecycleOwner) { isBottomBarEnabled ->
             enableBottomBar(isBottomBarEnabled)
         }
+
+        arguments?.let {
+            it.getString(ARG_COURSE_ID, null)?.apply {
+                router.navigateToCourseDetail(parentFragmentManager, this)
+            }
+            it.putString(ARG_COURSE_ID, null)
+        }
     }
 
     private fun initViewPager() {
@@ -86,6 +96,17 @@ class MainFragment : Fragment(R.layout.fragment_main) {
     private fun enableBottomBar(enable: Boolean) {
         for (i in 0 until binding.bottomNavView.menu.size()) {
             binding.bottomNavView.menu.getItem(i).isEnabled = enable
+        }
+    }
+
+    companion object {
+        private const val ARG_COURSE_ID = "courseId"
+        fun newInstance(courseId: String?): MainFragment {
+            val fragment = MainFragment()
+            fragment.arguments = bundleOf(
+                ARG_COURSE_ID to courseId
+            )
+            return fragment
         }
     }
 }

--- a/app/src/main/java/org/openedx/app/MainFragment.kt
+++ b/app/src/main/java/org/openedx/app/MainFragment.kt
@@ -68,11 +68,11 @@ class MainFragment : Fragment(R.layout.fragment_main) {
             enableBottomBar(isBottomBarEnabled)
         }
 
-        arguments?.let {
-            it.getString(ARG_COURSE_ID, null)?.apply {
+        requireArguments().apply {
+            this.getString(ARG_COURSE_ID, null)?.apply {
                 router.navigateToCourseDetail(parentFragmentManager, this)
             }
-            it.putString(ARG_COURSE_ID, null)
+            this.putString(ARG_COURSE_ID, null)
         }
     }
 
@@ -101,7 +101,7 @@ class MainFragment : Fragment(R.layout.fragment_main) {
 
     companion object {
         private const val ARG_COURSE_ID = "courseId"
-        fun newInstance(courseId: String?): MainFragment {
+        fun newInstance(courseId: String? = null): MainFragment {
             val fragment = MainFragment()
             fragment.arguments = bundleOf(
                 ARG_COURSE_ID to courseId

--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -62,7 +62,7 @@ val screenModule = module {
     factory { AuthRepository(get(), get(), get()) }
     factory { AuthInteractor(get()) }
     factory { Validator() }
-    viewModel {
+    viewModel { (courseId: String?) ->
         SignInViewModel(
             get(),
             get(),
@@ -73,10 +73,13 @@ val screenModule = module {
             get(),
             get(),
             get(),
-            get()
+            get(),
+            courseId,
         )
     }
-    viewModel { SignUpViewModel(get(), get(), get(), get(), get()) }
+    viewModel { (courseId: String?) ->
+        SignUpViewModel(get(), get(), get(), get(), get(), courseId)
+    }
     viewModel { RestorePasswordViewModel(get(), get(), get(), get()) }
 
     factory { DashboardRepository(get(), get(), get()) }

--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -255,5 +255,5 @@ val screenModule = module {
         )
     }
 
-    viewModel { WhatsNewViewModel(get()) }
+    viewModel { (courseId: String) -> WhatsNewViewModel(courseId, get()) }
 }

--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -122,6 +122,7 @@ val screenModule = module {
             get(),
             get(),
             get(),
+            get(),
             get()
         )
     }

--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -213,7 +213,7 @@ val screenModule = module {
             get()
         )
     }
-    viewModel { CourseSearchViewModel(get(), get(), get(), get()) }
+    viewModel { CourseSearchViewModel(get(), get(), get(), get(), get()) }
     viewModel { SelectDialogViewModel(get()) }
 
     single { DiscussionRepository(get(), get()) }

--- a/auth/src/main/java/org/openedx/auth/presentation/AuthRouter.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/AuthRouter.kt
@@ -6,11 +6,11 @@ interface AuthRouter {
 
     fun navigateToMain(fm: FragmentManager, courseId: String?)
 
-    fun navigateToSignIn(fm: FragmentManager, courseId: String? = null)
+    fun navigateToSignIn(fm: FragmentManager, courseId: String?)
 
-    fun navigateToLogistration(fm: FragmentManager, courseId: String? = null)
+    fun navigateToLogistration(fm: FragmentManager, courseId: String?)
 
-    fun navigateToSignUp(fm: FragmentManager, courseId: String? = null)
+    fun navigateToSignUp(fm: FragmentManager, courseId: String?)
 
     fun navigateToRestorePassword(fm: FragmentManager)
 

--- a/auth/src/main/java/org/openedx/auth/presentation/AuthRouter.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/AuthRouter.kt
@@ -8,6 +8,8 @@ interface AuthRouter {
 
     fun navigateToSignIn(fm: FragmentManager)
 
+    fun navigateToLogistration(fm: FragmentManager)
+
     fun navigateToSignUp(fm: FragmentManager)
 
     fun navigateToRestorePassword(fm: FragmentManager)

--- a/auth/src/main/java/org/openedx/auth/presentation/AuthRouter.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/AuthRouter.kt
@@ -4,17 +4,19 @@ import androidx.fragment.app.FragmentManager
 
 interface AuthRouter {
 
-    fun navigateToMain(fm: FragmentManager)
+    fun navigateToMain(fm: FragmentManager, courseId: String?)
 
-    fun navigateToSignIn(fm: FragmentManager)
+    fun navigateToSignIn(fm: FragmentManager, courseId: String? = null)
 
-    fun navigateToLogistration(fm: FragmentManager)
+    fun navigateToLogistration(fm: FragmentManager, courseId: String? = null)
 
-    fun navigateToSignUp(fm: FragmentManager)
+    fun navigateToSignUp(fm: FragmentManager, courseId: String? = null)
 
     fun navigateToRestorePassword(fm: FragmentManager)
 
     fun navigateToWhatsNew(fm: FragmentManager)
 
     fun navigateToDiscoverCourses(fm: FragmentManager, querySearch: String)
+
+    fun clearBackStack(fm: FragmentManager)
 }

--- a/auth/src/main/java/org/openedx/auth/presentation/AuthRouter.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/AuthRouter.kt
@@ -14,7 +14,7 @@ interface AuthRouter {
 
     fun navigateToRestorePassword(fm: FragmentManager)
 
-    fun navigateToWhatsNew(fm: FragmentManager)
+    fun navigateToWhatsNew(fm: FragmentManager, courseId: String? = null)
 
     fun navigateToDiscoverCourses(fm: FragmentManager, querySearch: String)
 

--- a/auth/src/main/java/org/openedx/auth/presentation/logistration/LogistrationFragment.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/logistration/LogistrationFragment.kt
@@ -38,11 +38,11 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import org.koin.android.ext.android.inject
 import org.openedx.auth.R
 import org.openedx.auth.presentation.AuthRouter
-import org.openedx.core.R as coreR
 import org.openedx.core.ui.OpenEdXButton
 import org.openedx.core.ui.OpenEdXOutlinedButton
 import org.openedx.core.ui.SearchBar
@@ -51,6 +51,7 @@ import org.openedx.core.ui.noRippleClickable
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appTypography
+import org.openedx.core.R as coreR
 
 class LogistrationFragment : Fragment() {
 
@@ -64,18 +65,30 @@ class LogistrationFragment : Fragment() {
         setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
         setContent {
             OpenEdXTheme {
+                val courseId = arguments?.getString(ARG_COURSE_ID, "")
                 LogistrationScreen(
                     onSignInClick = {
-                        router.navigateToSignIn(parentFragmentManager)
+                        router.navigateToSignIn(parentFragmentManager, courseId)
                     },
                     onRegisterClick = {
-                        router.navigateToSignUp(parentFragmentManager)
+                        router.navigateToSignUp(parentFragmentManager, courseId)
                     },
                     onSearchClick = { querySearch ->
                         router.navigateToDiscoverCourses(parentFragmentManager, querySearch)
                     }
                 )
             }
+        }
+    }
+
+    companion object {
+        private const val ARG_COURSE_ID = "courseId"
+        fun newInstance(courseId: String?): LogistrationFragment {
+            val fragment = LogistrationFragment()
+            fragment.arguments = bundleOf(
+                ARG_COURSE_ID to courseId
+            )
+            return fragment
         }
     }
 }

--- a/auth/src/main/java/org/openedx/auth/presentation/logistration/LogistrationFragment.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/logistration/LogistrationFragment.kt
@@ -6,14 +6,12 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -43,8 +41,7 @@ import androidx.fragment.app.Fragment
 import org.koin.android.ext.android.inject
 import org.openedx.auth.R
 import org.openedx.auth.presentation.AuthRouter
-import org.openedx.core.ui.OpenEdXButton
-import org.openedx.core.ui.OpenEdXOutlinedButton
+import org.openedx.core.ui.AuthButtons
 import org.openedx.core.ui.SearchBar
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.noRippleClickable
@@ -180,25 +177,7 @@ private fun LogistrationScreen(
 
                 Spacer(modifier = Modifier.weight(1f))
 
-                Row {
-                    OpenEdXButton(
-                        width = Modifier
-                            .width(0.dp)
-                            .weight(1f),
-                        text = stringResource(id = R.string.auth_register),
-                        onClick = { onRegisterClick() }
-                    )
-
-                    OpenEdXOutlinedButton(
-                        modifier = Modifier
-                            .width(100.dp)
-                            .padding(start = 16.dp),
-                        text = stringResource(id = R.string.auth_sign_in),
-                        onClick = { onSignInClick() },
-                        borderColor = MaterialTheme.appColors.textFieldBorder,
-                        textColor = MaterialTheme.appColors.primary
-                    )
-                }
+                AuthButtons(onRegisterClick = onRegisterClick, onSignInClick = onSignInClick)
             }
         }
     }

--- a/auth/src/main/java/org/openedx/auth/presentation/logistration/LogistrationFragment.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/logistration/LogistrationFragment.kt
@@ -41,7 +41,7 @@ import androidx.fragment.app.Fragment
 import org.koin.android.ext.android.inject
 import org.openedx.auth.R
 import org.openedx.auth.presentation.AuthRouter
-import org.openedx.core.ui.AuthButtons
+import org.openedx.core.ui.AuthButtonsPanel
 import org.openedx.core.ui.SearchBar
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.noRippleClickable
@@ -177,7 +177,7 @@ private fun LogistrationScreen(
 
                 Spacer(modifier = Modifier.weight(1f))
 
-                AuthButtons(onRegisterClick = onRegisterClick, onSignInClick = onSignInClick)
+                AuthButtonsPanel(onRegisterClick = onRegisterClick, onSignInClick = onSignInClick)
             }
         }
     }

--- a/auth/src/main/java/org/openedx/auth/presentation/restore/RestorePasswordFragment.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/restore/RestorePasswordFragment.kt
@@ -39,6 +39,7 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.openedx.core.presentation.global.app_upgrade.AppUpgradeRequiredScreen
 import org.openedx.core.AppUpdateState
 import org.openedx.auth.R as authR
+import org.openedx.core.R
 
 class RestorePasswordFragment : Fragment() {
 
@@ -296,7 +297,7 @@ private fun RestorePasswordScreen(
                                 Spacer(Modifier.height(48.dp))
                                 OpenEdXButton(
                                     width = buttonWidth,
-                                    text = stringResource(id = authR.string.auth_sign_in),
+                                    text = stringResource(id = R.string.core_sign_in),
                                     onClick = {
                                         onBackClick()
                                     }

--- a/auth/src/main/java/org/openedx/auth/presentation/signin/SignInFragment.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signin/SignInFragment.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
@@ -68,7 +69,7 @@ class SignInFragment : Fragment() {
 
                                 AuthEvent.RegisterClick -> {
                                     viewModel.signUpClickedEvent()
-                                    router.navigateToSignUp(parentFragmentManager)
+                                    router.navigateToSignUp(parentFragmentManager, null)
                                 }
 
                                 AuthEvent.BackClick -> {
@@ -84,9 +85,7 @@ class SignInFragment : Fragment() {
                             if (isNeedToShowWhatsNew) {
                                 router.navigateToWhatsNew(parentFragmentManager)
                             } else {
-                                if (!TextUtils.isEmpty(viewModel.courseId)) {
-                                    router.clearBackStack(parentFragmentManager)
-                                }
+                                router.clearBackStack(parentFragmentManager)
                                 router.navigateToMain(parentFragmentManager, viewModel.courseId)
                             }
                         }

--- a/auth/src/main/java/org/openedx/auth/presentation/signin/SignInFragment.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signin/SignInFragment.kt
@@ -1,7 +1,6 @@
 package org.openedx.auth.presentation.signin
 
 import android.os.Bundle
-import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.compose.runtime.LaunchedEffect
@@ -12,7 +11,6 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentManager
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
@@ -82,10 +80,10 @@ class SignInFragment : Fragment() {
                         val isNeedToShowWhatsNew =
                             whatsNewGlobalManager.shouldShowWhatsNew()
                         if (state.loginSuccess) {
+                            router.clearBackStack(parentFragmentManager)
                             if (isNeedToShowWhatsNew) {
-                                router.navigateToWhatsNew(parentFragmentManager)
+                                router.navigateToWhatsNew(parentFragmentManager, viewModel.courseId)
                             } else {
-                                router.clearBackStack(parentFragmentManager)
                                 router.navigateToMain(parentFragmentManager, viewModel.courseId)
                             }
                         }

--- a/auth/src/main/java/org/openedx/auth/presentation/signin/SignInViewModel.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signin/SignInViewModel.kt
@@ -42,7 +42,8 @@ class SignInViewModel(
     private val facebookAuthHelper: FacebookAuthHelper,
     private val googleAuthHelper: GoogleAuthHelper,
     private val microsoftAuthHelper: MicrosoftAuthHelper,
-    config: Config,
+    val config: Config,
+    val courseId: String?,
 ) : BaseViewModel() {
 
     private val logger = Logger("SignInViewModel")

--- a/auth/src/main/java/org/openedx/auth/presentation/signin/compose/SignInView.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signin/compose/SignInView.kt
@@ -52,7 +52,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.openedx.auth.R
-import org.openedx.core.R as coreR
 import org.openedx.auth.presentation.signin.AuthEvent
 import org.openedx.auth.presentation.signin.SignInUIState
 import org.openedx.auth.presentation.ui.LoginTextField
@@ -70,6 +69,7 @@ import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appShapes
 import org.openedx.core.ui.theme.appTypography
 import org.openedx.core.ui.windowSizeValue
+import org.openedx.core.R as coreR
 
 @Composable
 internal fun LoginScreen(
@@ -116,7 +116,7 @@ internal fun LoginScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .fillMaxHeight(0.3f),
-            painter = painterResource(id = org.openedx.core.R.drawable.core_top_header),
+            painter = painterResource(id = coreR.drawable.core_top_header),
             contentScale = ContentScale.FillBounds,
             contentDescription = null
         )
@@ -150,7 +150,7 @@ internal fun LoginScreen(
                 contentAlignment = Alignment.Center
             ) {
                 Image(
-                    painter = painterResource(id = org.openedx.core.R.drawable.core_ic_logo),
+                    painter = painterResource(id = coreR.drawable.core_ic_logo),
                     contentDescription = null,
                     modifier = Modifier
                         .padding(top = 20.dp)
@@ -359,7 +359,7 @@ private fun PasswordTextField(
     val focusManager = LocalFocusManager.current
     Text(
         modifier = Modifier.fillMaxWidth(),
-        text = stringResource(id = org.openedx.core.R.string.core_password),
+        text = stringResource(id = coreR.string.core_password),
         color = MaterialTheme.appColors.textPrimary,
         style = MaterialTheme.appTypography.labelLarge
     )

--- a/auth/src/main/java/org/openedx/auth/presentation/signin/compose/SignInView.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signin/compose/SignInView.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.openedx.auth.R
+import org.openedx.core.R as coreR
 import org.openedx.auth.presentation.signin.AuthEvent
 import org.openedx.auth.presentation.signin.SignInUIState
 import org.openedx.auth.presentation.ui.LoginTextField
@@ -172,7 +173,7 @@ internal fun LoginScreen(
                             .then(contentPaddings),
                     ) {
                         Text(
-                            text = stringResource(id = R.string.auth_sign_in),
+                            text = stringResource(id = coreR.string.core_sign_in),
                             color = MaterialTheme.appColors.textPrimary,
                             style = MaterialTheme.appTypography.displaySmall
                         )
@@ -234,7 +235,7 @@ private fun AuthForm(
                     modifier = Modifier.noRippleClickable {
                         onEvent(AuthEvent.RegisterClick)
                     },
-                    text = stringResource(id = R.string.auth_register),
+                    text = stringResource(id = coreR.string.core_register),
                     color = MaterialTheme.appColors.primary,
                     style = MaterialTheme.appTypography.labelLarge
                 )
@@ -255,7 +256,7 @@ private fun AuthForm(
         } else {
             OpenEdXButton(
                 width = buttonWidth,
-                text = stringResource(id = R.string.auth_sign_in),
+                text = stringResource(id = coreR.string.core_sign_in),
                 onClick = {
                     onEvent(AuthEvent.SignIn(login = login, password = password))
                 }

--- a/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpFragment.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpFragment.kt
@@ -146,9 +146,7 @@ class SignUpFragment : Fragment() {
 
                     LaunchedEffect(successLogin) {
                         if (successLogin == true) {
-                            if (!TextUtils.isEmpty(viewModel.courseId)) {
-                                router.clearBackStack(parentFragmentManager)
-                            }
+                            router.clearBackStack(requireActivity().supportFragmentManager)
                             router.navigateToMain(parentFragmentManager, viewModel.courseId)
                         }
                     }
@@ -348,7 +346,7 @@ internal fun RegistrationScreen(
                     Text(
                         modifier = Modifier
                             .fillMaxWidth(),
-                        text = stringResource(id = org.openedx.auth.R.string.auth_register),
+                        text = stringResource(id = R.string.core_register),
                         color = Color.White,
                         textAlign = TextAlign.Center,
                         style = MaterialTheme.appTypography.titleMedium

--- a/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpFragment.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpFragment.kt
@@ -4,7 +4,6 @@ package org.openedx.auth.presentation.signup
 
 import android.content.res.Configuration
 import android.os.Bundle
-import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.compose.animation.AnimatedVisibility
@@ -72,7 +71,6 @@ import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 import org.openedx.auth.presentation.AuthRouter
-import org.openedx.auth.presentation.signin.SignInFragment
 import org.openedx.auth.presentation.ui.ExpandableText
 import org.openedx.auth.presentation.ui.OptionalFields
 import org.openedx.auth.presentation.ui.RequiredFields

--- a/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpViewModel.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signup/SignUpViewModel.kt
@@ -23,7 +23,8 @@ class SignUpViewModel(
     private val resourceManager: ResourceManager,
     private val analytics: AuthAnalytics,
     private val preferencesManager: CorePreferences,
-    private val appUpgradeNotifier: AppUpgradeNotifier
+    private val appUpgradeNotifier: AppUpgradeNotifier,
+    val courseId: String?,
 ) : BaseViewModel() {
 
     private val _uiState = MutableLiveData<SignUpUIState>(SignUpUIState.Loading)

--- a/auth/src/main/res/values-uk/strings.xml
+++ b/auth/src/main/res/values-uk/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="auth_sign_in">Увійти</string>
     <string name="auth_sign_up">Зареєструватися</string>
-    <string name="auth_register">Зареєструватися</string>
     <string name="auth_registration">Реєстрація</string>
     <string name="auth_forgot_password">Забули пароль?</string>
     <string name="auth_email">Електронна пошта</string>

--- a/auth/src/main/res/values-uk/strings.xml
+++ b/auth/src/main/res/values-uk/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="auth_sign_up">Зареєструватися</string>
-    <string name="auth_registration">Реєстрація</string>
     <string name="auth_forgot_password">Забули пароль?</string>
     <string name="auth_email">Електронна пошта</string>
     <string name="auth_invalid_email">Неправильна E-mail адреса</string>

--- a/auth/src/main/res/values/strings.xml
+++ b/auth/src/main/res/values/strings.xml
@@ -5,7 +5,6 @@
     <string name="pre_auth_search_hint" tools:ignore="ExtraTranslation">Search our 3000+ courses</string>
     <string name="pre_auth_explore_all_courses" tools:ignore="ExtraTranslation">Explore all courses</string>
     <string name="auth_sign_up">Sign up</string>
-    <string name="auth_registration">Registration</string>
     <string name="auth_forgot_password">Forgot password?</string>
     <string name="auth_email">Email</string>
     <string name="auth_invalid_email">Invalid email</string>

--- a/auth/src/main/res/values/strings.xml
+++ b/auth/src/main/res/values/strings.xml
@@ -4,9 +4,7 @@
     <string name="pre_auth_search_title" tools:ignore="ExtraTranslation">What do you want to learn?</string>
     <string name="pre_auth_search_hint" tools:ignore="ExtraTranslation">Search our 3000+ courses</string>
     <string name="pre_auth_explore_all_courses" tools:ignore="ExtraTranslation">Explore all courses</string>
-    <string name="auth_sign_in">Sign in</string>
     <string name="auth_sign_up">Sign up</string>
-    <string name="auth_register">Register</string>
     <string name="auth_registration">Registration</string>
     <string name="auth_forgot_password">Forgot password?</string>
     <string name="auth_email">Email</string>

--- a/auth/src/test/java/org/openedx/auth/presentation/signin/SignInViewModelTest.kt
+++ b/auth/src/test/java/org/openedx/auth/presentation/signin/SignInViewModelTest.kt
@@ -105,6 +105,7 @@ class SignInViewModelTest {
             googleAuthHelper = googleAuthHelper,
             microsoftAuthHelper = microsoftAuthHelper,
             config = config,
+            courseId = "",
         )
         viewModel.login("", "")
         coVerify(exactly = 0) { interactor.login(any(), any()) }
@@ -133,6 +134,7 @@ class SignInViewModelTest {
             googleAuthHelper = googleAuthHelper,
             microsoftAuthHelper = microsoftAuthHelper,
             config = config,
+            courseId = "",
         )
         viewModel.login("acc@test.o", "")
         coVerify(exactly = 0) { interactor.login(any(), any()) }
@@ -163,6 +165,7 @@ class SignInViewModelTest {
             googleAuthHelper = googleAuthHelper,
             microsoftAuthHelper = microsoftAuthHelper,
             config = config,
+            courseId = "",
         )
         viewModel.login("acc@test.org", "")
 
@@ -192,6 +195,7 @@ class SignInViewModelTest {
             googleAuthHelper = googleAuthHelper,
             microsoftAuthHelper = microsoftAuthHelper,
             config = config,
+            courseId = "",
         )
         viewModel.login("acc@test.org", "ed")
 
@@ -223,6 +227,7 @@ class SignInViewModelTest {
             googleAuthHelper = googleAuthHelper,
             microsoftAuthHelper = microsoftAuthHelper,
             config = config,
+            courseId = "",
         )
         coEvery { interactor.login("acc@test.org", "edx") } returns Unit
         viewModel.login("acc@test.org", "edx")
@@ -255,6 +260,7 @@ class SignInViewModelTest {
             googleAuthHelper = googleAuthHelper,
             microsoftAuthHelper = microsoftAuthHelper,
             config = config,
+            courseId = "",
         )
         coEvery { interactor.login("acc@test.org", "edx") } throws UnknownHostException()
         viewModel.login("acc@test.org", "edx")
@@ -288,6 +294,7 @@ class SignInViewModelTest {
             googleAuthHelper = googleAuthHelper,
             microsoftAuthHelper = microsoftAuthHelper,
             config = config,
+            courseId = "",
         )
         coEvery { interactor.login("acc@test.org", "edx") } throws EdxError.InvalidGrantException()
         viewModel.login("acc@test.org", "edx")
@@ -321,6 +328,7 @@ class SignInViewModelTest {
             googleAuthHelper = googleAuthHelper,
             microsoftAuthHelper = microsoftAuthHelper,
             config = config,
+            courseId = "",
         )
         coEvery { interactor.login("acc@test.org", "edx") } throws IllegalStateException()
         viewModel.login("acc@test.org", "edx")
@@ -336,5 +344,4 @@ class SignInViewModelTest {
         assertFalse(uiState.loginSuccess)
         assertEquals(somethingWrong, message.message)
     }
-
 }

--- a/auth/src/test/java/org/openedx/auth/presentation/signup/SignUpViewModelTest.kt
+++ b/auth/src/test/java/org/openedx/auth/presentation/signup/SignUpViewModelTest.kt
@@ -1,16 +1,6 @@
 package org.openedx.auth.presentation.signup
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import org.openedx.auth.data.model.ValidationFields
-import org.openedx.auth.domain.interactor.AuthInteractor
-import org.openedx.auth.presentation.AuthAnalytics
-import org.openedx.core.ApiConstants
-import org.openedx.core.R
-import org.openedx.core.UIMessage
-import org.openedx.core.domain.model.RegistrationField
-import org.openedx.core.domain.model.RegistrationFieldType
-import org.openedx.core.data.model.User
-import org.openedx.core.system.ResourceManager
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -30,7 +20,17 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
+import org.openedx.auth.data.model.ValidationFields
+import org.openedx.auth.domain.interactor.AuthInteractor
+import org.openedx.auth.presentation.AuthAnalytics
+import org.openedx.core.ApiConstants
+import org.openedx.core.R
+import org.openedx.core.UIMessage
+import org.openedx.core.data.model.User
 import org.openedx.core.data.storage.CorePreferences
+import org.openedx.core.domain.model.RegistrationField
+import org.openedx.core.domain.model.RegistrationFieldType
+import org.openedx.core.system.ResourceManager
 import org.openedx.core.system.notifier.AppUpgradeNotifier
 import java.net.UnknownHostException
 
@@ -104,7 +104,14 @@ class SignUpViewModelTest {
 
     @Test
     fun `register has validation errors`() = runTest {
-        val viewModel = SignUpViewModel(interactor, resourceManager, analytics, preferencesManager, appUpgradeNotifier)
+        val viewModel = SignUpViewModel(
+            interactor,
+            resourceManager,
+            analytics,
+            preferencesManager,
+            appUpgradeNotifier,
+            courseId = "",
+        )
         coEvery { interactor.validateRegistrationFields(parametersMap) } returns ValidationFields(
             parametersMap
         )
@@ -130,7 +137,14 @@ class SignUpViewModelTest {
 
     @Test
     fun `register no internet error`() = runTest {
-        val viewModel = SignUpViewModel(interactor, resourceManager, analytics, preferencesManager, appUpgradeNotifier)
+        val viewModel = SignUpViewModel(
+            interactor,
+            resourceManager,
+            analytics,
+            preferencesManager,
+            appUpgradeNotifier,
+            courseId = "",
+        )
         coEvery { interactor.validateRegistrationFields(parametersMap) } throws UnknownHostException()
         coEvery { interactor.register(parametersMap) } returns Unit
         coEvery {
@@ -161,7 +175,14 @@ class SignUpViewModelTest {
 
     @Test
     fun `something went wrong error`() = runTest {
-        val viewModel = SignUpViewModel(interactor, resourceManager, analytics, preferencesManager, appUpgradeNotifier)
+        val viewModel = SignUpViewModel(
+            interactor,
+            resourceManager,
+            analytics,
+            preferencesManager,
+            appUpgradeNotifier,
+            courseId = "",
+        )
         coEvery { interactor.validateRegistrationFields(parametersMap) } throws Exception()
         coEvery { interactor.register(parametersMap) } returns Unit
         coEvery { interactor.login("", "") } returns Unit
@@ -188,7 +209,14 @@ class SignUpViewModelTest {
 
     @Test
     fun `success register`() = runTest {
-        val viewModel = SignUpViewModel(interactor, resourceManager, analytics, preferencesManager, appUpgradeNotifier)
+        val viewModel = SignUpViewModel(
+            interactor,
+            resourceManager,
+            analytics,
+            preferencesManager,
+            appUpgradeNotifier,
+            courseId = "",
+        )
         coEvery { interactor.validateRegistrationFields(parametersMap) } returns ValidationFields(
             emptyMap()
         )
@@ -221,7 +249,14 @@ class SignUpViewModelTest {
 
     @Test
     fun `getRegistrationFields no internet error`() = runTest {
-        val viewModel = SignUpViewModel(interactor, resourceManager, analytics, preferencesManager, appUpgradeNotifier)
+        val viewModel = SignUpViewModel(
+            interactor,
+            resourceManager,
+            analytics,
+            preferencesManager,
+            appUpgradeNotifier,
+            courseId = "",
+        )
         coEvery { interactor.getRegistrationFields() } throws UnknownHostException()
         viewModel.getRegistrationFields()
         advanceUntilIdle()
@@ -236,7 +271,14 @@ class SignUpViewModelTest {
 
     @Test
     fun `getRegistrationFields unknown error`() = runTest {
-        val viewModel = SignUpViewModel(interactor, resourceManager, analytics, preferencesManager, appUpgradeNotifier)
+        val viewModel = SignUpViewModel(
+            interactor,
+            resourceManager,
+            analytics,
+            preferencesManager,
+            appUpgradeNotifier,
+            courseId = "",
+        )
         coEvery { interactor.getRegistrationFields() } throws Exception()
         viewModel.getRegistrationFields()
         advanceUntilIdle()
@@ -251,7 +293,14 @@ class SignUpViewModelTest {
 
     @Test
     fun `getRegistrationFields success`() = runTest {
-        val viewModel = SignUpViewModel(interactor, resourceManager, analytics, preferencesManager, appUpgradeNotifier)
+        val viewModel = SignUpViewModel(
+            interactor,
+            resourceManager,
+            analytics,
+            preferencesManager,
+            appUpgradeNotifier,
+            courseId = "",
+        )
         coEvery { interactor.getRegistrationFields() } returns listOfFields
         viewModel.getRegistrationFields()
         advanceUntilIdle()
@@ -263,5 +312,4 @@ class SignUpViewModelTest {
         assert(viewModel.uiState.value is SignUpUIState.Fields)
         assertEquals(null, viewModel.uiMessage.value)
     }
-
 }

--- a/core/src/main/java/org/openedx/core/data/model/User.kt
+++ b/core/src/main/java/org/openedx/core/data/model/User.kt
@@ -15,7 +15,7 @@ data class User(
 ) {
     fun mapToDomain(): User {
         return User(
-            id, username, email, name ?: ""
+            id, username, email, name?:""
         )
     }
 }

--- a/core/src/main/java/org/openedx/core/data/model/User.kt
+++ b/core/src/main/java/org/openedx/core/data/model/User.kt
@@ -15,7 +15,7 @@ data class User(
 ) {
     fun mapToDomain(): User {
         return User(
-            id, username, email, name?:""
+            id, username, email, name ?: ""
         )
     }
 }

--- a/core/src/main/java/org/openedx/core/ui/ComposeCommon.kt
+++ b/core/src/main/java/org/openedx/core/ui/ComposeCommon.kt
@@ -1158,6 +1158,32 @@ fun ConnectionErrorView(
     }
 }
 
+@Composable
+fun AuthButtons(
+    onRegisterClick: () -> Unit,
+    onSignInClick: () -> Unit
+) {
+    Row {
+        OpenEdXButton(
+            width = Modifier
+                .width(0.dp)
+                .weight(1f),
+            text = stringResource(id = R.string.core_register),
+            onClick = { onRegisterClick() }
+        )
+
+        OpenEdXOutlinedButton(
+            modifier = Modifier
+                .width(100.dp)
+                .padding(start = 16.dp),
+            text = stringResource(id = R.string.core_sign_in),
+            onClick = { onSignInClick() },
+            borderColor = MaterialTheme.appColors.textFieldBorder,
+            textColor = MaterialTheme.appColors.primary
+        )
+    }
+}
+
 @Preview
 @Composable
 private fun StaticSearchBarPreview() {

--- a/core/src/main/java/org/openedx/core/ui/ComposeCommon.kt
+++ b/core/src/main/java/org/openedx/core/ui/ComposeCommon.kt
@@ -1159,7 +1159,7 @@ fun ConnectionErrorView(
 }
 
 @Composable
-fun AuthButtons(
+fun AuthButtonsPanel(
     onRegisterClick: () -> Unit,
     onSignInClick: () -> Unit
 ) {
@@ -1205,4 +1205,10 @@ private fun SearchBarPreview() {
         keyboardActions = {},
         onClearValue = {}
     )
+}
+
+@Preview
+@Composable
+private fun AuthButtonsPanelPreview() {
+    AuthButtonsPanel(onRegisterClick = {}, onSignInClick = {})
 }

--- a/core/src/main/res/values-uk/strings.xml
+++ b/core/src/main/res/values-uk/strings.xml
@@ -60,6 +60,9 @@
     <string name="core_thank_you_dialog_negative_description">Ми отримали ваш відгук і використовуватимемо його, щоб покращити ваш досвід навчання в майбутньому. Дякуємо, що поділилися!</string>
     <string name="core_not_connected_to_internet">Ви не підключені до Інтернету. Будь ласка, перевірте ваше підключення до Інтернету.</string>
 
+    <string name="core_register">Зареєструватися</string>
+    <string name="core_sign_in">Увійти</string>
+
     <!--    Accessibility-->
     <string name="core_accessibility_user_profile_image">%1$s зображення профілю</string>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -85,6 +85,9 @@
     <string name="core_date_type_not_yet_released" tools:ignore="MissingTranslation">Not Yet Released</string>
     <!-- endregion -->
 
+    <string name="core_register">Register</string>
+    <string name="core_sign_in">Sign in</string>
+
     <!--    Accessibility-->
     <string name="core_accessibility_user_profile_image">%1$s profile image</string>
 </resources>

--- a/course/build.gradle
+++ b/course/build.gradle
@@ -59,6 +59,7 @@ android {
 
 dependencies {
     implementation project(path: ':core')
+    implementation project(path: ':auth')
     implementation project(path: ':discussion')
     implementation "com.pierfrancescosoffritti.androidyoutubeplayer:core:$youtubeplayer_version"
     implementation "androidx.media3:media3-exoplayer:$media3_version"

--- a/course/build.gradle
+++ b/course/build.gradle
@@ -59,7 +59,6 @@ android {
 
 dependencies {
     implementation project(path: ':core')
-    implementation project(path: ':auth')
     implementation project(path: ':discussion')
     implementation "com.pierfrancescosoffritti.androidyoutubeplayer:core:$youtubeplayer_version"
     implementation "androidx.media3:media3-exoplayer:$media3_version"

--- a/course/src/main/java/org/openedx/course/presentation/CourseRouter.kt
+++ b/course/src/main/java/org/openedx/course/presentation/CourseRouter.kt
@@ -75,4 +75,6 @@ interface CourseRouter {
     fun navigateToSignUp(fm: FragmentManager, courseId: String?)
 
     fun navigateToSignIn(fm: FragmentManager, courseId: String?)
+
+    fun navigateToLogistration(fm: FragmentManager, courseId: String?)
 }

--- a/course/src/main/java/org/openedx/course/presentation/CourseRouter.kt
+++ b/course/src/main/java/org/openedx/course/presentation/CourseRouter.kt
@@ -9,9 +9,7 @@ import java.util.Date
 interface CourseRouter {
 
     fun navigateToCourseOutline(
-        fm: FragmentManager,
-        courseId: String,
-        courseTitle: String
+        fm: FragmentManager, courseId: String, courseTitle: String
     )
 
     fun navigateToNoAccess(
@@ -65,10 +63,7 @@ interface CourseRouter {
     )
 
     fun navigateToHandoutsWebView(
-        fm: FragmentManager,
-        courseId: String,
-        title: String,
-        type: HandoutsType
+        fm: FragmentManager, courseId: String, title: String, type: HandoutsType
     )
 
     fun navigateToCourseInfo(
@@ -77,4 +72,7 @@ interface CourseRouter {
         infoType: String,
     )
 
+    fun navigateToSignUp(fm: FragmentManager, courseId: String?)
+
+    fun navigateToSignIn(fm: FragmentManager, courseId: String?)
 }

--- a/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsFragment.kt
@@ -180,7 +180,10 @@ internal fun CourseDetailsScreen(
         bottomBar = {
             if (!isUserLoggedIn) {
                 Box(modifier = Modifier.padding(horizontal = 16.dp, vertical = 32.dp)) {
-                    AuthButtons(onRegisterClick = onRegisterClick, onSignInClick = onSignInClick)
+                    AuthButtonsPanel(
+                        onRegisterClick = onRegisterClick,
+                        onSignInClick = onSignInClick
+                    )
                 }
             }
         }

--- a/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsFragment.kt
@@ -39,7 +39,6 @@ import androidx.fragment.app.Fragment
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
-import org.openedx.auth.presentation.AuthRouter
 import org.openedx.core.UIMessage
 import org.openedx.core.domain.model.Course
 import org.openedx.core.domain.model.Media
@@ -101,8 +100,8 @@ class CourseDetailsFragment : Fragment() {
                         val currentState = uiState
                         if (currentState is CourseDetailsUIState.CourseData) {
                             when {
-                                (!currentState.isUserLoggedIn && router is AuthRouter) -> {
-                                    (router as AuthRouter).navigateToLogistration(
+                                (!currentState.isUserLoggedIn) -> {
+                                    router.navigateToLogistration(
                                         parentFragmentManager,
                                         currentState.course.courseId
                                     )

--- a/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsFragment.kt
@@ -102,7 +102,8 @@ class CourseDetailsFragment : Fragment() {
                             when {
                                 (!currentState.isUserLoggedIn && router is AuthRouter) -> {
                                     (router as AuthRouter).navigateToLogistration(
-                                        parentFragmentManager
+                                        parentFragmentManager,
+                                        currentState.course.courseId
                                     )
                                 }
 

--- a/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsFragment.kt
@@ -90,6 +90,7 @@ class CourseDetailsFragment : Fragment() {
                         colorTextValue
                     ),
                     hasInternetConnection = viewModel.hasInternetConnection,
+                    isUserLoggedIn = viewModel.isUserLoggedIn,
                     onReloadClick = {
                         viewModel.getCourseDetail()
                     },
@@ -124,7 +125,14 @@ class CourseDetailsFragment : Fragment() {
                                 }
                             }
                         }
-                    })
+                    },
+                    onRegisterClick = {
+                        router.navigateToSignUp(parentFragmentManager, viewModel.courseId)
+                    },
+                    onSignInClick = {
+                        router.navigateToSignIn(parentFragmentManager, viewModel.courseId)
+                    },
+                )
             }
         }
     }
@@ -150,9 +158,12 @@ internal fun CourseDetailsScreen(
     apiHostUrl: String,
     htmlBody: String,
     hasInternetConnection: Boolean,
+    isUserLoggedIn: Boolean,
     onReloadClick: () -> Unit,
     onBackClick: () -> Unit,
     onButtonClick: () -> Unit,
+    onRegisterClick: () -> Unit,
+    onSignInClick: () -> Unit,
 ) {
     val scaffoldState = rememberScaffoldState()
     val configuration = LocalConfiguration.current
@@ -166,7 +177,14 @@ internal fun CourseDetailsScreen(
             .fillMaxSize()
             .navigationBarsPadding(),
         scaffoldState = scaffoldState,
-        backgroundColor = MaterialTheme.appColors.background
+        backgroundColor = MaterialTheme.appColors.background,
+        bottomBar = {
+            if (!isUserLoggedIn) {
+                Box(modifier = Modifier.padding(horizontal = 16.dp, vertical = 32.dp)) {
+                    AuthButtons(onRegisterClick = onRegisterClick, onSignInClick = onSignInClick)
+                }
+            }
+        }
     ) {
 
         val screenWidth by remember(key1 = windowSize) {
@@ -228,7 +246,6 @@ internal fun CourseDetailsScreen(
                 Spacer(Modifier.height(6.dp))
                 Box(
                     Modifier
-                        .padding(it)
                         .fillMaxSize()
                         .background(MaterialTheme.appColors.background),
                     contentAlignment = Alignment.TopCenter
@@ -634,10 +651,13 @@ private fun CourseDetailNativeContentPreview() {
             uiMessage = null,
             apiHostUrl = "http://localhost:8000",
             hasInternetConnection = false,
+            isUserLoggedIn = true,
             htmlBody = "<b>Preview text</b>",
             onReloadClick = {},
             onBackClick = {},
-            onButtonClick = {}
+            onButtonClick = {},
+            onRegisterClick = {},
+            onSignInClick = {},
         )
     }
 }
@@ -653,10 +673,13 @@ private fun CourseDetailNativeContentTabletPreview() {
             uiMessage = null,
             apiHostUrl = "http://localhost:8000",
             hasInternetConnection = false,
+            isUserLoggedIn = true,
             htmlBody = "<b>Preview text</b>",
             onReloadClick = {},
             onBackClick = {},
-            onButtonClick = {}
+            onButtonClick = {},
+            onRegisterClick = {},
+            onSignInClick = {},
         )
     }
 }

--- a/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsFragment.kt
@@ -39,6 +39,7 @@ import androidx.fragment.app.Fragment
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
+import org.openedx.auth.presentation.AuthRouter
 import org.openedx.core.UIMessage
 import org.openedx.core.domain.model.Course
 import org.openedx.core.domain.model.Media
@@ -98,18 +99,28 @@ class CourseDetailsFragment : Fragment() {
                     onButtonClick = {
                         val currentState = uiState
                         if (currentState is CourseDetailsUIState.CourseData) {
-                            if (currentState.course.isEnrolled) {
-                                viewModel.viewCourseClickedEvent(
-                                    currentState.course.courseId,
-                                    currentState.course.name
-                                )
-                                router.navigateToCourseOutline(
-                                    requireActivity().supportFragmentManager,
-                                    currentState.course.courseId,
-                                    currentState.course.name
-                                )
-                            } else {
-                                viewModel.enrollInACourse(currentState.course.courseId)
+                            when {
+                                (!currentState.isUserLoggedIn && router is AuthRouter) -> {
+                                    (router as AuthRouter).navigateToLogistration(
+                                        parentFragmentManager
+                                    )
+                                }
+
+                                currentState.course.isEnrolled -> {
+                                    viewModel.viewCourseClickedEvent(
+                                        currentState.course.courseId,
+                                        currentState.course.name
+                                    )
+                                    router.navigateToCourseOutline(
+                                        requireActivity().supportFragmentManager,
+                                        currentState.course.courseId,
+                                        currentState.course.name
+                                    )
+                                }
+
+                                else -> {
+                                    viewModel.enrollInACourse(currentState.course.courseId)
+                                }
                             }
                         }
                     })

--- a/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsUIState.kt
+++ b/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsUIState.kt
@@ -3,6 +3,12 @@ package org.openedx.course.presentation.detail
 import org.openedx.core.domain.model.Course
 
 sealed class CourseDetailsUIState {
-    data class CourseData(val course: Course) : CourseDetailsUIState()
+    data class CourseData(
+        val course: Course,
+        val isLogistrationEnabled: Boolean = false,
+        val isUserLoggedIn: Boolean = false
+    ) :
+        CourseDetailsUIState()
+
     object Loading : CourseDetailsUIState()
 }

--- a/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsUIState.kt
+++ b/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsUIState.kt
@@ -3,11 +3,7 @@ package org.openedx.course.presentation.detail
 import org.openedx.core.domain.model.Course
 
 sealed class CourseDetailsUIState {
-    data class CourseData(
-        val course: Course,
-        val isLogistrationEnabled: Boolean = false,
-        val isUserLoggedIn: Boolean = false
-    ) :
+    data class CourseData(val course: Course, val isUserLoggedIn: Boolean = false) :
         CourseDetailsUIState()
 
     object Loading : CourseDetailsUIState()

--- a/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsViewModel.kt
@@ -52,7 +52,7 @@ class CourseDetailsViewModel(
         _uiState.value = CourseDetailsUIState.Loading
         viewModelScope.launch {
             try {
-                course = if (networkConnection.isOnline()) {
+                course = if (hasInternetConnection) {
                     interactor.getCourseDetails(courseId)
                 } else {
                     interactor.getCourseDetailsFromCache(courseId)
@@ -60,7 +60,7 @@ class CourseDetailsViewModel(
                 course?.let {
                     _uiState.value = CourseDetailsUIState.CourseData(
                         course = it,
-                        isUserLoggedIn = corePreferences.user != null
+                        isUserLoggedIn = isUserLoggedIn
                     )
                 } ?: run {
                     _uiMessage.value =

--- a/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsViewModel.kt
@@ -20,7 +20,7 @@ import org.openedx.course.domain.interactor.CourseInteractor
 import org.openedx.course.presentation.CourseAnalytics
 
 class CourseDetailsViewModel(
-    private val courseId: String,
+    val courseId: String,
     private val config: Config,
     private val corePreferences: CorePreferences,
     private val networkConnection: NetworkConnection,
@@ -30,6 +30,7 @@ class CourseDetailsViewModel(
     private val analytics: CourseAnalytics
 ) : BaseViewModel() {
     val apiHostUrl get() = config.getApiHostURL()
+    val isUserLoggedIn get() = corePreferences.user != null
 
     private val _uiState = MutableLiveData<CourseDetailsUIState>(CourseDetailsUIState.Loading)
     val uiState: LiveData<CourseDetailsUIState>

--- a/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsViewModel.kt
@@ -57,11 +57,15 @@ class CourseDetailsViewModel(
                 } else {
                     interactor.getCourseDetailsFromCache(courseId)
                 }
-                _uiState.value = CourseDetailsUIState.CourseData(
-                    course = course!!,
-                    config.isPreLoginExperienceEnabled(),
-                    corePreferences.user != null
-                )
+                course?.let {
+                    _uiState.value = CourseDetailsUIState.CourseData(
+                        course = it,
+                        isUserLoggedIn = corePreferences.user != null
+                    )
+                } ?: run {
+                    _uiMessage.value =
+                        UIMessage.SnackBarMessage(resourceManager.getString(R.string.core_error_unknown_error))
+                }
             } catch (e: Exception) {
                 if (e.isInternetError()) {
                     _uiMessage.value =

--- a/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/detail/CourseDetailsViewModel.kt
@@ -9,6 +9,7 @@ import org.openedx.core.R
 import org.openedx.core.SingleEventLiveData
 import org.openedx.core.UIMessage
 import org.openedx.core.config.Config
+import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.Course
 import org.openedx.core.extension.isInternetError
 import org.openedx.core.system.ResourceManager
@@ -21,6 +22,7 @@ import org.openedx.course.presentation.CourseAnalytics
 class CourseDetailsViewModel(
     private val courseId: String,
     private val config: Config,
+    private val corePreferences: CorePreferences,
     private val networkConnection: NetworkConnection,
     private val interactor: CourseInteractor,
     private val resourceManager: ResourceManager,
@@ -54,7 +56,11 @@ class CourseDetailsViewModel(
                 } else {
                     interactor.getCourseDetailsFromCache(courseId)
                 }
-                _uiState.value = CourseDetailsUIState.CourseData(course = course!!)
+                _uiState.value = CourseDetailsUIState.CourseData(
+                    course = course!!,
+                    config.isPreLoginExperienceEnabled(),
+                    corePreferences.user != null
+                )
             } catch (e: Exception) {
                 if (e.isInternetError()) {
                     _uiMessage.value =

--- a/course/src/test/java/org/openedx/course/presentation/detail/CourseDetailsViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/detail/CourseDetailsViewModelTest.kt
@@ -1,11 +1,20 @@
 package org.openedx.course.presentation.detail
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import io.mockk.*
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.test.*
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -15,6 +24,7 @@ import org.junit.rules.TestRule
 import org.openedx.core.R
 import org.openedx.core.UIMessage
 import org.openedx.core.config.Config
+import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.Course
 import org.openedx.core.domain.model.Media
 import org.openedx.core.system.ResourceManager
@@ -34,6 +44,7 @@ class CourseDetailsViewModelTest {
     private val dispatcher = StandardTestDispatcher()
 
     private val config = mockk<Config>()
+    private val preferencesManager = mockk<CorePreferences>()
     private val resourceManager = mockk<ResourceManager>()
     private val interactor = mockk<CourseInteractor>()
     private val networkConnection = mockk<NetworkConnection>()
@@ -85,6 +96,7 @@ class CourseDetailsViewModelTest {
         val viewModel = CourseDetailsViewModel(
             "",
             config,
+            preferencesManager,
             networkConnection,
             interactor,
             resourceManager,
@@ -108,6 +120,7 @@ class CourseDetailsViewModelTest {
         val viewModel = CourseDetailsViewModel(
             "",
             config,
+            preferencesManager,
             networkConnection,
             interactor,
             resourceManager,
@@ -131,12 +144,15 @@ class CourseDetailsViewModelTest {
         val viewModel = CourseDetailsViewModel(
             "",
             config,
+            preferencesManager,
             networkConnection,
             interactor,
             resourceManager,
             notifier,
             analytics
         )
+        every { config.isPreLoginExperienceEnabled() } returns false
+        every { preferencesManager.user } returns null
         every { networkConnection.isOnline() } returns true
         coEvery { interactor.getCourseDetails(any()) } returns mockk()
 
@@ -153,12 +169,15 @@ class CourseDetailsViewModelTest {
         val viewModel = CourseDetailsViewModel(
             "",
             config,
+            preferencesManager,
             networkConnection,
             interactor,
             resourceManager,
             notifier,
             analytics
         )
+        every { config.isPreLoginExperienceEnabled() } returns false
+        every { preferencesManager.user } returns null
         every { networkConnection.isOnline() } returns false
         coEvery { interactor.getCourseDetailsFromCache(any()) } returns mockk()
 
@@ -176,12 +195,15 @@ class CourseDetailsViewModelTest {
         val viewModel = CourseDetailsViewModel(
             "",
             config,
+            preferencesManager,
             networkConnection,
             interactor,
             resourceManager,
             notifier,
             analytics
         )
+        every { config.isPreLoginExperienceEnabled() } returns false
+        every { preferencesManager.user } returns null
         coEvery { interactor.enrollInACourse(any()) } throws UnknownHostException()
         coEvery { notifier.send(CourseDashboardUpdate()) } returns Unit
         every { networkConnection.isOnline() } returns true
@@ -206,12 +228,15 @@ class CourseDetailsViewModelTest {
         val viewModel = CourseDetailsViewModel(
             "",
             config,
+            preferencesManager,
             networkConnection,
             interactor,
             resourceManager,
             notifier,
             analytics
         )
+        every { config.isPreLoginExperienceEnabled() } returns false
+        every { preferencesManager.user } returns null
         coEvery { interactor.enrollInACourse(any()) } throws Exception()
         coEvery { notifier.send(CourseDashboardUpdate()) } returns Unit
         every { networkConnection.isOnline() } returns true
@@ -237,12 +262,15 @@ class CourseDetailsViewModelTest {
         val viewModel = CourseDetailsViewModel(
             "",
             config,
+            preferencesManager,
             networkConnection,
             interactor,
             resourceManager,
             notifier,
             analytics
         )
+        every { config.isPreLoginExperienceEnabled() } returns false
+        every { preferencesManager.user } returns null
         every { analytics.courseEnrollClickedEvent(any(), any()) } returns Unit
         every { analytics.courseEnrollSuccessEvent(any(), any()) } returns Unit
         coEvery { interactor.enrollInACourse(any()) } returns Unit
@@ -268,6 +296,7 @@ class CourseDetailsViewModelTest {
         val viewModel = CourseDetailsViewModel(
             "",
             config,
+            preferencesManager,
             networkConnection,
             interactor,
             resourceManager,
@@ -284,6 +313,7 @@ class CourseDetailsViewModelTest {
         val viewModel = CourseDetailsViewModel(
             "",
             config,
+            preferencesManager,
             networkConnection,
             interactor,
             resourceManager,

--- a/discovery/src/main/java/org/openedx/discovery/presentation/DiscoveryRouter.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/DiscoveryRouter.kt
@@ -11,4 +11,8 @@ interface DiscoveryRouter {
     fun navigateToUpgradeRequired(fm: FragmentManager)
 
     fun navigateToCourseInfo(fm: FragmentManager, courseId: String, infoType: String)
+
+    fun navigateToSignUp(fm: FragmentManager, courseId: String?)
+
+    fun navigateToSignIn(fm: FragmentManager, courseId: String?)
 }

--- a/discovery/src/main/java/org/openedx/discovery/presentation/DiscoveryRouter.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/DiscoveryRouter.kt
@@ -12,7 +12,7 @@ interface DiscoveryRouter {
 
     fun navigateToCourseInfo(fm: FragmentManager, courseId: String, infoType: String)
 
-    fun navigateToSignUp(fm: FragmentManager, courseId: String?)
+    fun navigateToSignUp(fm: FragmentManager, courseId: String? = null)
 
     fun navigateToSignIn(fm: FragmentManager, courseId: String?)
 }

--- a/discovery/src/main/java/org/openedx/discovery/presentation/NativeDiscoveryFragment.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/NativeDiscoveryFragment.kt
@@ -60,7 +60,7 @@ import org.openedx.core.domain.model.Media
 import org.openedx.core.presentation.dialog.appupgrade.AppUpgradeDialogFragment
 import org.openedx.core.presentation.global.app_upgrade.AppUpgradeRecommendedBox
 import org.openedx.core.system.notifier.AppUpgradeEvent
-import org.openedx.core.ui.AuthButtons
+import org.openedx.core.ui.AuthButtonsPanel
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.DiscoveryCourseItem
 import org.openedx.core.ui.HandleUIMessage
@@ -233,7 +233,7 @@ internal fun DiscoveryScreen(
                             vertical = 32.dp,
                         )
                 ) {
-                    AuthButtons(
+                    AuthButtonsPanel(
                         onRegisterClick = onRegisterClick,
                         onSignInClick = onSignInClick
                     )

--- a/discovery/src/main/java/org/openedx/discovery/presentation/NativeDiscoveryViewModel.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/NativeDiscoveryViewModel.kt
@@ -31,7 +31,8 @@ class NativeDiscoveryViewModel(
 ) : BaseViewModel() {
 
     val apiHostUrl get() = config.getApiHostURL()
-    val canShowBackButton get() = config.isPreLoginExperienceEnabled() && corePreferences.user == null
+    val isUserLoggedIn get() = corePreferences.user != null
+    val canShowBackButton get() = config.isPreLoginExperienceEnabled() && !isUserLoggedIn
 
     private val _uiState = MutableLiveData<DiscoveryUIState>(DiscoveryUIState.Loading)
     val uiState: LiveData<DiscoveryUIState>

--- a/discovery/src/main/java/org/openedx/discovery/presentation/search/CourseSearchFragment.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/search/CourseSearchFragment.kt
@@ -63,6 +63,7 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.openedx.core.UIMessage
 import org.openedx.core.domain.model.Course
 import org.openedx.core.domain.model.Media
+import org.openedx.core.ui.AuthButtons
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.DiscoveryCourseItem
 import org.openedx.core.ui.HandleUIMessage
@@ -113,6 +114,7 @@ class CourseSearchFragment : Fragment() {
                     canLoadMore = canLoadMore,
                     refreshing = refreshing,
                     querySearch = querySearch,
+                    isUserLoggedIn = viewModel.isUserLoggedIn,
                     onBackClick = {
                         requireActivity().supportFragmentManager.popBackStack()
                     },
@@ -130,7 +132,13 @@ class CourseSearchFragment : Fragment() {
                             requireActivity().supportFragmentManager,
                             it
                         )
-                    }
+                    },
+                    onRegisterClick = {
+                        router.navigateToSignUp(parentFragmentManager, null)
+                    },
+                    onSignInClick = {
+                        router.navigateToSignIn(parentFragmentManager, null)
+                    },
                 )
             }
         }
@@ -159,11 +167,14 @@ private fun CourseSearchScreen(
     canLoadMore: Boolean,
     refreshing: Boolean,
     querySearch: String,
+    isUserLoggedIn: Boolean,
     onBackClick: () -> Unit,
     onSearchTextChanged: (String) -> Unit,
     onSwipeRefresh: () -> Unit,
     paginationCallback: () -> Unit,
-    onItemClick: (String) -> Unit
+    onItemClick: (String) -> Unit,
+    onRegisterClick: () -> Unit,
+    onSignInClick: () -> Unit,
 ) {
     val scaffoldState = rememberScaffoldState()
     val scrollState = rememberLazyListState()
@@ -195,7 +206,23 @@ private fun CourseSearchScreen(
         modifier = Modifier
             .fillMaxSize()
             .navigationBarsPadding(),
-        backgroundColor = MaterialTheme.appColors.background
+        backgroundColor = MaterialTheme.appColors.background,
+        bottomBar = {
+            if (!isUserLoggedIn) {
+                Box(
+                    modifier = Modifier
+                        .padding(
+                            horizontal = 16.dp,
+                            vertical = 32.dp,
+                        )
+                ) {
+                    AuthButtons(
+                        onRegisterClick = onRegisterClick,
+                        onSignInClick = onSignInClick
+                    )
+                }
+            }
+        }
     ) {
 
         val screenWidth by remember(key1 = windowSize) {
@@ -397,11 +424,14 @@ fun CourseSearchScreenPreview() {
             canLoadMore = false,
             refreshing = false,
             querySearch = "",
+            isUserLoggedIn = true,
             onBackClick = {},
             onSearchTextChanged = {},
             onSwipeRefresh = {},
             paginationCallback = {},
-            onItemClick = {}
+            onItemClick = {},
+            onSignInClick = {},
+            onRegisterClick = {},
         )
     }
 }
@@ -419,11 +449,14 @@ fun CourseSearchScreenTabletPreview() {
             canLoadMore = false,
             refreshing = false,
             querySearch = "",
+            isUserLoggedIn = false,
             onBackClick = {},
             onSearchTextChanged = {},
             onSwipeRefresh = {},
             paginationCallback = {},
-            onItemClick = {}
+            onItemClick = {},
+            onSignInClick = {},
+            onRegisterClick = {},
         )
     }
 }

--- a/discovery/src/main/java/org/openedx/discovery/presentation/search/CourseSearchFragment.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/search/CourseSearchFragment.kt
@@ -63,7 +63,7 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.openedx.core.UIMessage
 import org.openedx.core.domain.model.Course
 import org.openedx.core.domain.model.Media
-import org.openedx.core.ui.AuthButtons
+import org.openedx.core.ui.AuthButtonsPanel
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.DiscoveryCourseItem
 import org.openedx.core.ui.HandleUIMessage
@@ -216,7 +216,7 @@ private fun CourseSearchScreen(
                             vertical = 32.dp,
                         )
                 ) {
-                    AuthButtons(
+                    AuthButtonsPanel(
                         onRegisterClick = onRegisterClick,
                         onSignInClick = onSignInClick
                     )

--- a/discovery/src/main/java/org/openedx/discovery/presentation/search/CourseSearchViewModel.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/search/CourseSearchViewModel.kt
@@ -13,6 +13,7 @@ import org.openedx.core.R
 import org.openedx.core.SingleEventLiveData
 import org.openedx.core.UIMessage
 import org.openedx.core.config.Config
+import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.Course
 import org.openedx.core.extension.isInternetError
 import org.openedx.core.system.ResourceManager
@@ -21,12 +22,14 @@ import org.openedx.discovery.presentation.DiscoveryAnalytics
 
 class CourseSearchViewModel(
     private val config: Config,
+    private val corePreferences: CorePreferences,
     private val interactor: DiscoveryInteractor,
     private val resourceManager: ResourceManager,
     private val analytics: DiscoveryAnalytics
 ) : BaseViewModel() {
 
     val apiHostUrl get() = config.getApiHostURL()
+    val isUserLoggedIn get() = corePreferences.user != null
 
     private val _uiState =
         MutableLiveData<CourseSearchUIState>(CourseSearchUIState.Courses(emptyList(), 0))

--- a/discovery/src/test/java/org/openedx/discovery/presentation/search/CourseSearchViewModelTest.kt
+++ b/discovery/src/test/java/org/openedx/discovery/presentation/search/CourseSearchViewModelTest.kt
@@ -1,8 +1,28 @@
 package org.openedx.discovery.presentation.search
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
 import org.openedx.core.R
 import org.openedx.core.UIMessage
+import org.openedx.core.config.Config
+import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.Course
 import org.openedx.core.domain.model.CourseList
 import org.openedx.core.domain.model.Media
@@ -10,20 +30,6 @@ import org.openedx.core.domain.model.Pagination
 import org.openedx.core.system.ResourceManager
 import org.openedx.discovery.domain.interactor.DiscoveryInteractor
 import org.openedx.discovery.presentation.DiscoveryAnalytics
-import io.mockk.coEvery
-import io.mockk.coVerify
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
-import kotlinx.coroutines.*
-import kotlinx.coroutines.test.*
-import org.junit.After
-import org.junit.Assert.*
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TestRule
-import org.openedx.core.config.Config
 import java.net.UnknownHostException
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -36,6 +42,7 @@ class CourseSearchViewModelTest {
     private val dispatcher = UnconfinedTestDispatcher()
 
     private val config = mockk<Config>()
+    private val corePreferences = mockk<CorePreferences>()
     private val resourceManager = mockk<ResourceManager>()
     private val interactor = mockk<DiscoveryInteractor>()
     private val analytics = mockk<DiscoveryAnalytics>()
@@ -86,7 +93,8 @@ class CourseSearchViewModelTest {
 
     @Test
     fun `search empty query`() = runTest {
-        val viewModel = CourseSearchViewModel(config, interactor, resourceManager, analytics)
+        val viewModel =
+            CourseSearchViewModel(config, corePreferences, interactor, resourceManager, analytics)
 
         viewModel.search("")
         advanceUntilIdle()
@@ -100,7 +108,8 @@ class CourseSearchViewModelTest {
 
     @Test
     fun `search query no internet connection exception`() = runTest {
-        val viewModel = CourseSearchViewModel(config, interactor, resourceManager, analytics)
+        val viewModel =
+            CourseSearchViewModel(config, corePreferences, interactor, resourceManager, analytics)
         coEvery { interactor.getCoursesListByQuery(any(), any()) } throws UnknownHostException()
 
         viewModel.search("course")
@@ -115,7 +124,8 @@ class CourseSearchViewModelTest {
 
     @Test
     fun `search query unknown exception`() = runTest {
-        val viewModel = CourseSearchViewModel(config, interactor, resourceManager, analytics)
+        val viewModel =
+            CourseSearchViewModel(config, corePreferences, interactor, resourceManager, analytics)
         coEvery { interactor.getCoursesListByQuery(any(), any()) } throws Exception()
 
         viewModel.search("course")
@@ -130,7 +140,8 @@ class CourseSearchViewModelTest {
 
     @Test
     fun `search query success without next page`() = runTest {
-        val viewModel = CourseSearchViewModel(config, interactor, resourceManager, analytics)
+        val viewModel =
+            CourseSearchViewModel(config, corePreferences, interactor, resourceManager, analytics)
         coEvery { interactor.getCoursesListByQuery(any(), any()) } returns CourseList(
             Pagination(
                 10,
@@ -155,7 +166,8 @@ class CourseSearchViewModelTest {
 
     @Test
     fun `search query success with next page and fetch`() = runTest {
-        val viewModel = CourseSearchViewModel(config, interactor, resourceManager, analytics)
+        val viewModel =
+            CourseSearchViewModel(config, corePreferences, interactor, resourceManager, analytics)
         coEvery { interactor.getCoursesListByQuery(any(), eq(1)) } returns CourseList(
             Pagination(
                 10,
@@ -189,7 +201,8 @@ class CourseSearchViewModelTest {
 
     @Test
     fun `search query success with next page and fetch, update`() = runTest {
-        val viewModel = CourseSearchViewModel(config, interactor, resourceManager, analytics)
+        val viewModel =
+            CourseSearchViewModel(config, corePreferences, interactor, resourceManager, analytics)
         coEvery { interactor.getCoursesListByQuery(any(), eq(1)) } returns CourseList(
             Pagination(
                 10,
@@ -224,7 +237,8 @@ class CourseSearchViewModelTest {
 
     @Test
     fun `search query update in empty state`() = runTest {
-        val viewModel = CourseSearchViewModel(config, interactor, resourceManager, analytics)
+        val viewModel =
+            CourseSearchViewModel(config, corePreferences, interactor, resourceManager, analytics)
         coEvery { interactor.getCoursesListByQuery(any(), eq(1)) } returns CourseList(
             Pagination(
                 10,

--- a/whatsnew/src/main/java/org/openedx/whatsnew/WhatsNewRouter.kt
+++ b/whatsnew/src/main/java/org/openedx/whatsnew/WhatsNewRouter.kt
@@ -3,5 +3,5 @@ package org.openedx.whatsnew
 import androidx.fragment.app.FragmentManager
 
 interface WhatsNewRouter {
-    fun navigateToMain(fm: FragmentManager, courseId: String?)
+    fun navigateToMain(fm: FragmentManager, courseId: String? = null)
 }

--- a/whatsnew/src/main/java/org/openedx/whatsnew/WhatsNewRouter.kt
+++ b/whatsnew/src/main/java/org/openedx/whatsnew/WhatsNewRouter.kt
@@ -3,5 +3,5 @@ package org.openedx.whatsnew
 import androidx.fragment.app.FragmentManager
 
 interface WhatsNewRouter {
-    fun navigateToMain(fm: FragmentManager)
+    fun navigateToMain(fm: FragmentManager, courseId: String?)
 }

--- a/whatsnew/src/main/java/org/openedx/whatsnew/presentation/whatsnew/WhatsNewFragment.kt
+++ b/whatsnew/src/main/java/org/openedx/whatsnew/presentation/whatsnew/WhatsNewFragment.kt
@@ -47,10 +47,12 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.koin.core.parameter.parametersOf
 import org.openedx.core.presentation.global.AppData
 import org.openedx.core.ui.WindowSize
 import org.openedx.core.ui.calculateCurrentOffsetForPage
@@ -69,7 +71,9 @@ import org.openedx.whatsnew.presentation.ui.PageIndicator
 
 class WhatsNewFragment : Fragment() {
 
-    private val viewModel: WhatsNewViewModel by viewModel()
+    private val viewModel: WhatsNewViewModel by viewModel {
+        parametersOf(requireArguments().getString(ARG_COURSE_ID, null))
+    }
     private val preferencesManager by inject<WhatsNewPreferences>()
     private val router by inject<WhatsNewRouter>()
     private val appData: AppData by inject()
@@ -90,10 +94,21 @@ class WhatsNewFragment : Fragment() {
                     onCloseClick = {
                         val versionName = appData.versionName
                         preferencesManager.lastWhatsNewVersion = versionName
-                        router.navigateToMain(parentFragmentManager)
+                        router.navigateToMain(parentFragmentManager, viewModel.courseId)
                     }
                 )
             }
+        }
+    }
+
+    companion object {
+        private const val ARG_COURSE_ID = "courseId"
+        fun newInstance(courseId: String? = null): WhatsNewFragment {
+            val fragment = WhatsNewFragment()
+            fragment.arguments = bundleOf(
+                ARG_COURSE_ID to courseId
+            )
+            return fragment
         }
     }
 }

--- a/whatsnew/src/main/java/org/openedx/whatsnew/presentation/whatsnew/WhatsNewFragment.kt
+++ b/whatsnew/src/main/java/org/openedx/whatsnew/presentation/whatsnew/WhatsNewFragment.kt
@@ -90,7 +90,7 @@ class WhatsNewFragment : Fragment() {
                     onCloseClick = {
                         val versionName = appData.versionName
                         preferencesManager.lastWhatsNewVersion = versionName
-                        router.navigateToMain(parentFragmentManager, null)
+                        router.navigateToMain(parentFragmentManager)
                     }
                 )
             }
@@ -329,7 +329,7 @@ private fun WhatsNewScreenLandscape(
                     state = pagerState
                 ) { page ->
                     val image = whatsNewItem.messages[page].image
-                    val alpha = (0.2f + pagerState.calculateCurrentOffsetForPage(page))*10
+                    val alpha = (0.2f + pagerState.calculateCurrentOffsetForPage(page)) * 10
                     Image(
                         modifier = Modifier
                             .alpha(alpha)
@@ -443,8 +443,18 @@ private fun WhatsNewPortraitPreview() {
 }
 
 @OptIn(ExperimentalFoundationApi::class)
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO, device = Devices.AUTOMOTIVE_1024p, widthDp = 720, heightDp = 360)
-@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES, device = Devices.AUTOMOTIVE_1024p, widthDp = 720, heightDp = 360)
+@Preview(
+    uiMode = Configuration.UI_MODE_NIGHT_NO,
+    device = Devices.AUTOMOTIVE_1024p,
+    widthDp = 720,
+    heightDp = 360
+)
+@Preview(
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    device = Devices.AUTOMOTIVE_1024p,
+    widthDp = 720,
+    heightDp = 360
+)
 @Composable
 private fun WhatsNewLandscapePreview() {
     OpenEdXTheme {

--- a/whatsnew/src/main/java/org/openedx/whatsnew/presentation/whatsnew/WhatsNewFragment.kt
+++ b/whatsnew/src/main/java/org/openedx/whatsnew/presentation/whatsnew/WhatsNewFragment.kt
@@ -90,7 +90,7 @@ class WhatsNewFragment : Fragment() {
                     onCloseClick = {
                         val versionName = appData.versionName
                         preferencesManager.lastWhatsNewVersion = versionName
-                        router.navigateToMain(parentFragmentManager)
+                        router.navigateToMain(parentFragmentManager, null)
                     }
                 )
             }

--- a/whatsnew/src/main/java/org/openedx/whatsnew/presentation/whatsnew/WhatsNewViewModel.kt
+++ b/whatsnew/src/main/java/org/openedx/whatsnew/presentation/whatsnew/WhatsNewViewModel.kt
@@ -7,6 +7,7 @@ import org.openedx.whatsnew.WhatsNewManager
 import org.openedx.whatsnew.domain.model.WhatsNewItem
 
 class WhatsNewViewModel(
+    val courseId: String,
     private val whatsNewManager: WhatsNewManager
 ) : BaseViewModel() {
 

--- a/whatsnew/src/test/java/org/openedx/whatsnew/WhatsNewViewModelTest.kt
+++ b/whatsnew/src/test/java/org/openedx/whatsnew/WhatsNewViewModelTest.kt
@@ -21,9 +21,7 @@ class WhatsNewViewModelTest {
     fun `getNewestData success`() = runTest {
         every { whatsNewManager.getNewestData() } returns whatsNewItem
 
-        val viewModel = WhatsNewViewModel(
-            whatsNewManager
-        )
+        val viewModel = WhatsNewViewModel("", whatsNewManager)
 
         verify(exactly = 1) { whatsNewManager.getNewestData() }
         assert(viewModel.whatsNewItem.value == whatsNewItem)


### PR DESCRIPTION
### Pre-login Exploration Enrolment Handling

- Tapping the enroll button should lead the user to the logistration screen.
- On successfully logging in or registering the user should return to the course about page in the native experience.
- There needs to be a sticky bottom banner having the register and sign-in buttons a they explore discovery without logging in.

[Screen_recording_20231218_174011.webm](https://github.com/openedx/openedx-app-android/assets/43750646/311fd5f9-dd09-4dc1-ad2d-4bc5cca2e2b7)
