### PR TITLE
fix: a bug when Discover and Program screens appear not in the middle

### DIFF
--- a/discovery/src/main/java/org/openedx/discovery/presentation/NativeDiscoveryFragment.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/NativeDiscoveryFragment.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.widthIn
@@ -241,6 +242,7 @@ internal fun DiscoveryScreen(
                             horizontal = 16.dp,
                             vertical = 32.dp,
                         )
+                        .navigationBarsPadding()
                 ) {
                     AuthButtonsPanel(
                         onRegisterClick = onRegisterClick,

--- a/discovery/src/main/java/org/openedx/discovery/presentation/WebViewDiscoveryFragment.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/WebViewDiscoveryFragment.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.CircularProgressIndicator
@@ -197,6 +198,7 @@ private fun WebViewDiscoveryScreen(
                             horizontal = 16.dp,
                             vertical = 32.dp,
                         )
+                        .navigationBarsPadding()
                 ) {
                     AuthButtonsPanel(
                         onRegisterClick = onRegisterClick,
@@ -220,7 +222,7 @@ private fun WebViewDiscoveryScreen(
         }
 
         Column(
-            modifier = modifierScreenWidth
+            modifier = Modifier
                 .fillMaxSize()
                 .padding(it)
                 .statusBarsInset()
@@ -235,8 +237,8 @@ private fun WebViewDiscoveryScreen(
 
             Surface {
                 Box(
-                    modifier = Modifier
-                        .fillMaxSize()
+                    modifier = modifierScreenWidth
+                        .fillMaxHeight()
                         .background(Color.White),
                     contentAlignment = Alignment.TopCenter
                 ) {

--- a/discovery/src/main/java/org/openedx/discovery/presentation/info/CourseInfoFragment.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/info/CourseInfoFragment.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.CircularProgressIndicator
@@ -269,7 +270,7 @@ private fun CourseInfoScreen(
         }
 
         Column(
-            modifier = modifierScreenWidth
+            modifier = Modifier
                 .fillMaxSize()
                 .padding(it)
                 .statusBarsInset()
@@ -284,9 +285,10 @@ private fun CourseInfoScreen(
 
             Surface {
                 Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(Color.White),
+                    modifier = modifierScreenWidth
+                        .fillMaxHeight()
+                        .background(Color.White)
+                        .navigationBarsPadding(),
                     contentAlignment = Alignment.TopCenter
                 ) {
                     if (hasInternetConnection) {

--- a/discovery/src/main/java/org/openedx/discovery/presentation/program/ProgramFragment.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/program/ProgramFragment.kt
@@ -258,7 +258,7 @@ private fun ProgramInfoScreen(
         }
 
         Column(
-            modifier = modifierScreenWidth
+            modifier = Modifier
                 .fillMaxSize()
                 .padding(it)
                 .statusBarsInset()
@@ -273,8 +273,8 @@ private fun ProgramInfoScreen(
 
             Surface {
                 Box(
-                    modifier = Modifier
-                        .fillMaxSize()
+                    modifier = modifierScreenWidth
+                        .fillMaxHeight()
                         .background(Color.White),
                     contentAlignment = Alignment.TopCenter
                 ) {


### PR DESCRIPTION
Discover, Program and Explore all courses screens now appear in the middle on tablets