### PR TITLE
fix: bug when data is not displayed on the Hangouts and Announcement

### DIFF
--- a/core/src/main/java/org/openedx/core/ui/WebContentScreen.kt
+++ b/core/src/main/java/org/openedx/core/ui/WebContentScreen.kt
@@ -202,5 +202,19 @@ private fun WebViewContent(
                 }
             }
         },
+        update = { webView ->
+            body?.let {
+                webView.loadDataWithBaseURL(
+                    apiHostUrl,
+                    body.replaceLinkTags(isDarkTheme),
+                    "text/html",
+                    StandardCharsets.UTF_8.name(),
+                    null
+                )
+            }
+            contentUrl?.let {
+                webView.loadUrl(it)
+            }
+        }
     )
 }


### PR DESCRIPTION
Fixed the next bug:

<img width="373" alt="Снимок экрана 2024-02-28 в 18 56 30" src="https://github.com/openedx/openedx-app-android/assets/5153976/047a18f9-aabf-4797-af84-fe06394a4556">

it occurred due to the inability to update the URL in the WebView