### PR TITLE
Fix: toolbar alignment

### DIFF
--- a/core/src/main/java/org/openedx/core/ui/ComposeCommon.kt
+++ b/core/src/main/java/org/openedx/core/ui/ComposeCommon.kt
@@ -152,7 +152,7 @@ fun Toolbar(
     canShowBackBtn: Boolean = false,
     onBackClick: () -> Unit = {}
 ) {
-    Row(
+    Box(
         modifier = modifier
             .fillMaxWidth()
             .height(48.dp),
@@ -163,9 +163,10 @@ fun Toolbar(
 
         Text(
             modifier = Modifier
+                .fillMaxWidth()
                 .testTag("txt_toolbar_title")
-                .align(Alignment.CenterVertically)
-                .padding(end = 16.dp),
+                .align(Alignment.Center)
+                .padding(start = 48.dp, end = 48.dp),
             text = label,
             color = MaterialTheme.appColors.textPrimary,
             style = MaterialTheme.appTypography.titleMedium,


### PR DESCRIPTION
This pull request addresses the toolbar text alignment issue caused by earlier pull requests.
According to Open edX mobile design, all titles should be centered aligned.

### **Before:**
<img width="427" alt="Screenshot 2024-03-22 at 16 37 55" src="https://github.com/openedx/openedx-app-android/assets/127732735/ae727b9b-ef26-46d1-8d62-6cdeafe34060">
<img width="427" alt="Screenshot 2024-03-22 at 16 43 28" src="https://github.com/openedx/openedx-app-android/assets/127732735/88ec032a-abee-4ff5-9bf7-366ad6dc5a8c">
<img width="427" alt="Screenshot 2024-03-22 at 16 43 50" src="https://github.com/openedx/openedx-app-android/assets/127732735/b7ec67e0-caf3-494e-8406-fa37309283c1">

### **After:**
<img width="427" alt="Screenshot 2024-03-22 at 16 51 23" src="https://github.com/openedx/openedx-app-android/assets/127732735/5d9f4ffe-5bc1-47fb-9baa-accb97a7d663">
<img width="427" alt="Screenshot 2024-03-22 at 16 51 30" src="https://github.com/openedx/openedx-app-android/assets/127732735/ebc7c968-f5ed-43d9-af3a-ee997069012a">
<img width="427" alt="Screenshot 2024-03-22 at 16 51 35" src="https://github.com/openedx/openedx-app-android/assets/127732735/9e4b1a14-3927-4bde-9425-b3fb5cf8c6ae">

