### PR TITLE
feat: Braze Push Notifications Capabilities

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,14 +47,17 @@ android {
         prod {
             dimension 'env'
             setupBranchConfigFields(it)
+            setupFirebaseConfigFields(it)
         }
         develop {
             dimension 'env'
             setupBranchConfigFields(it)
+            setupFirebaseConfigFields(it)
         }
         stage {
             dimension 'env'
             setupBranchConfigFields(it)
+            setupFirebaseConfigFields(it)
         }
     }
 
@@ -132,6 +135,10 @@ dependencies {
     implementation 'com.segment.analytics.kotlin.destinations:firebase:1.5.2'
     // Braze SDK Integration
     implementation "com.braze:braze-segment-kotlin:1.4.2"
+    implementation "com.braze:android-sdk-ui:30.2.0"
+
+    // Firebase Cloud Messaging Integration for Braze
+    implementation 'com.google.firebase:firebase-messaging-ktx:23.4.1'
 
     // Branch SDK Integration
     implementation 'io.branch.sdk.android:library:5.9.0'
@@ -173,4 +180,12 @@ private def setupBranchConfigFields(buildType) {
     buildType.resValue "string", "branch_uri_scheme", branchUriScheme
     buildType.resValue "string", "branch_host", branchHost
     buildType.resValue "string", "branch_alternate_host", branchAlternateHost
+}
+
+private def setupFirebaseConfigFields(buildType) {
+    def firebaseConfig = configHelper.fetchConfig().get('FIREBASE')
+    def firebaseEnabled = firebaseConfig?.getOrDefault('ENABLED', false)
+    def cloudMessagingEnabled = firebaseConfig?.getOrDefault('CLOUD_MESSAGING_ENABLED', false)
+
+    buildType.manifestPlaceholders = [fcmEnabled: firebaseEnabled && cloudMessagingEnabled]
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -101,6 +101,16 @@
             android:name="androidx.work.impl.foreground.SystemForegroundService"
             android:foregroundServiceType="dataSync"
             tools:node="merge" />
+
+        <!-- Braze init -->
+        <service
+            android:name="com.braze.push.BrazeFirebaseMessagingService"
+            android:enabled="${fcmEnabled}"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/org/openedx/app/OpenEdXApp.kt
+++ b/app/src/main/java/org/openedx/app/OpenEdXApp.kt
@@ -1,6 +1,8 @@
 package org.openedx.app
 
 import android.app.Application
+import com.braze.Braze
+import com.braze.configuration.BrazeConfig
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.ktx.initialize
 import io.branch.referral.Branch
@@ -36,6 +38,19 @@ class OpenEdXApp : Application() {
                 Branch.enableLogging()
             }
             Branch.getAutoInstance(this)
+        }
+
+        if (config.getBrazeConfig().isEnabled && config.getFirebaseConfig().enabled) {
+            val isCloudMessagingEnabled = config.getFirebaseConfig().isCloudMessagingEnabled &&
+                    config.getBrazeConfig().isPushNotificationsEnabled
+
+            val brazeConfig = BrazeConfig.Builder()
+                .setIsFirebaseCloudMessagingRegistrationEnabled(isCloudMessagingEnabled)
+                .setFirebaseCloudMessagingSenderIdKey(config.getFirebaseConfig().projectNumber)
+                .setHandlePushDeepLinksAutomatically(true)
+                .setIsFirebaseMessagingServiceOnNewTokenRegistrationEnabled(true)
+                .build()
+            Braze.configure(this, brazeConfig)
         }
     }
 }

--- a/core/src/main/java/org/openedx/core/config/FirebaseConfig.kt
+++ b/core/src/main/java/org/openedx/core/config/FirebaseConfig.kt
@@ -9,6 +9,9 @@ data class FirebaseConfig(
     @SerializedName("ANALYTICS_SOURCE")
     val analyticsSource: AnalyticsSource = AnalyticsSource.NONE,
 
+    @SerializedName("CLOUD_MESSAGING_ENABLED")
+    val isCloudMessagingEnabled: Boolean = false,
+
     @SerializedName("PROJECT_NUMBER")
     val projectNumber: String = "",
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,6 +21,14 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven {
+            url "http://appboy.github.io/appboy-android-sdk/sdk"
+            allowInsecureProtocol = true
+        }
+        maven {
+            url "https://appboy.github.io/appboy-segment-android/sdk"
+            allowInsecureProtocol = true
+        }
         maven { url "https://pkgs.dev.azure.com/MicrosoftDeviceSDK/DuoSDK-Public/_packaging/Duo-SDK-Feed/maven/v1" }
     }
 }


### PR DESCRIPTION
This PR expands Braze's capabilities to seamlessly receive Push Notifications directly from the Braze Dashboard.

To achieve this, integration of the Firebase Cloud Messaging (FCM) SDK is necessary, along with registering the Firebase service.

### References:
- [Segment-Braze Integration](https://segment.com/docs/connections/destinations/catalog/braze/#android)
- [Braze Push Notification Integration](https://www.braze.com/docs/developer_guide/platform_integration_guides/android/push_notifications/android/integration/standard_integration/)