### PR TITLE
 fix: Crash on opening a course from DashboardListFragment 

### DIFF
--- a/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardListFragment.kt
+++ b/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardListFragment.kt
@@ -139,7 +139,7 @@ class DashboardListFragment : Fragment() {
                     onItemClick = {
                         viewModel.dashboardCourseClickedEvent(it.course.id, it.course.name)
                         router.navigateToCourseOutline(
-                            requireParentFragment().parentFragmentManager,
+                            requireActivity().supportFragmentManager,
                             it.course.id,
                             it.course.name,
                             it.mode


### PR DESCRIPTION
### Description:

 - Replace the fragmentManager of parentFragment with activity
 
 [Issue: 325](https://github.com/openedx/openedx-app-android/issues/325)