### PR TITLE
fix: Ensure cookies authentication prior to webview loading

### DIFF
--- a/core/src/main/java/org/openedx/core/extension/ViewExt.kt
+++ b/core/src/main/java/org/openedx/core/extension/ViewExt.kt
@@ -6,8 +6,12 @@ import android.graphics.Rect
 import android.util.DisplayMetrics
 import android.view.View
 import android.view.ViewGroup
+import android.webkit.WebView
 import android.widget.Toast
 import androidx.fragment.app.DialogFragment
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.openedx.core.system.AppCookieManager
 
 fun Context.dpToPixel(dp: Int): Float {
     return dp * (resources.displayMetrics.densityDpi.toFloat() / DisplayMetrics.DENSITY_DEFAULT)
@@ -45,4 +49,15 @@ fun DialogFragment.setWidthPercent(percentage: Int) {
 
 fun Context.toastMessage(message: String) {
     Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+}
+
+fun WebView.loadUrl(url: String, scope: CoroutineScope, cookieManager: AppCookieManager) {
+    if (cookieManager.isSessionCookieMissingOrExpired()) {
+        scope.launch {
+            cookieManager.tryToRefreshSessionCookie()
+            loadUrl(url)
+        }
+    } else {
+        loadUrl(url)
+    }
 }

--- a/core/src/main/java/org/openedx/core/system/AppCookieManager.kt
+++ b/core/src/main/java/org/openedx/core/system/AppCookieManager.kt
@@ -11,8 +11,6 @@ import java.util.concurrent.TimeUnit
 class AppCookieManager(private val config: Config, private val api: CookiesApi) {
 
     companion object {
-        private const val REV_934_COOKIE =
-            "REV_934=mobile; expires=Tue, 31 Dec 2021 12:00:20 GMT; domain=.edx.org;"
         private val FRESHNESS_INTERVAL = TimeUnit.HOURS.toMillis(1)
     }
 
@@ -34,19 +32,11 @@ class AppCookieManager(private val config: Config, private val api: CookiesApi) 
     }
 
     fun clearWebViewCookie() {
-        CookieManager.getInstance().removeAllCookies { result ->
-            if (result) {
-                authSessionCookieExpiration = -1
-            }
-        }
+        CookieManager.getInstance().removeAllCookies(null)
+        authSessionCookieExpiration = -1
     }
 
     fun isSessionCookieMissingOrExpired(): Boolean {
         return authSessionCookieExpiration < System.currentTimeMillis()
     }
-
-    fun setMobileCookie() {
-        CookieManager.getInstance().setCookie(config.getApiHostURL(), REV_934_COOKIE)
-    }
-
 }

--- a/course/src/main/java/org/openedx/course/presentation/unit/html/HtmlUnitFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/html/HtmlUnitFragment.kt
@@ -9,13 +9,30 @@ import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import android.webkit.*
+import android.webkit.JavascriptInterface
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import android.webkit.WebViewClient
 import androidx.compose.foundation.background
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.*
-import androidx.compose.runtime.*
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -33,10 +50,15 @@ import androidx.fragment.app.Fragment
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.openedx.core.extension.isEmailValid
+import org.openedx.core.extension.loadUrl
 import org.openedx.core.system.AppCookieManager
-import org.openedx.core.ui.*
+import org.openedx.core.ui.ConnectionErrorView
+import org.openedx.core.ui.WindowSize
+import org.openedx.core.ui.rememberWindowSize
+import org.openedx.core.ui.roundBorderWithoutBottom
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
+import org.openedx.core.ui.windowSizeValue
 import org.openedx.core.utils.EmailUtil
 
 class HtmlUnitFragment : Fragment() {
@@ -268,13 +290,15 @@ private fun HTMLContentView(
                 }
                 isVerticalScrollBarEnabled = false
                 isHorizontalScrollBarEnabled = false
-                loadUrl(url)
+
+                loadUrl(url, coroutineScope, cookieManager)
             }
         },
         update = { webView ->
             if (!isLoading && injectJSList.isNotEmpty()) {
                 injectJSList.forEach { webView.evaluateJavascript(it, null) }
             }
-        })
+        }
+    )
 }
 

--- a/discovery/src/main/java/org/openedx/discovery/presentation/program/ProgramViewModel.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/program/ProgramViewModel.kt
@@ -34,6 +34,8 @@ class ProgramViewModel(
 
     val programConfig get() = config.getProgramConfig().webViewConfig
 
+    val cookieManager get() = edxCookieManager
+
     val hasInternetConnection: Boolean get() = networkConnection.isOnline()
 
     private val _uiState = MutableSharedFlow<ProgramUIState>(
@@ -103,9 +105,5 @@ class ProgramViewModel(
 
     fun navigateToSettings(fragmentManager: FragmentManager) {
         router.navigateToSettings(fragmentManager)
-    }
-
-    fun refreshCookie() {
-        viewModelScope.launch { edxCookieManager.tryToRefreshSessionCookie() }
     }
 }


### PR DESCRIPTION
### Description

Ensure cookies' expiry time is verified before loading an authenticated web view and address a race condition within the `clearWebViewCookie` method. This race condition caused the premature reset of `authSessionCookieExpiration` to -1 due to delays in the callback execution.

Closes #306 