### PR TITLE
chore: validate plurals in strings.xml | FC-55

### DIFF
--- a/.github/workflows/validate-english-strings.yml
+++ b/.github/workflows/validate-english-strings.yml
@@ -1,0 +1,32 @@
+name: Validate English strings.xml
+
+on:
+  pull_request: { }
+  push:
+    branches: [ main, develop ]
+
+jobs:
+  translation_strings:
+    name: Validate strings.xml
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install translations requirements
+        run: make translation_requirements
+
+      - name: Validate English plurals in strings.xml
+        run: make validate_english_plurals
+
+      - name: Test extract strings
+        run: |
+          make extract_translations
+          # Ensure the file is extracted
+          test -f i18n/src/main/res/values/strings.xml

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,16 @@ pull_translations: clean_translations_temp_directory
 
 extract_translations: clean_translations_temp_directory
 	python3 i18n_scripts/translation.py --combine
+
+validate_english_plurals:
+	@if git grep 'quantity' -- '**/res/values/strings.xml' | grep -E 'quantity=.(zero|two|few|many)'; then \
+		echo ""; \
+		echo ""; \
+		echo "Error: Found invalid plurals in the files listed above."; \
+		echo "       Please only use 'one' and 'other' in English strings.xml files,"; \
+		echo "       otherwise Transifex fails to parse them."; \
+		echo ""; \
+		exit 1; \
+	else \
+		echo "strings.xml files are valid."; \
+	fi

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -100,19 +100,11 @@
     <string name="core_date_format_assignment_due_tomorrow" tools:ignore="MissingTranslation">Due Tomorrow</string>
     <string name="core_date_format_assignment_due_yesterday" tools:ignore="MissingTranslation">Due Yesterday</string>
     <plurals name="core_date_format_assignment_due_days_ago" tools:ignore="MissingTranslation">
-        <item quantity="zero">Due %1$d days ago</item>
         <item quantity="one">Due %1$d day ago</item>
-        <item quantity="two">Due %1$d days ago</item>
-        <item quantity="few">Due %1$d days ago</item>
-        <item quantity="many">Due %1$d days ago</item>
         <item quantity="other">Due %1$d days ago</item>
     </plurals>
     <plurals name="core_date_format_assignment_due_in" tools:ignore="MissingTranslation">
-        <item quantity="zero">Due in %1$d days</item>
         <item quantity="one">Due in %1$d day</item>
-        <item quantity="two">Due in %1$d days</item>
-        <item quantity="few">Due in %1$d days</item>
-        <item quantity="many">Due in %1$d days</item>
         <item quantity="other">Due in %1$d days</item>
     </plurals>
     <plurals name="core_date_items_hidden" tools:ignore="MissingTranslation">

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -65,11 +65,7 @@
     <string name="course_subsection_assignment_info" translatable="false">%1$s - %2$s - %3$d / %4$d</string>
 
     <plurals name="course_assignments_complete" tools:ignore="MissingTranslation">
-        <item quantity="zero">%1$s of %2$s  assignments complete</item>
         <item quantity="one">%1$s of %2$s  assignment complete</item>
-        <item quantity="two">%1$s of %2$s  assignments complete</item>
-        <item quantity="few">%1$s of %2$s  assignments complete</item>
-        <item quantity="many">%1$s of %2$s  assignments complete</item>
         <item quantity="other">%1$s of %2$s  assignments complete</item>
     </plurals>
 

--- a/dashboard/src/main/res/values/strings.xml
+++ b/dashboard/src/main/res/values/strings.xml
@@ -21,11 +21,7 @@
     <string name="dashboard_no_status_courses">No %1$s Courses</string>
 
     <plurals name="dashboard_past_due_assignment">
-        <item quantity="zero">%1$d Past Due Assignments</item>
         <item quantity="one">%1$d Past Due Assignment</item>
-        <item quantity="two">%1$d Past Due Assignments</item>
-        <item quantity="few">%1$d Past Due Assignments</item>
-        <item quantity="many">%1$d Past Due Assignments</item>
         <item quantity="other">%1$d Past Due Assignments</item>
     </plurals>
 </resources>


### PR DESCRIPTION
Plurals are failing the transifex import. I've fixed them manually in #341, but more are coming. Therefore a GitHub Actions is needed.

### Testing

Example failure:

 - https://github.com/openedx/openedx-app-android/actions/runs/9610916922/job/26508405063#step:5:33


```
core/src/main/res/values/strings.xml:        <item quantity="zero">Due %1$d days ago</item>
core/src/main/res/values/strings.xml:        <item quantity="two">Due %1$d days ago</item>
make: *** [Makefile:15: validate_english_plurals] Error 1
core/src/main/res/values/strings.xml:        <item quantity="few">Due %1$d days ago</item>
core/src/main/res/values/strings.xml:        <item quantity="many">Due %1$d days ago</item>
core/src/main/res/values/strings.xml:        <item quantity="zero">Due in %1$d days</item>
core/src/main/res/values/strings.xml:        <item quantity="two">Due in %1$d days</item>
core/src/main/res/values/strings.xml:        <item quantity="few">Due in %1$d days</item>
core/src/main/res/values/strings.xml:        <item quantity="many">Due in %1$d days</item>
course/src/main/res/values/strings.xml:        <item quantity="zero">%1$s of %2$s  assignments complete</item>
course/src/main/res/values/strings.xml:        <item quantity="two">%1$s of %2$s  assignments complete</item>
course/src/main/res/values/strings.xml:        <item quantity="few">%1$s of %2$s  assignments complete</item>
course/src/main/res/values/strings.xml:        <item quantity="many">%1$s of %2$s  assignments complete</item>
dashboard/src/main/res/values/strings.xml:        <item quantity="zero">%1$d Past Due Assignments</item>
dashboard/src/main/res/values/strings.xml:        <item quantity="two">%1$d Past Due Assignments</item>
dashboard/src/main/res/values/strings.xml:        <item quantity="few">%1$d Past Due Assignments</item>
dashboard/src/main/res/values/strings.xml:        <item quantity="many">%1$d Past Due Assignments</item>


Error: Found invalid plurals in the files listed above.
       Please only use 'one' and 'other' in English strings.xml files,
       otherwise Transifex fails to parse them.

```

The second commit fixes those failures and the CI passes correctly.