### PR TITLE
chore: Update dependency versions

### DIFF
--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -58,9 +58,14 @@ dependencies {
     implementation "androidx.credentials:credentials:1.2.0"
     implementation "androidx.credentials:credentials-play-services-auth:1.2.0"
     implementation "com.facebook.android:facebook-login:16.2.0"
-    implementation "com.google.android.gms:play-services-auth:20.7.0"
+    implementation "com.google.android.gms:play-services-auth:21.0.0"
     implementation "com.google.android.libraries.identity.googleid:googleid:1.1.0"
-    implementation 'com.microsoft.identity.client:msal:4.9.0'
+    implementation("com.microsoft.identity.client:msal:4.9.0") {
+        //Workaround for the error Failed to resolve: 'io.opentelemetry:opentelemetry-bom' for AS Iguana
+        exclude(group: "io.opentelemetry")
+    }
+    implementation("io.opentelemetry:opentelemetry-api:1.18.0")
+    implementation("io.opentelemetry:opentelemetry-context:1.18.0")
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"

--- a/build.gradle
+++ b/build.gradle
@@ -5,16 +5,16 @@ import java.util.regex.Pattern
 
 buildscript {
     ext {
-        kotlin_version = '1.8.21'
+        kotlin_version = '1.9.22'
         coroutines_version = '1.7.1'
-        compose_version = '1.5.0'
-        compose_compiler_version = '1.4.7'
+        compose_version = '1.6.2'
+        compose_compiler_version = '1.5.10'
     }
 }
 
 plugins {
-    id 'com.android.application' version '8.1.1' apply false
-    id 'com.android.library' version '8.1.1' apply false
+    id 'com.android.application' version '8.3.0' apply false
+    id 'com.android.library' version '8.3.0' apply false
     id 'org.jetbrains.kotlin.android' version "$kotlin_version" apply false
     id 'com.google.gms.google-services' version '4.3.15' apply false
     id "com.google.firebase.crashlytics" version "2.9.6" apply false
@@ -27,9 +27,9 @@ task clean(type: Delete) {
 ext {
     core_version = "1.10.1"
     appcompat_version = "1.6.1"
-    material_version = "1.9.0"
-    lifecycle_version = "2.6.1"
-    fragment_version = "1.6.1"
+    material_version = "1.11.0"
+    lifecycle_version = "2.7.0"
+    fragment_version = "1.6.2"
     constraintlayout_version = "2.1.4"
     viewpager2_version = "1.0.0"
     media3_version = "1.1.1"
@@ -46,11 +46,11 @@ ext {
 
     jsoup_version = '1.13.1'
 
-    room_version = '2.5.2'
+    room_version = '2.6.1'
 
-    work_version = '2.8.1'
+    work_version = '2.9.0'
 
-    window_version = '1.1.0'
+    window_version = '1.2.0'
 
     in_app_review = '2.0.1'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Sep 12 17:38:01 EEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
PR includes updates to project dependencies and introduces a workaround for com.microsoft.identity.client:msal for AS Iguana.

Gradle 8.0 -> 8.4
Kotlin 1.8.21 -> 1.9.22
Compose 1.5.0 -> 1.6.2
Compose Compiler 1.4.7 -> 1.5.10
Material 1.9.0 -> 1.11.0
Lifecycle 2.6.1 -> 2.7.0
Fragment 1.6.1 -> 1.6.2
Room 2.5.2 -> 2.6.1
WorkManager 2.8.1 -> 2.9.0
Window 1.1.0 -> 1.2.0
play-services-auth 20.7.0 -> 21.0.0