### PR TITLE
fix: added default value to the AppConfig to prevent crashes in some cases

### DIFF
--- a/app/src/main/java/org/openedx/app/data/storage/PreferencesManager.kt
+++ b/app/src/main/java/org/openedx/app/data/storage/PreferencesManager.kt
@@ -145,9 +145,11 @@ class PreferencesManager(context: Context) : CorePreferences, ProfilePreferences
             saveString(APP_CONFIG, appConfigJson)
         }
         get() {
-            val appConfigString = getString(APP_CONFIG)
+            val appConfigString = getString(APP_CONFIG, getDefaultAppConfig())
             return Gson().fromJson(appConfigString, AppConfig::class.java)
         }
+
+    private fun getDefaultAppConfig() = Gson().toJson(AppConfig())
 
     override var lastWhatsNewVersion: String
         set(value) {

--- a/core/src/main/java/org/openedx/core/domain/model/AppConfig.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/AppConfig.kt
@@ -3,12 +3,12 @@ package org.openedx.core.domain.model
 import java.io.Serializable
 
 data class AppConfig(
-    val courseDatesCalendarSync: CourseDatesCalendarSync,
+    val courseDatesCalendarSync: CourseDatesCalendarSync = CourseDatesCalendarSync(),
 ) : Serializable
 
 data class CourseDatesCalendarSync(
-    val isEnabled: Boolean,
-    val isSelfPacedEnabled: Boolean,
-    val isInstructorPacedEnabled: Boolean,
-    val isDeepLinkEnabled: Boolean,
+    val isEnabled: Boolean = false,
+    val isSelfPacedEnabled: Boolean = false,
+    val isInstructorPacedEnabled: Boolean = false,
+    val isDeepLinkEnabled: Boolean = false,
 ) : Serializable


### PR DESCRIPTION
**Fix based on the crash report:**

```
PreferencesManager.getAppConfig
Caused by java.lang.NullPointerException: fromJson(...) must not be null
       at org.openedx.app.data.storage.PreferencesManager.getAppConfig(PreferencesManager.kt:20)
       at org.openedx.profile.presentation.settings.SettingsViewModel.getConfiguration(SourceFile:7)
       at org.openedx.profile.presentation.settings.SettingsViewModel.<init>(SourceFile:32)
       at org.openedx.app.di.ScreenModuleKt$screenModule$1$28.invoke(ScreenModule.kt:193)
       at org.openedx.app.di.ScreenModuleKt$screenModule$1$28.invoke(ScreenModule.kt:193)
       at org.koin.core.instance.InstanceFactory.create(InstanceFactory.kt:53)
```

**Steps to reproduce:**

- Fresh install app
- Login into app
- See What's new
- Turn off internet connection
- Go to profile and open settings
- App crashing