### PR TITLE
fix: Modifier.noRippleClickable Modifier factory error

### DIFF
--- a/core/src/main/java/org/openedx/core/ui/ComposeExtensions.kt
+++ b/core/src/main/java/org/openedx/core/ui/ComposeExtensions.kt
@@ -92,7 +92,7 @@ fun Modifier.displayCutoutForLandscape(): Modifier = composed {
 }
 
 inline fun Modifier.noRippleClickable(crossinline onClick: () -> Unit): Modifier = composed {
-    clickable(
+    this then Modifier.clickable(
         indication = null,
         interactionSource = remember { MutableInteractionSource() }) {
         onClick()


### PR DESCRIPTION
Modifier factory functions must use the receiver Modifier instance.

`Inspection info:` Modifier factory functions are fluently chained to construct a chain of Modifier objects that will be applied to a layout. As a result, each factory function must use the receiver Modifier parameter, to ensure that the function is returning a chain that includes previous items in the chain. Make sure the returned chain either explicitly includes this, such as return this.then(MyModifier) or implicitly by returning a chain that starts with an implicit call to another factory function, such as return myModifier(), where myModifier is defined as fun Modifier.myModifier(): Modifier.

<img width="760" alt="image" src="https://github.com/openedx/openedx-app-android/assets/127732735/230d5c63-e326-404c-b961-209bf8f30ddf">