### PR TITLE
feat: delete old videos Directory

### DIFF
--- a/app/src/main/java/org/openedx/app/AppActivity.kt
+++ b/app/src/main/java/org/openedx/app/AppActivity.kt
@@ -136,6 +136,10 @@ class AppActivity : AppCompatActivity(), InsetHolder, WindowSizeHolder {
             }
         }
 
+        if (viewModel.canResetAppDirectory){
+            viewModel.resetAppDirectory(this)
+        }
+
         viewModel.logoutUser.observe(this) {
             profileRouter.restartApp(supportFragmentManager, viewModel.isLogistrationEnabled)
         }

--- a/app/src/main/java/org/openedx/app/AppActivity.kt
+++ b/app/src/main/java/org/openedx/app/AppActivity.kt
@@ -136,10 +136,6 @@ class AppActivity : AppCompatActivity(), InsetHolder, WindowSizeHolder {
             }
         }
 
-        if (viewModel.canResetAppDirectory){
-            viewModel.resetAppDirectory(this)
-        }
-
         viewModel.logoutUser.observe(this) {
             profileRouter.restartApp(supportFragmentManager, viewModel.isLogistrationEnabled)
         }

--- a/app/src/main/java/org/openedx/app/AppViewModel.kt
+++ b/app/src/main/java/org/openedx/app/AppViewModel.kt
@@ -1,5 +1,6 @@
 package org.openedx.app
 
+import android.content.Context
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.viewModelScope
@@ -13,6 +14,7 @@ import org.openedx.core.BaseViewModel
 import org.openedx.core.SingleEventLiveData
 import org.openedx.core.config.Config
 import org.openedx.core.data.storage.CorePreferences
