### PR TITLE
fix: show only one screen with all downloadable content

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineViewModel.kt
@@ -388,14 +388,17 @@ class CourseOutlineViewModel(
         }
     }
 
-    fun downloadBlocks(blocksIds: List<String>, fragmentManager: FragmentManager, context: Context) {
+    fun downloadBlocks(
+        blocksIds: List<String>,
+        fragmentManager: FragmentManager,
+        context: Context
+    ) {
+        if (blocksIds.find { isBlockDownloading(it) } != null) {
+            courseRouter.navigateToDownloadQueue(fm = fragmentManager)
+            return
+        }
         blocksIds.forEach { blockId ->
-            if (isBlockDownloading(blockId)) {
-                courseRouter.navigateToDownloadQueue(
-                    fm = fragmentManager,
-                    getDownloadableChildren(blockId) ?: arrayListOf()
-                )
-            } else if (isBlockDownloaded(blockId)) {
+            if (isBlockDownloaded(blockId)) {
                 removeDownloadModels(blockId)
             } else {
                 saveDownloadModels(

--- a/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
+++ b/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
@@ -244,8 +244,7 @@ fun OfflineQueueCard(
                 maxLines = 1
             )
 
-            val progress = progressValue.toFloat() / progressSize
-
+            val progress = if (progressSize == 0L) 0f else progressValue.toFloat() / progressSize
             LinearProgressIndicator(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/course/src/main/java/org/openedx/course/presentation/videos/CourseVideoViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/videos/CourseVideoViewModel.kt
@@ -214,14 +214,17 @@ class CourseVideoViewModel(
         return resultBlocks.toList()
     }
 
-    fun downloadBlocks(blocksIds: List<String>, fragmentManager: FragmentManager, context: Context) {
+    fun downloadBlocks(
+        blocksIds: List<String>,
+        fragmentManager: FragmentManager,
+        context: Context
+    ) {
+        if (blocksIds.find { isBlockDownloading(it) } != null) {
+            courseRouter.navigateToDownloadQueue(fm = fragmentManager)
+            return
+        }
         blocksIds.forEach { blockId ->
-            if (isBlockDownloading(blockId)) {
-                courseRouter.navigateToDownloadQueue(
-                    fm = fragmentManager,
-                    getDownloadableChildren(blockId) ?: arrayListOf()
-                )
-            } else if (isBlockDownloaded(blockId)) {
+            if (isBlockDownloaded(blockId)) {
                 removeDownloadModels(blockId)
             } else {
                 saveDownloadModels(


### PR DESCRIPTION
Consolidated the progress screens into a single screen that lists all ongoing downloads, mirroring the interface used for bulk downloads.