### PR TITLE
fix: Video Subtitles on Native and Youtube Player

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
+++ b/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
@@ -69,6 +69,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
@@ -563,6 +564,11 @@ fun VideoSubtitles(
                             } else {
                                 MaterialTheme.appColors.textFieldBorder
                             }
+                        val fontWeight = if (currentIndex == index) {
+                            FontWeight.SemiBold
+                        } else {
+                            FontWeight.Normal
+                        }
                         Text(
                             modifier = Modifier
                                 .fillMaxWidth()
@@ -571,7 +577,8 @@ fun VideoSubtitles(
                                 },
                             text = Jsoup.parse(item.content).text(),
                             color = textColor,
-                            style = MaterialTheme.appTypography.bodyMedium
+                            style = MaterialTheme.appTypography.bodyMedium,
+                            fontWeight = fontWeight,
                         )
                         Spacer(Modifier.height(16.dp))
                     }

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitFragment.kt
@@ -91,7 +91,6 @@ class VideoUnitFragment : Fragment(R.layout.fragment_video_unit) {
             viewModel.isDownloaded = getBoolean(ARG_DOWNLOADED)
         }
         viewModel.downloadSubtitles()
-        handler.removeCallbacks(videoTimeRunnable)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitViewModel.kt
@@ -100,8 +100,8 @@ open class VideoUnitViewModel(
 
 
     open fun markBlockCompleted(blockId: String, medium: String) {
-        logLoadedCompletedEvent(videoUrl, false, getCurrentVideoTime(), medium)
         if (!isBlockAlreadyCompleted) {
+            logLoadedCompletedEvent(videoUrl, false, getCurrentVideoTime(), medium)
             viewModelScope.launch {
                 try {
                     isBlockAlreadyCompleted = true

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoViewModel.kt
@@ -40,8 +40,8 @@ class VideoViewModel(
     }
 
     fun markBlockCompleted(blockId: String, medium: String) {
-        logLoadedCompletedEvent(videoUrl, false, currentVideoTime, medium)
         if (!isBlockAlreadyCompleted) {
+            logLoadedCompletedEvent(videoUrl, false, currentVideoTime, medium)
             viewModelScope.launch {
                 try {
                     isBlockAlreadyCompleted = true


### PR DESCRIPTION
The video subtitles weren't working because the handler was deleted.

<img src="https://github.com/openedx/openedx-app-android/assets/71447999/f9cca4e5-f874-4bf2-b931-9e8c4cb27d31" height=500 />
