### PR TITLE
fix: Adjust padding on WebContentScreen

### DIFF
--- a/core/src/main/java/org/openedx/core/ui/ComposeCommon.kt
+++ b/core/src/main/java/org/openedx/core/ui/ComposeCommon.kt
@@ -152,7 +152,7 @@ fun Toolbar(
     canShowBackBtn: Boolean = false,
     onBackClick: () -> Unit = {}
 ) {
-    Box(
+    Row(
         modifier = modifier
             .fillMaxWidth()
             .height(48.dp),
@@ -164,7 +164,8 @@ fun Toolbar(
         Text(
             modifier = Modifier
                 .testTag("txt_toolbar_title")
-                .align(Alignment.Center),
+                .align(Alignment.CenterVertically)
+                .padding(end = 16.dp),
             text = label,
             color = MaterialTheme.appColors.textPrimary,
             style = MaterialTheme.appTypography.titleMedium,

--- a/core/src/main/java/org/openedx/core/ui/WebContentScreen.kt
+++ b/core/src/main/java/org/openedx/core/ui/WebContentScreen.kt
@@ -10,10 +10,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.CircularProgressIndicator
@@ -59,7 +57,7 @@ fun WebContentScreen(
     Scaffold(
         modifier = Modifier
             .fillMaxSize()
-            .padding(bottom = 16.dp)
+            .padding(bottom = 24.dp)
             .semantics {
                 testTagsAsResourceId = true
             },
@@ -97,7 +95,6 @@ fun WebContentScreen(
                         onBackClick = onBackClick
                     )
                 }
-                Spacer(Modifier.height(6.dp))
                 Surface(
                     Modifier.fillMaxSize(),
                     color = MaterialTheme.appColors.background
@@ -115,9 +112,7 @@ fun WebContentScreen(
                     } else {
                         var webViewAlpha by rememberSaveable { mutableFloatStateOf(0f) }
                         Surface(
-                            Modifier
-                                .padding(horizontal = 16.dp, vertical = 24.dp)
-                                .alpha(webViewAlpha),
+                            Modifier.alpha(webViewAlpha),
                             color = MaterialTheme.appColors.background
                         ) {
                             WebViewContent(


### PR DESCRIPTION
### Description:

- Adjust padding and text on the toolbar
- Remove padding from WebContentScreen

| Old Implementation   | New Implementation  |
| ------------- | ------------- |
| <Img src="https://github.com/openedx/openedx-app-android/assets/30689349/ebab3645-a57f-4bdc-ad8d-50ab5ace6c98" height=480/>  |<Img src="https://github.com/openedx/openedx-app-android/assets/30689349/2f53ea4a-a586-4f46-9354-1a6f77a03a2e" height=480/>  |



