### PR TITLE
chore: Upgrade AGP 8.3 -> 8.4

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Generate mock files
         run: ./gradlew generateMockedRawFile
       - name: Run unit tests
-        run: ./gradlew testProdReleaseUnitTest $CI_GRADLE_ARG_PROPERTIES
+        run: ./gradlew testProdDebugUnitTest $CI_GRADLE_ARG_PROPERTIES
 
       - name: Upload reports
         uses: actions/upload-artifact@v3

--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,8 @@ buildscript {
 }
 
 plugins {
-    id 'com.android.application' version '8.3.0' apply false
-    id 'com.android.library' version '8.3.0' apply false
+    id 'com.android.application' version '8.4.0' apply false
+    id 'com.android.library' version '8.4.0' apply false
     id 'org.jetbrains.kotlin.android' version "$kotlin_version" apply false
     id 'com.google.gms.google-services' version '4.3.15' apply false
     id "com.google.firebase.crashlytics" version "2.9.6" apply false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Sep 12 17:38:01 EEST 2022
+#Fri May 03 13:24:00 EEST 2024
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
Gradle was updated from 8.4 to 8.6, and the Android Gradle plugin was updated from 8.3 to 8.4 according to the AS Jellyfish release.

Note: `java.lang.OutOfMemoryError` still appears on rebuild.
Workaround: change locally `org.gradle.jvmargs=-Xmx2048m` to a required value.