### PR TITLE
fix: dashboard view all button

### DIFF
--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -14,6 +14,7 @@ import org.openedx.auth.presentation.signup.SignUpViewModel
 import org.openedx.core.Validator
 import org.openedx.core.presentation.dialog.selectorbottomsheet.SelectDialogViewModel
 import org.openedx.core.presentation.settings.video.VideoQualityViewModel
+import org.openedx.core.ui.WindowSize
 import org.openedx.course.data.repository.CourseRepository
 import org.openedx.course.domain.interactor.CourseInteractor
 import org.openedx.course.presentation.container.CourseContainerViewModel
@@ -67,7 +68,18 @@ import org.openedx.whatsnew.presentation.whatsnew.WhatsNewViewModel
 
 val screenModule = module {
 
-    viewModel { AppViewModel(get(), get(), get(), get(), get(named("IODispatcher")), get(), get(), get()) }
+    viewModel {
+        AppViewModel(
+            get(),
+            get(),
+            get(),
+            get(),
+            get(named("IODispatcher")),
+            get(),
+            get(),
+            get()
+        )
+    }
     viewModel { MainViewModel(get(), get(), get()) }
 
     factory { AuthRepository(get(), get(), get()) }
@@ -121,7 +133,18 @@ val screenModule = module {
     factory { DashboardRepository(get(), get(), get(), get()) }
     factory { DashboardInteractor(get()) }
     viewModel { DashboardListViewModel(get(), get(), get(), get(), get(), get(), get()) }
-    viewModel { DashboardGalleryViewModel(get(), get(), get(), get(), get(), get(), get()) }
+    viewModel { (windowSize: WindowSize) ->
+        DashboardGalleryViewModel(
+            get(),
+            get(),
+            get(),
+            get(),
+            get(),
+            get(),
+            get(),
+            windowSize
+        )
+    }
     viewModel { AllEnrolledCoursesViewModel(get(), get(), get(), get(), get(), get(), get()) }
     viewModel { LearnViewModel(get(), get()) }
 

--- a/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryView.kt
+++ b/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryView.kt
@@ -66,6 +66,7 @@ import androidx.fragment.app.FragmentManager
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import org.koin.androidx.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
 import org.openedx.Lock
 import org.openedx.core.UIMessage
 import org.openedx.core.domain.model.AppConfig
@@ -100,7 +101,8 @@ import org.openedx.core.R as CoreR
 fun DashboardGalleryView(
     fragmentManager: FragmentManager,
 ) {
-    val viewModel: DashboardGalleryViewModel = koinViewModel()
+    val windowSize = rememberWindowSize()
+    val viewModel: DashboardGalleryViewModel = koinViewModel { parametersOf(windowSize) }
     val updating by viewModel.updating.collectAsState(false)
     val uiMessage by viewModel.uiMessage.collectAsState(null)
     val uiState by viewModel.uiState.collectAsState(DashboardGalleryUIState.Loading)
@@ -293,6 +295,7 @@ private fun UserCourses(
         if (userCourses.enrollments.courses.isNotEmpty()) {
             SecondaryCourses(
                 courses = userCourses.enrollments.courses,
+                hasNextPage = userCourses.enrollments.pagination.next.isNotEmpty(),
                 apiHostUrl = apiHostUrl,
                 onCourseClick = openCourse,
                 onViewAllClick = onViewAllClick
@@ -304,6 +307,7 @@ private fun UserCourses(
 @Composable
 private fun SecondaryCourses(
     courses: List<EnrolledCourse>,
+    hasNextPage: Boolean,
     apiHostUrl: String,
     onCourseClick: (EnrolledCourse) -> Unit,
     onViewAllClick: () -> Unit
@@ -342,10 +346,12 @@ private fun SecondaryCourses(
                         onCourseClick = onCourseClick
                     )
                 }
-                item {
-                    ViewAllItem(
-                        onViewAllClick = onViewAllClick
-                    )
+                if (hasNextPage) {
+                    item {
+                        ViewAllItem(
+                            onViewAllClick = onViewAllClick
+                        )
+                    }
                 }
             }
         )

--- a/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryViewModel.kt
+++ b/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryViewModel.kt
@@ -21,6 +21,7 @@ import org.openedx.core.system.connection.NetworkConnection
 import org.openedx.core.system.notifier.CourseDashboardUpdate
 import org.openedx.core.system.notifier.DiscoveryNotifier
 import org.openedx.core.system.notifier.NavigationToDiscovery
+import org.openedx.core.ui.WindowSize
 import org.openedx.core.utils.FileUtil
 import org.openedx.dashboard.domain.interactor.DashboardInteractor
 import org.openedx.dashboard.presentation.DashboardRouter
@@ -33,6 +34,7 @@ class DashboardGalleryViewModel(
     private val networkConnection: NetworkConnection,
     private val fileUtil: FileUtil,
     private val dashboardRouter: DashboardRouter,
+    private val windowSize: WindowSize
 ) : BaseViewModel() {
 
     val apiHostUrl get() = config.getApiHostURL()
@@ -62,7 +64,12 @@ class DashboardGalleryViewModel(
         viewModelScope.launch {
             try {
                 if (networkConnection.isOnline()) {
-                    val response = interactor.getMainUserCourses()
+                    val pageSize = if (windowSize.isTablet) {
+                        PAGE_SIZE_TABLET
+                    } else {
+                        PAGE_SIZE_PHONE
+                    }
+                    val response = interactor.getMainUserCourses(pageSize)
                     if (response.primary == null && response.enrollments.courses.isEmpty()) {
                         _uiState.value = DashboardGalleryUIState.Empty
                     } else {
@@ -126,5 +133,10 @@ class DashboardGalleryViewModel(
                 }
             }
         }
+    }
+
+    companion object {
+        private const val PAGE_SIZE_TABLET = 7
+        private const val PAGE_SIZE_PHONE = 5
     }
 }

--- a/dashboard/src/main/java/org/openedx/dashboard/data/repository/DashboardRepository.kt
+++ b/dashboard/src/main/java/org/openedx/dashboard/data/repository/DashboardRepository.kt
@@ -35,9 +35,10 @@ class DashboardRepository(
         return list.map { it.mapToDomain() }
     }
 
-    suspend fun getMainUserCourses(): CourseEnrollments {
+    suspend fun getMainUserCourses(pageSize: Int): CourseEnrollments {
         val result = api.getUserCourses(
             username = preferencesManager.user?.username ?: "",
+            pageSize = pageSize
         )
         preferencesManager.appConfig = result.configs.mapToDomain()
 

--- a/dashboard/src/main/java/org/openedx/dashboard/domain/interactor/DashboardInteractor.kt
+++ b/dashboard/src/main/java/org/openedx/dashboard/domain/interactor/DashboardInteractor.kt
@@ -14,7 +14,7 @@ class DashboardInteractor(
 
     suspend fun getEnrolledCoursesFromCache() = repository.getEnrolledCoursesFromCache()
 
-    suspend fun getMainUserCourses() = repository.getMainUserCourses()
+    suspend fun getMainUserCourses(pageSize: Int) = repository.getMainUserCourses(pageSize)
 
     suspend fun getAllUserCourses(
         page: Int = 1,


### PR DESCRIPTION
The view all button must appear when a user is enrolled in more than 5 courses (mobile) and 7 for tablet.

<img width="736" alt="image" src="https://github.com/openedx/openedx-app-android/assets/127732735/26cf4948-582b-42ac-9301-28ab2cf06d7e">
