### PR TITLE
refactor: Enhance calendar event comparison for migration

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/calendarsync/CalendarManager.kt
+++ b/course/src/main/java/org/openedx/course/presentation/calendarsync/CalendarManager.kt
@@ -294,7 +294,18 @@ class CalendarManager(
                 }
 
                 matchedDate?.let { unit ->
-                    if (unit.date.toCalendar().timeInMillis == dueDateInMillis) {
+                    val dueDateCalendar = Calendar.getInstance().apply {
+                        timeInMillis = dueDateInMillis
+                        set(Calendar.SECOND, 0)
+                        set(Calendar.MILLISECOND, 0)
+                    }
+
+                    val unitDateCalendar = unit.date.toCalendar().apply {
+                        set(Calendar.SECOND, 0)
+                        set(Calendar.MILLISECOND, 0)
+                    }
+
+                    if (dueDateCalendar == unitDateCalendar) {
                         datesList.remove(unit)
                     } else {
                         // If any single value isn't matched, return false


### PR DESCRIPTION
Enhances calendar events comparison for migration by ignoring seconds, and milliseconds improving compatibility with the new codebase. Previously, seconds and milliseconds were not considered. Calendar events and course date blocks have seconds and milliseconds set to zero for precise matching, ensuring a smooth transition.

