### PR TITLE
fix: Support pull to refresh for empty dashboard

### DIFF
--- a/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardListFragment.kt
+++ b/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardListFragment.kt
@@ -24,7 +24,9 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.ExperimentalMaterialApi
@@ -35,6 +37,7 @@ import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
@@ -305,7 +308,7 @@ internal fun DashboardListView(
                         is DashboardUIState.Empty -> {
                             Box(
                                 modifier = Modifier.fillMaxSize(),
-                                contentAlignment = Alignment.Center
+                                contentAlignment = Alignment.Center,
                             ) {
                                 Column(
                                     Modifier
@@ -475,13 +478,18 @@ private fun CourseItem(
 
 @Composable
 private fun EmptyState() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Column(
-            Modifier.width(185.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+            Modifier
+                .fillMaxSize()
+                .weight(1f),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
         ) {
             Icon(
                 painter = painterResource(id = R.drawable.dashboard_ic_empty),
@@ -499,6 +507,13 @@ private fun EmptyState() {
                 textAlign = TextAlign.Center
             )
         }
+        Text(
+            modifier = Modifier.fillMaxWidth(),
+            text = stringResource(id = R.string.dashboard_pull_to_refresh),
+            color = MaterialTheme.appColors.textSecondary,
+            style = MaterialTheme.appTypography.labelSmall,
+            textAlign = TextAlign.Center
+        )
     }
 }
 
@@ -564,6 +579,29 @@ private fun DashboardListViewTabletPreview() {
                     mockCourseEnrolled
                 )
             ),
+            uiMessage = null,
+            onSwipeRefresh = {},
+            onItemClick = {},
+            onReloadClick = {},
+            hasInternetConnection = true,
+            refreshing = false,
+            canLoadMore = false,
+            paginationCallback = {},
+            appUpgradeParameters = AppUpdateState.AppUpgradeParameters()
+        )
+    }
+}
+
+
+@Preview(uiMode = UI_MODE_NIGHT_NO)
+@Preview(uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun EmptyStatePreview() {
+    OpenEdXTheme {
+        DashboardListView(
+            windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
+            apiHostUrl = "http://localhost:8000",
+            state = DashboardUIState.Empty,
             uiMessage = null,
             onSwipeRefresh = {},
             onItemClick = {},

--- a/dashboard/src/main/res/values/strings.xml
+++ b/dashboard/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="dashboard_all_courses_empty_description">You are not currently enrolled in any courses, would you like to explore the course catalog?</string>
     <string name="dashboard_find_a_course">Find a Course</string>
     <string name="dashboard_no_status_courses">No %1$s Courses</string>
+    <string name="dashboard_pull_to_refresh">Swipe down to refresh</string>
 
     <plurals name="dashboard_past_due_assignment">
         <item quantity="one">%1$d Past Due Assignment</item>


### PR DESCRIPTION
In the main branch of the app it isn't possible to refresh the course list when there are no courses listed, since pull to refresh can only be triggered when a container is scrollable. This makes the empty container scrollable to allow it to trigger a pull to refresh action. 

This change was originally made for the main branch; however, it seems that the develop version has changed significantly enough that this may no longer be needed. The files for the old UI are still there, though, so perhaps there are situations where it's still used, and this PR would be useful? If not, feel free to close the PR. 

