### PR TITLE
fix: removed extra space on the course tab

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineFragment.kt
@@ -364,7 +364,6 @@ internal fun CourseOutlineScreen(
                                         )
                                     }
                                 }
-                                item { Spacer(Modifier.height(28.dp)) }
                                 if (uiState.datesBannerInfo.isBannerAvailableForDashboard()) {
                                     item {
                                         Box(
@@ -373,13 +372,11 @@ internal fun CourseOutlineScreen(
                                         ) {
                                             if (windowSize.isTablet) {
                                                 CourseDatesBannerTablet(
-                                                    modifier = Modifier.padding(bottom = 16.dp),
                                                     banner = uiState.datesBannerInfo,
                                                     resetDates = onResetDatesClick,
                                                 )
                                             } else {
                                                 CourseDatesBanner(
-                                                    modifier = Modifier.padding(bottom = 16.dp),
                                                     banner = uiState.datesBannerInfo,
                                                     resetDates = onResetDatesClick,
                                                 )
@@ -392,11 +389,13 @@ internal fun CourseOutlineScreen(
                                         Box(listPadding) {
                                             if (windowSize.isTablet) {
                                                 ResumeCourseTablet(
+                                                    modifier = Modifier.padding(vertical = 16.dp),
                                                     block = uiState.resumeComponent,
                                                     onResumeClick = onResumeClick
                                                 )
                                             } else {
                                                 ResumeCourse(
+                                                    modifier = Modifier.padding(vertical = 16.dp),
                                                     block = uiState.resumeComponent,
                                                     onResumeClick = onResumeClick
                                                 )
@@ -406,9 +405,6 @@ internal fun CourseOutlineScreen(
                                 }
 
                                 if (isCourseNestedListEnabled) {
-                                    item {
-                                        Spacer(Modifier.height(16.dp))
-                                    }
                                     uiState.courseStructure.blockData.forEach { section ->
                                         val courseSubSections =
                                             uiState.courseSubSections[section.id]
@@ -509,11 +505,12 @@ internal fun CourseOutlineScreen(
 
 @Composable
 private fun ResumeCourse(
+    modifier: Modifier = Modifier,
     block: Block,
     onResumeClick: (String) -> Unit,
 ) {
     Column(
-        modifier = Modifier.fillMaxWidth()
+        modifier = modifier.fillMaxWidth()
     ) {
         Text(
             text = stringResource(id = org.openedx.course.R.string.course_continue_with),
@@ -560,11 +557,12 @@ private fun ResumeCourse(
 
 @Composable
 private fun ResumeCourseTablet(
+    modifier: Modifier = Modifier,
     block: Block,
     onResumeClick: (String) -> Unit,
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Column(
@@ -700,7 +698,7 @@ private fun CourseOutlineScreenTabletPreview() {
 @Composable
 private fun ResumeCoursePreview() {
     OpenEdXTheme {
-        ResumeCourse(mockChapterBlock) {}
+        ResumeCourse(block = mockChapterBlock) {}
     }
 }
 

--- a/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
+++ b/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
@@ -1058,7 +1058,7 @@ fun SubSectionUnitsList(
 
 @Composable
 fun CourseDatesBanner(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     banner: CourseDatesBannerInfo,
     resetDates: () -> Unit,
 ) {
@@ -1104,7 +1104,7 @@ fun CourseDatesBanner(
 
 @Composable
 fun CourseDatesBannerTablet(
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
     banner: CourseDatesBannerInfo,
     resetDates: () -> Unit,
 ) {


### PR DESCRIPTION
Removed extra space on the course tab in different scenarios like: with/without new design, with/without resume button, with/without Dates banner.