### PR TITLE
fix: bug when sequence units level appear after tapping back

### DIFF
--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -246,6 +246,7 @@ val screenModule = module {
             get(),
             get(),
             get(),
+            get(),
         )
     }
     viewModel { (courseId: String, handoutsType: String) ->

--- a/course/src/main/java/org/openedx/course/presentation/dates/CourseDatesFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/dates/CourseDatesFragment.kt
@@ -156,16 +156,26 @@ class CourseDatesFragment : Fragment() {
                     onItemClick = { blockId ->
                         if (blockId.isNotEmpty()) {
                             viewModel.getVerticalBlock(blockId)?.let { verticalBlock ->
-                                viewModel.getSequentialBlock(verticalBlock.id)
-                                    ?.let { sequentialBlock ->
-                                        router.navigateToCourseSubsections(
-                                            fm = requireActivity().supportFragmentManager,
-                                            subSectionId = sequentialBlock.id,
-                                            courseId = viewModel.courseId,
-                                            unitId = verticalBlock.id,
-                                            mode = CourseViewMode.FULL
-                                        )
-                                    }
+                                if (viewModel.isCourseExpandableSectionsEnabled) {
+                                    router.navigateToCourseContainer(
+                                        fm = requireActivity().supportFragmentManager,
+                                        courseId = viewModel.courseId,
+                                        unitId = verticalBlock.id,
+                                        componentId = "",
+                                        mode = CourseViewMode.FULL
+                                    )
+                                } else {
+                                    viewModel.getSequentialBlock(verticalBlock.id)
+                                        ?.let { sequentialBlock ->
+                                            router.navigateToCourseSubsections(
+                                                fm = requireActivity().supportFragmentManager,
+                                                subSectionId = sequentialBlock.id,
+                                                courseId = viewModel.courseId,
+                                                unitId = verticalBlock.id,
+                                                mode = CourseViewMode.FULL
+                                            )
+                                        }
+                                }
                             }
                         }
                     },

--- a/course/src/main/java/org/openedx/course/presentation/dates/CourseDatesViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/dates/CourseDatesViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.launch
 import org.openedx.core.BaseViewModel
 import org.openedx.core.SingleEventLiveData
 import org.openedx.core.UIMessage
+import org.openedx.core.config.Config
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.Block
 import org.openedx.core.extension.getSequentialBlocks
@@ -37,6 +38,7 @@ class CourseDatesViewModel(
     private val networkConnection: NetworkConnection,
     private val resourceManager: ResourceManager,
     private val corePreferences: CorePreferences,
+    private val config: Config,
 ) : BaseViewModel() {
 
     private val _uiState = MutableLiveData<DatesUIState>(DatesUIState.Loading)
@@ -63,6 +65,8 @@ class CourseDatesViewModel(
 
     val hasInternetConnection: Boolean
         get() = networkConnection.isOnline()
+
+    val isCourseExpandableSectionsEnabled get() = config.isCourseNestedListEnabled()
 
     init {
         getCourseDates()

--- a/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineFragment.kt
@@ -168,14 +168,24 @@ class CourseOutlineFragment : Fragment() {
                         viewModel.resumeSectionBlock?.let { subSection ->
                             viewModel.resumeCourseTappedEvent(subSection.id)
                             viewModel.resumeVerticalBlock?.let { unit ->
-                                router.navigateToCourseSubsections(
-                                    requireActivity().supportFragmentManager,
-                                    courseId = viewModel.courseId,
-                                    subSectionId = subSection.id,
-                                    mode = CourseViewMode.FULL,
-                                    unitId = unit.id,
-                                    componentId = componentId
-                                )
+                                if (viewModel.isCourseExpandableSectionsEnabled) {
+                                    router.navigateToCourseContainer(
+                                        fm = requireActivity().supportFragmentManager,
+                                        courseId = viewModel.courseId,
+                                        unitId = unit.id,
+                                        componentId = componentId,
+                                        mode = CourseViewMode.FULL
+                                    )
+                                } else {
+                                    router.navigateToCourseSubsections(
+                                        requireActivity().supportFragmentManager,
+                                        courseId = viewModel.courseId,
+                                        subSectionId = subSection.id,
+                                        mode = CourseViewMode.FULL,
+                                        unitId = unit.id,
+                                        componentId = componentId
+                                    )
+                                }
                             }
                         }
                     },

--- a/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineViewModel.kt
@@ -73,6 +73,8 @@ class CourseOutlineViewModel(
     val hasInternetConnection: Boolean
         get() = networkConnection.isOnline()
 
+    val isCourseExpandableSectionsEnabled get() = config.isCourseNestedListEnabled()
+
     private val courseSubSections = mutableMapOf<String, MutableList<Block>>()
     private val subSectionsDownloadsCount = mutableMapOf<String, Int>()
     val courseSubSectionUnit = mutableMapOf<String, Block?>()

--- a/course/src/test/java/org/openedx/course/presentation/dates/CourseDatesViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/dates/CourseDatesViewModelTest.kt
@@ -21,6 +21,7 @@ import org.junit.Test
 import org.junit.rules.TestRule
 import org.openedx.core.R
 import org.openedx.core.UIMessage
+import org.openedx.core.config.Config
 import org.openedx.core.data.model.DateType
 import org.openedx.core.data.model.User
 import org.openedx.core.data.storage.CorePreferences
@@ -54,6 +55,7 @@ class CourseDatesViewModelTest {
     private val calendarManager = mockk<CalendarManager>()
     private val networkConnection = mockk<NetworkConnection>()
     private val corePreferences = mockk<CorePreferences>()
+    private val config = mockk<Config>()
 
     private val openEdx = "OpenEdx"
     private val calendarTitle = "OpenEdx - Abc"
@@ -159,7 +161,8 @@ class CourseDatesViewModelTest {
             calendarManager,
             networkConnection,
             resourceManager,
-            corePreferences
+            corePreferences,
+            config
         )
         every { networkConnection.isOnline() } returns true
         coEvery { interactor.getCourseDates(any()) } throws UnknownHostException()
@@ -185,7 +188,8 @@ class CourseDatesViewModelTest {
             calendarManager,
             networkConnection,
             resourceManager,
-            corePreferences
+            corePreferences,
+            config
         )
         every { networkConnection.isOnline() } returns true
         coEvery { interactor.getCourseDates(any()) } throws Exception()
@@ -211,7 +215,8 @@ class CourseDatesViewModelTest {
             calendarManager,
             networkConnection,
             resourceManager,
-            corePreferences
+            corePreferences,
+            config
         )
         every { networkConnection.isOnline() } returns true
         coEvery { interactor.getCourseDates(any()) } returns mockedCourseDatesResult
@@ -236,7 +241,8 @@ class CourseDatesViewModelTest {
             calendarManager,
             networkConnection,
             resourceManager,
-            corePreferences
+            corePreferences,
+            config
         )
         every { networkConnection.isOnline() } returns true
         coEvery { interactor.getCourseDates(any()) } returns CourseDatesResult(


### PR DESCRIPTION
Removed sequence units level when open a content from Resume or Dates