+import org.openedx.core.utils.FileUtil
 
 class AppViewModel(
     private val config: Config,
@@ -32,6 +34,7 @@ class AppViewModel(
     private var logoutHandledAt: Long = 0
 
     val isBranchEnabled get() = config.getBranchConfig().enabled
+    val canResetAppDirectory = preferencesManager.canResetAppDirectory
 
     override fun onCreate(owner: LifecycleOwner) {
         super.onCreate(owner)
@@ -58,6 +61,11 @@ class AppViewModel(
                 put(AppAnalyticsKey.NAME.key, AppAnalyticsEvent.LAUNCH.biValue)
             }
         )
+    }
+
+    fun resetAppDirectory(context: Context) {
+        FileUtil.deleteOldAppDirectory(context)
+        preferencesManager.canResetAppDirectory = false
     }
 
     private fun setUserId() {

--- a/app/src/main/java/org/openedx/app/AppViewModel.kt
+++ b/app/src/main/java/org/openedx/app/AppViewModel.kt
@@ -1,6 +1,5 @@
 package org.openedx.app
 
-import android.content.Context
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.viewModelScope
@@ -23,6 +22,7 @@ class AppViewModel(
     private val preferencesManager: CorePreferences,
     private val dispatcher: CoroutineDispatcher,
     private val analytics: AppAnalytics,
+    private val fileUtil: FileUtil,
 ) : BaseViewModel() {
 
     private val _logoutUser = SingleEventLiveData<Unit>()
@@ -39,8 +39,8 @@ class AppViewModel(
     override fun onCreate(owner: LifecycleOwner) {
         super.onCreate(owner)
         setUserId()
-        if(canResetAppDirectory) {
-            resetAppDirectory(owner as Context)
+        if (canResetAppDirectory) {
+            resetAppDirectory()
         }
         viewModelScope.launch {
             notifier.notifier.collect { event ->
@@ -66,8 +66,8 @@ class AppViewModel(
         )
     }
 
-    private fun resetAppDirectory(context: Context) {
-        FileUtil.deleteOldAppDirectory(context)
+    private fun resetAppDirectory() {
+        fileUtil.deleteOldAppDirectory()
         preferencesManager.canResetAppDirectory = false
     }
 

--- a/app/src/main/java/org/openedx/app/AppViewModel.kt
+++ b/app/src/main/java/org/openedx/app/AppViewModel.kt
@@ -34,11 +34,14 @@ class AppViewModel(
     private var logoutHandledAt: Long = 0
 
     val isBranchEnabled get() = config.getBranchConfig().enabled
-    val canResetAppDirectory = preferencesManager.canResetAppDirectory
+    private val canResetAppDirectory get() = preferencesManager.canResetAppDirectory
 
     override fun onCreate(owner: LifecycleOwner) {
         super.onCreate(owner)
         setUserId()
+        if(canResetAppDirectory) {
+            resetAppDirectory(owner as Context)
+        }
         viewModelScope.launch {
             notifier.notifier.collect { event ->
                 if (event is LogoutEvent && System.currentTimeMillis() - logoutHandledAt > 5000) {
@@ -63,7 +66,7 @@ class AppViewModel(
         )
     }
 
-    fun resetAppDirectory(context: Context) {
+    private fun resetAppDirectory(context: Context) {
         FileUtil.deleteOldAppDirectory(context)
         preferencesManager.canResetAppDirectory = false
     }

--- a/app/src/main/java/org/openedx/app/data/storage/PreferencesManager.kt
+++ b/app/src/main/java/org/openedx/app/data/storage/PreferencesManager.kt
@@ -152,6 +152,12 @@ class PreferencesManager(context: Context) : CorePreferences, ProfilePreferences
         }
         get() = getBoolean(APP_WAS_POSITIVE_RATED)
 
+    override var canResetAppDirectory: Boolean
+        set(value) {
+            saveBoolean(RESET_APP_DIRECTORY, value)
+        }
+        get() = getBoolean(RESET_APP_DIRECTORY, true)
+
     override fun setCalendarSyncEventsDialogShown(courseName: String) {
         saveBoolean(courseName.replaceSpace("_"), true)
     }
@@ -172,5 +178,6 @@ class PreferencesManager(context: Context) : CorePreferences, ProfilePreferences
         private const val VIDEO_SETTINGS_STREAMING_QUALITY = "video_settings_streaming_quality"
         private const val VIDEO_SETTINGS_DOWNLOAD_QUALITY = "video_settings_download_quality"
         private const val APP_CONFIG = "app_config"
+        private const val RESET_APP_DIRECTORY = "reset_app_directory"
     }
 }

--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -123,7 +123,7 @@ val screenModule = module {
     viewModel { DashboardListViewModel(get(), get(), get(), get(), get(), get(), get()) }
     viewModel { DashboardGalleryViewModel(get(), get(), get(), get(), get(), get(), get()) }
     viewModel { AllEnrolledCoursesViewModel(get(), get(), get(), get(), get(), get(), get()) }
-    viewModel { LearnViewModel(get(), get(), get()) }
+    viewModel { LearnViewModel(get(), get()) }
 
     factory { DiscoveryRepository(get(), get(), get()) }
     factory { DiscoveryInteractor(get()) }

--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -67,7 +67,7 @@ import org.openedx.whatsnew.presentation.whatsnew.WhatsNewViewModel
 
 val screenModule = module {
 
-    viewModel { AppViewModel(get(), get(), get(), get(), get(named("IODispatcher")), get()) }
+    viewModel { AppViewModel(get(), get(), get(), get(), get(named("IODispatcher")), get(), get()) }
     viewModel { MainViewModel(get(), get(), get()) }
 
     factory { AuthRepository(get(), get(), get()) }

--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -123,7 +123,7 @@ val screenModule = module {
     viewModel { DashboardListViewModel(get(), get(), get(), get(), get(), get(), get()) }
     viewModel { DashboardGalleryViewModel(get(), get(), get(), get(), get(), get(), get()) }
     viewModel { AllEnrolledCoursesViewModel(get(), get(), get(), get(), get(), get(), get()) }
-    viewModel { LearnViewModel(get(), get()) }
+    viewModel { LearnViewModel(get(), get(), get()) }
 
     factory { DiscoveryRepository(get(), get(), get()) }
     factory { DiscoveryInteractor(get()) }

--- a/app/src/test/java/org/openedx/AppViewModelTest.kt
+++ b/app/src/test/java/org/openedx/AppViewModelTest.kt
@@ -60,6 +60,7 @@ class AppViewModelTest {
         every { analytics.setUserIdForSession(any()) } returns Unit
         every { preferencesManager.user } returns user
         every { notifier.notifier } returns flow { }
+        every { preferencesManager.canResetAppDirectory } returns true
         val viewModel =
             AppViewModel(config, notifier, room, preferencesManager, dispatcher, analytics)
 
@@ -82,6 +83,7 @@ class AppViewModelTest {
         every { preferencesManager.user } returns user
         every { room.clearAllTables() } returns Unit
         every { analytics.logoutEvent(true) } returns Unit
+        every { preferencesManager.canResetAppDirectory } returns true
         val viewModel =
             AppViewModel(config, notifier, room, preferencesManager, dispatcher, analytics)
 
@@ -106,6 +108,7 @@ class AppViewModelTest {
         every { preferencesManager.user } returns user
         every { room.clearAllTables() } returns Unit
         every { analytics.logoutEvent(true) } returns Unit
+        every { preferencesManager.canResetAppDirectory } returns true
         val viewModel =
             AppViewModel(config, notifier, room, preferencesManager, dispatcher, analytics)
 

--- a/app/src/test/java/org/openedx/AppViewModelTest.kt
+++ b/app/src/test/java/org/openedx/AppViewModelTest.kt
@@ -28,6 +28,7 @@ import org.openedx.app.system.notifier.AppNotifier
 import org.openedx.app.system.notifier.LogoutEvent
 import org.openedx.core.config.Config
 import org.openedx.core.data.model.User
+import org.openedx.core.utils.FileUtil
 
 @ExperimentalCoroutinesApi
 class AppViewModelTest {
@@ -42,6 +43,7 @@ class AppViewModelTest {
     private val room = mockk<AppDatabase>()
     private val preferencesManager = mockk<PreferencesManager>()
     private val analytics = mockk<AppAnalytics>()
+    private val fileUtil = mockk<FileUtil>()
 
     private val user = User(0, "", "", "")
 
@@ -60,9 +62,17 @@ class AppViewModelTest {
         every { analytics.setUserIdForSession(any()) } returns Unit
         every { preferencesManager.user } returns user
         every { notifier.notifier } returns flow { }
-        every { preferencesManager.canResetAppDirectory } returns true
+        every { preferencesManager.canResetAppDirectory } returns false
         val viewModel =
-            AppViewModel(config, notifier, room, preferencesManager, dispatcher, analytics)
+            AppViewModel(
+                config,
+                notifier,
+                room,
+                preferencesManager,
+                dispatcher,
+                analytics,
+                fileUtil
+            )
 
         val mockLifeCycleOwner: LifecycleOwner = mockk()
         val lifecycleRegistry = LifecycleRegistry(mockLifeCycleOwner)
@@ -83,9 +93,17 @@ class AppViewModelTest {
         every { preferencesManager.user } returns user
         every { room.clearAllTables() } returns Unit
         every { analytics.logoutEvent(true) } returns Unit
-        every { preferencesManager.canResetAppDirectory } returns true
+        every { preferencesManager.canResetAppDirectory } returns false
         val viewModel =
-            AppViewModel(config, notifier, room, preferencesManager, dispatcher, analytics)
+            AppViewModel(
+                config,
+                notifier,
+                room,
+                preferencesManager,
+                dispatcher,
+                analytics,
+                fileUtil
+            )
 
         val mockLifeCycleOwner: LifecycleOwner = mockk()
         val lifecycleRegistry = LifecycleRegistry(mockLifeCycleOwner)
@@ -108,9 +126,17 @@ class AppViewModelTest {
         every { preferencesManager.user } returns user
         every { room.clearAllTables() } returns Unit
         every { analytics.logoutEvent(true) } returns Unit
-        every { preferencesManager.canResetAppDirectory } returns true
+        every { preferencesManager.canResetAppDirectory } returns false
         val viewModel =
-            AppViewModel(config, notifier, room, preferencesManager, dispatcher, analytics)
+            AppViewModel(
+                config,
+                notifier,
+                room,
+                preferencesManager,
+                dispatcher,
+                analytics,
+                fileUtil
+            )
 
         val mockLifeCycleOwner: LifecycleOwner = mockk()
         val lifecycleRegistry = LifecycleRegistry(mockLifeCycleOwner)

--- a/core/src/main/java/org/openedx/core/data/storage/CorePreferences.kt
+++ b/core/src/main/java/org/openedx/core/data/storage/CorePreferences.kt
@@ -11,6 +11,7 @@ interface CorePreferences {
     var user: User?
     var videoSettings: VideoSettings
     var appConfig: AppConfig
+    var canResetAppDirectory: Boolean
 
     fun clear()
 }

--- a/core/src/main/java/org/openedx/core/utils/FileUtil.kt
+++ b/core/src/main/java/org/openedx/core/utils/FileUtil.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import java.io.File
+import java.util.Collections
 
 class FileUtil(val context: Context) {
 
@@ -15,7 +16,10 @@ class FileUtil(val context: Context) {
         return file
     }
 
-    inline fun <reified T> saveObjectToFile(obj: T, fileName: String = "${T::class.java.simpleName}.json") {
+    inline fun <reified T> saveObjectToFile(
+        obj: T,
+        fileName: String = "${T::class.java.simpleName}.json",
+    ) {
         val gson: Gson = GsonBuilder().setPrettyPrinting().create()
         val jsonString = gson.toJson(obj)
         File(getExternalAppDir().path + fileName).writeText(jsonString)
@@ -30,6 +34,45 @@ class FileUtil(val context: Context) {
         } else {
             null
         }
+    }
+
+    /**
+     * Deletes all the files and directories in the app's external storage directory.
+     *
+     * @param context The current context.
+     */
+    fun deleteOldAppDirectory(context: Context) {
+        val externalFilesDir = context.getExternalFilesDir(null)
+        val externalAppDir: File = File(externalFilesDir?.parentFile, "videos")
+        if (externalAppDir.isDirectory) {
+            deleteRecursive(externalAppDir, Collections.emptyList())
+        }
+    }
+
+    /**
+     * Deletes a file or directory and all its content recursively.
+     *
+     * @param fileOrDirectory The file or directory that needs to be deleted.
+     * @param exceptions      Names of the files or directories that need to be skipped while deletion.
+     */
+    private fun deleteRecursive(
+        fileOrDirectory: File,
+        exceptions: List<String>,
+    ) {
+        if (exceptions.contains(fileOrDirectory.name)) return
+
+        if (fileOrDirectory.isDirectory) {
+            val filesList = fileOrDirectory.listFiles()
+            if (filesList != null) {
+                for (child in filesList) {
+                    deleteRecursive(child, exceptions)
+                }
+            }
+        }
+
+        // Don't break the recursion upon encountering an error
+        // noinspection ResultOfMethodCallIgnored
+        fileOrDirectory.delete()
     }
 }
 

--- a/core/src/main/java/org/openedx/core/utils/FileUtil.kt
+++ b/core/src/main/java/org/openedx/core/utils/FileUtil.kt
@@ -43,7 +43,7 @@ class FileUtil(val context: Context) {
      */
     fun deleteOldAppDirectory(context: Context) {
         val externalFilesDir = context.getExternalFilesDir(null)
-        val externalAppDir: File = File(externalFilesDir?.parentFile, Directories.VIDEOS.name)
+        val externalAppDir = File(externalFilesDir?.parentFile, Directories.VIDEOS.name)
         if (externalAppDir.isDirectory) {
             deleteRecursive(externalAppDir, Collections.emptyList())
         }

--- a/core/src/main/java/org/openedx/core/utils/FileUtil.kt
+++ b/core/src/main/java/org/openedx/core/utils/FileUtil.kt
@@ -43,7 +43,7 @@ class FileUtil(val context: Context) {
      */
     fun deleteOldAppDirectory(context: Context) {
         val externalFilesDir = context.getExternalFilesDir(null)
-        val externalAppDir: File = File(externalFilesDir?.parentFile, "videos")
+        val externalAppDir: File = File(externalFilesDir?.parentFile, Directories.VIDEOS.name)
         if (externalAppDir.isDirectory) {
             deleteRecursive(externalAppDir, Collections.emptyList())
         }

--- a/core/src/main/java/org/openedx/core/utils/FileUtil.kt
+++ b/core/src/main/java/org/openedx/core/utils/FileUtil.kt
@@ -38,10 +38,8 @@ class FileUtil(val context: Context) {
 
     /**
      * Deletes all the files and directories in the app's external storage directory.
-     *
-     * @param context The current context.
      */
-    fun deleteOldAppDirectory(context: Context) {
+    fun deleteOldAppDirectory() {
         val externalFilesDir = context.getExternalFilesDir(null)
         val externalAppDir = File(externalFilesDir?.parentFile, Directories.VIDEOS.name)
         if (externalAppDir.isDirectory) {

--- a/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardListFragment.kt
+++ b/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardListFragment.kt
@@ -96,6 +96,7 @@ import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appShapes
 import org.openedx.core.ui.theme.appTypography
 import org.openedx.core.ui.windowSizeValue
+import org.openedx.core.utils.FileUtil
 import org.openedx.core.utils.TimeUtils
 import org.openedx.dashboard.R
 import java.util.Date
@@ -163,6 +164,11 @@ class DashboardListFragment : Fragment() {
                     }
                 )
             }
+        }
+
+        if (viewModel.canResetAppDirectory) {
+            FileUtil.deleteOldAppDirectory(context)
+            viewModel.setResetAppDirectoryPreference()
         }
     }
 }

--- a/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardListFragment.kt
+++ b/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardListFragment.kt
@@ -96,7 +96,6 @@ import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appShapes
 import org.openedx.core.ui.theme.appTypography
 import org.openedx.core.ui.windowSizeValue
-import org.openedx.core.utils.FileUtil
 import org.openedx.core.utils.TimeUtils
 import org.openedx.dashboard.R
 import java.util.Date
@@ -164,11 +163,6 @@ class DashboardListFragment : Fragment() {
                     }
                 )
             }
-        }
-
-        if (viewModel.canResetAppDirectory) {
-            FileUtil.deleteOldAppDirectory(context)
-            viewModel.setResetAppDirectoryPreference()
         }
     }
 }
@@ -387,7 +381,7 @@ private fun CourseItem(
     apiHostUrl: String,
     enrolledCourse: EnrolledCourse,
     windowSize: WindowSize,
-    onClick: (EnrolledCourse) -> Unit
+    onClick: (EnrolledCourse) -> Unit,
 ) {
     val imageWidth by remember(key1 = windowSize) {
         mutableStateOf(

--- a/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardListViewModel.kt
+++ b/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardListViewModel.kt
@@ -10,7 +10,6 @@ import org.openedx.core.R
 import org.openedx.core.SingleEventLiveData
 import org.openedx.core.UIMessage
 import org.openedx.core.config.Config
-import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.EnrolledCourse
 import org.openedx.core.extension.isInternetError
 import org.openedx.core.system.ResourceManager
@@ -29,7 +28,6 @@ class DashboardListViewModel(
     private val discoveryNotifier: DiscoveryNotifier,
     private val analytics: DashboardAnalytics,
     private val appUpgradeNotifier: AppUpgradeNotifier,
-    private val preferences: CorePreferences
 ) : BaseViewModel() {
 
     private val coursesList = mutableListOf<EnrolledCourse>()
@@ -37,7 +35,6 @@ class DashboardListViewModel(
     private var isLoading = false
 
     val apiHostUrl get() = config.getApiHostURL()
-    val canResetAppDirectory = preferences.canResetAppDirectory
 
     private val _uiState = MutableLiveData<DashboardUIState>(DashboardUIState.Loading)
     val uiState: LiveData<DashboardUIState>
@@ -166,10 +163,6 @@ class DashboardListViewModel(
         if (!isLoading && page != -1) {
             internalLoadingCourses()
         }
-    }
-
-    fun setResetAppDirectoryPreference(){
-        preferences.canResetAppDirectory = false
     }
 
     private fun collectAppUpgradeEvent() {

--- a/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardListViewModel.kt
+++ b/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardListViewModel.kt
@@ -10,6 +10,7 @@ import org.openedx.core.R
 import org.openedx.core.SingleEventLiveData
 import org.openedx.core.UIMessage
 import org.openedx.core.config.Config
+import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.EnrolledCourse
 import org.openedx.core.extension.isInternetError
 import org.openedx.core.system.ResourceManager
@@ -27,7 +28,8 @@ class DashboardListViewModel(
     private val resourceManager: ResourceManager,
     private val discoveryNotifier: DiscoveryNotifier,
     private val analytics: DashboardAnalytics,
-    private val appUpgradeNotifier: AppUpgradeNotifier
+    private val appUpgradeNotifier: AppUpgradeNotifier,
+    private val preferences: CorePreferences
 ) : BaseViewModel() {
 
     private val coursesList = mutableListOf<EnrolledCourse>()
@@ -35,6 +37,7 @@ class DashboardListViewModel(
     private var isLoading = false
 
     val apiHostUrl get() = config.getApiHostURL()
+    val canResetAppDirectory = preferences.canResetAppDirectory
 
     private val _uiState = MutableLiveData<DashboardUIState>(DashboardUIState.Loading)
     val uiState: LiveData<DashboardUIState>
@@ -163,6 +166,10 @@ class DashboardListViewModel(
         if (!isLoading && page != -1) {
             internalLoadingCourses()
         }
+    }
+
+    fun setResetAppDirectoryPreference(){
+        preferences.canResetAppDirectory = false
     }
 
     private fun collectAppUpgradeEvent() {


### PR DESCRIPTION
### Description

This PR implements functionality to delete outdated video files stored in the previous app directory upon the first launch of the updated app version. This ensures that storage is efficiently managed, preventing unnecessary space usage by obsolete files, and maintaining consistency with the new data storage structure.

fix: LEARNER-9950