### PR TITLE
feat: add flag to remove registration from app

### DIFF
--- a/Documentation/ConfigurationManagement.md
+++ b/Documentation/ConfigurationManagement.md
@@ -89,7 +89,8 @@ android:
 - **WHATS_NEW_ENABLED:** Enables the "What's New" feature to present the latest changes to the user.
 - **SOCIAL_AUTH_ENABLED:** Enables SSO buttons on the SignIn and SignUp screens.
 - **COURSE_DROPDOWN_NAVIGATION_ENABLED:** Enables an alternative navigation through units.
-- **COURSE_UNIT_PROGRESS_ENABLED:** Enables the display of the unit progress within the courseware. 
+- **COURSE_UNIT_PROGRESS_ENABLED:** Enables the display of the unit progress within the courseware.
+- **REGISTRATION_ENABLED:** Enables user registration from the app.
 
 ## Future Support
 - To add config related to some other service, create a class, e.g. `ServiceNameConfig.kt`, to be able to populate related fields.

--- a/auth/src/main/java/org/openedx/auth/presentation/logistration/LogistrationFragment.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/logistration/LogistrationFragment.kt
@@ -74,7 +74,8 @@ class LogistrationFragment : Fragment() {
                     },
                     onSearchClick = { querySearch ->
                         viewModel.navigateToDiscovery(parentFragmentManager, querySearch)
-                    }
+                    },
+                    isRegistrationEnabled = viewModel.isRegistrationEnabled
                 )
             }
         }
@@ -98,6 +99,7 @@ private fun LogistrationScreen(
     onSearchClick: (String) -> Unit,
     onRegisterClick: () -> Unit,
     onSignInClick: () -> Unit,
+    isRegistrationEnabled: Boolean,
 ) {
 
     var textFieldValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {
@@ -183,7 +185,11 @@ private fun LogistrationScreen(
 
                 Spacer(modifier = Modifier.weight(1f))
 
-                AuthButtonsPanel(onRegisterClick = onRegisterClick, onSignInClick = onSignInClick)
+                AuthButtonsPanel(
+                    onRegisterClick = onRegisterClick,
+                    onSignInClick = onSignInClick,
+                    showRegisterButton = isRegistrationEnabled
+                )
             }
         }
     }
@@ -199,7 +205,24 @@ private fun LogistrationPreview() {
         LogistrationScreen(
             onSearchClick = {},
             onSignInClick = {},
-            onRegisterClick = {}
+            onRegisterClick = {},
+            isRegistrationEnabled = true,
+        )
+    }
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "NEXUS_9_Light", device = Devices.NEXUS_9, uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(name = "NEXUS_9_Night", device = Devices.NEXUS_9, uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun LogistrationRegistrationDisabledPreview() {
+    OpenEdXTheme {
+        LogistrationScreen(
+            onSearchClick = {},
+            onSignInClick = {},
+            onRegisterClick = {},
+            isRegistrationEnabled = false,
         )
     }
 }

--- a/auth/src/main/java/org/openedx/auth/presentation/logistration/LogistrationViewModel.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/logistration/LogistrationViewModel.kt
@@ -17,6 +17,7 @@ class LogistrationViewModel(
 ) : BaseViewModel() {
 
     private val discoveryTypeWebView get() = config.getDiscoveryConfig().isViewTypeWebView()
+    val isRegistrationEnabled get() = config.isRegistrationEnabled()
 
     init {
         logLogistrationScreenEvent()

--- a/auth/src/main/java/org/openedx/auth/presentation/signin/SignInUIState.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signin/SignInUIState.kt
@@ -18,6 +18,7 @@ internal data class SignInUIState(
     val isMicrosoftAuthEnabled: Boolean = false,
     val isSocialAuthEnabled: Boolean = false,
     val isLogistrationEnabled: Boolean = false,
+    val isRegistrationEnabled: Boolean = true,
     val showProgress: Boolean = false,
     val loginSuccess: Boolean = false,
     val agreement: RegistrationField? = null,

--- a/auth/src/main/java/org/openedx/auth/presentation/signin/SignInViewModel.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signin/SignInViewModel.kt
@@ -67,6 +67,7 @@ class SignInViewModel(
             isMicrosoftAuthEnabled = config.getMicrosoftConfig().isEnabled(),
             isSocialAuthEnabled = config.isSocialAuthEnabled(),
             isLogistrationEnabled = config.isPreLoginExperienceEnabled(),
+            isRegistrationEnabled = config.isRegistrationEnabled(),
             agreement = agreementProvider.getAgreement(isSignIn = true)?.createHonorCodeField(),
         )
     )

--- a/auth/src/main/java/org/openedx/auth/presentation/signin/compose/SignInView.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signin/compose/SignInView.kt
@@ -264,7 +264,7 @@ private fun AuthForm(
                 .fillMaxWidth()
                 .padding(top = 20.dp, bottom = 36.dp)
         ) {
-            if (state.isLogistrationEnabled.not()) {
+            if (state.isLogistrationEnabled.not() && state.isRegistrationEnabled) {
                 Text(
                     modifier = Modifier
                         .testTag("txt_register")

--- a/auth/src/test/java/org/openedx/auth/presentation/signin/SignInViewModelTest.kt
+++ b/auth/src/test/java/org/openedx/auth/presentation/signin/SignInViewModelTest.kt
@@ -95,6 +95,7 @@ class SignInViewModelTest {
         every { calendarPreferences.clearCalendarPreferences() } returns Unit
         coEvery { calendarInteractor.clearCalendarCachedData() } returns Unit
         every { analytics.logScreenEvent(any(), any()) } returns Unit
+        every { config.isRegistrationEnabled() } returns true
     }
 
     @After

--- a/core/src/main/java/org/openedx/core/config/Config.kt
+++ b/core/src/main/java/org/openedx/core/config/Config.kt
@@ -115,6 +115,10 @@ class Config(context: Context) {
         return getObjectOrNewInstance(UI_COMPONENTS, UIConfig::class.java)
     }
 
+    fun isRegistrationEnabled(): Boolean {
+        return getBoolean(REGISTRATION_ENABLED, true)
+    }
+
     private fun getString(key: String, defaultValue: String = ""): String {
         val element = getObject(key)
         return if (element != null) {
@@ -168,6 +172,7 @@ class Config(context: Context) {
         private const val GOOGLE = "GOOGLE"
         private const val MICROSOFT = "MICROSOFT"
         private const val PRE_LOGIN_EXPERIENCE_ENABLED = "PRE_LOGIN_EXPERIENCE_ENABLED"
+        private const val REGISTRATION_ENABLED = "REGISTRATION_ENABLED"
         private const val DISCOVERY = "DISCOVERY"
         private const val PROGRAM = "PROGRAM"
         private const val DASHBOARD = "DASHBOARD"

--- a/core/src/main/java/org/openedx/core/ui/ComposeCommon.kt
+++ b/core/src/main/java/org/openedx/core/ui/ComposeCommon.kt
@@ -1183,24 +1183,32 @@ fun ConnectionErrorView(
 fun AuthButtonsPanel(
     onRegisterClick: () -> Unit,
     onSignInClick: () -> Unit,
+    showRegisterButton: Boolean,
 ) {
     Row {
-        OpenEdXButton(
-            modifier = Modifier
-                .testTag("btn_register")
-                .width(0.dp)
-                .weight(1f),
-            text = stringResource(id = R.string.core_register),
-            textColor = MaterialTheme.appColors.primaryButtonText,
-            backgroundColor = MaterialTheme.appColors.secondaryButtonBackground,
-            onClick = { onRegisterClick() }
-        )
+        if (showRegisterButton) {
+            OpenEdXButton(
+                modifier = Modifier
+                    .testTag("btn_register")
+                    .width(0.dp)
+                    .weight(1f),
+                text = stringResource(id = R.string.core_register),
+                textColor = MaterialTheme.appColors.primaryButtonText,
+                backgroundColor = MaterialTheme.appColors.secondaryButtonBackground,
+                onClick = { onRegisterClick() }
+            )
+        }
 
         OpenEdXOutlinedButton(
             modifier = Modifier
                 .testTag("btn_sign_in")
-                .width(100.dp)
-                .padding(start = 16.dp),
+                .then(
+                    if (showRegisterButton) {
+                        Modifier.width(100.dp).padding(start = 16.dp)
+                    } else {
+                        Modifier.weight(1f)
+                    }
+                ),
             text = stringResource(id = R.string.core_sign_in),
             onClick = { onSignInClick() },
             textColor = MaterialTheme.appColors.secondaryButtonBorderedText,
@@ -1333,7 +1341,7 @@ private fun ToolbarPreview() {
 @Preview
 @Composable
 private fun AuthButtonsPanelPreview() {
-    AuthButtonsPanel(onRegisterClick = {}, onSignInClick = {})
+    AuthButtonsPanel(onRegisterClick = {}, onSignInClick = {}, showRegisterButton = true)
 }
 
 @Preview

--- a/default_config/dev/config.yaml
+++ b/default_config/dev/config.yaml
@@ -84,6 +84,8 @@ TOKEN_TYPE: "JWT"
 WHATS_NEW_ENABLED: false
 #feature flag enable Social Login buttons
 SOCIAL_AUTH_ENABLED: false
+#feature flag to enable registration from app
+REGISTRATION_ENABLED: true
 #Course navigation feature flags
 UI_COMPONENTS:
   COURSE_DROPDOWN_NAVIGATION_ENABLED: false

--- a/default_config/prod/config.yaml
+++ b/default_config/prod/config.yaml
@@ -84,6 +84,8 @@ TOKEN_TYPE: "JWT"
 WHATS_NEW_ENABLED: false
 #feature flag enable Social Login buttons
 SOCIAL_AUTH_ENABLED: false
+#feature flag to enable registration from app
+REGISTRATION_ENABLED: true
 #Course navigation feature flags
 UI_COMPONENTS:
   COURSE_DROPDOWN_NAVIGATION_ENABLED: false

--- a/default_config/stage/config.yaml
+++ b/default_config/stage/config.yaml
@@ -84,6 +84,8 @@ TOKEN_TYPE: "JWT"
 WHATS_NEW_ENABLED: false
 #feature flag enable Social Login buttons
 SOCIAL_AUTH_ENABLED: false
+#feature flag to enable registration from app
+REGISTRATION_ENABLED: true
 #Course navigation feature flags
 UI_COMPONENTS:
   COURSE_DROPDOWN_NAVIGATION_ENABLED: false

--- a/discovery/src/main/java/org/openedx/discovery/presentation/NativeDiscoveryFragment.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/NativeDiscoveryFragment.kt
@@ -117,6 +117,7 @@ class NativeDiscoveryFragment : Fragment() {
                     hasInternetConnection = viewModel.hasInternetConnection,
                     canShowBackButton = viewModel.canShowBackButton,
                     isUserLoggedIn = viewModel.isUserLoggedIn,
+                    isRegistrationEnabled = viewModel.isRegistrationEnabled,
                     appUpgradeParameters = AppUpdateState.AppUpgradeParameters(
                         appUpgradeEvent = appUpgradeEvent,
                         wasUpdateDialogClosed = wasUpdateDialogClosed,
@@ -209,6 +210,7 @@ internal fun DiscoveryScreen(
     hasInternetConnection: Boolean,
     canShowBackButton: Boolean,
     isUserLoggedIn: Boolean,
+    isRegistrationEnabled: Boolean,
     appUpgradeParameters: AppUpdateState.AppUpgradeParameters,
     onSearchClick: () -> Unit,
     onSwipeRefresh: () -> Unit,
@@ -252,7 +254,8 @@ internal fun DiscoveryScreen(
                 ) {
                     AuthButtonsPanel(
                         onRegisterClick = onRegisterClick,
-                        onSignInClick = onSignInClick
+                        onSignInClick = onSignInClick,
+                        showRegisterButton = isRegistrationEnabled
                     )
                 }
             }
@@ -517,6 +520,7 @@ private fun DiscoveryScreenPreview() {
             refreshing = false,
             hasInternetConnection = true,
             isUserLoggedIn = false,
+            isRegistrationEnabled = true,
             appUpgradeParameters = AppUpdateState.AppUpgradeParameters(),
             onSignInClick = {},
             onRegisterClick = {},
@@ -558,6 +562,7 @@ private fun DiscoveryScreenTabletPreview() {
             refreshing = false,
             hasInternetConnection = true,
             isUserLoggedIn = true,
+            isRegistrationEnabled = true,
             appUpgradeParameters = AppUpdateState.AppUpgradeParameters(),
             onSignInClick = {},
             onRegisterClick = {},

--- a/discovery/src/main/java/org/openedx/discovery/presentation/NativeDiscoveryViewModel.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/NativeDiscoveryViewModel.kt
@@ -33,6 +33,7 @@ class NativeDiscoveryViewModel(
     val apiHostUrl get() = config.getApiHostURL()
     val isUserLoggedIn get() = corePreferences.user != null
     val canShowBackButton get() = config.isPreLoginExperienceEnabled() && !isUserLoggedIn
+    val isRegistrationEnabled: Boolean get() = config.isRegistrationEnabled()
 
     private val _uiState = MutableLiveData<DiscoveryUIState>(DiscoveryUIState.Loading)
     val uiState: LiveData<DiscoveryUIState>

--- a/discovery/src/main/java/org/openedx/discovery/presentation/WebViewDiscoveryFragment.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/WebViewDiscoveryFragment.kt
@@ -91,6 +91,7 @@ class WebViewDiscoveryFragment : Fragment() {
                     isPreLogin = viewModel.isPreLogin,
                     contentUrl = viewModel.discoveryUrl,
                     uriScheme = viewModel.uriScheme,
+                    isRegistrationEnabled = viewModel.isRegistrationEnabled,
                     hasInternetConnection = hasInternetConnection,
                     checkInternetConnection = {
                         hasInternetConnection = viewModel.hasInternetConnection
@@ -173,6 +174,7 @@ private fun WebViewDiscoveryScreen(
     isPreLogin: Boolean,
     contentUrl: String,
     uriScheme: String,
+    isRegistrationEnabled: Boolean,
     hasInternetConnection: Boolean,
     checkInternetConnection: () -> Unit,
     onWebPageUpdated: (String) -> Unit,
@@ -206,7 +208,8 @@ private fun WebViewDiscoveryScreen(
                 ) {
                     AuthButtonsPanel(
                         onRegisterClick = onRegisterClick,
-                        onSignInClick = onSignInClick
+                        onSignInClick = onSignInClick,
+                        showRegisterButton = isRegistrationEnabled
                     )
                 }
             }
@@ -363,6 +366,7 @@ private fun WebViewDiscoveryScreenPreview() {
             contentUrl = "https://www.example.com/",
             isPreLogin = false,
             uriScheme = "",
+            isRegistrationEnabled = true,
             hasInternetConnection = false,
             checkInternetConnection = {},
             onWebPageUpdated = {},

--- a/discovery/src/main/java/org/openedx/discovery/presentation/WebViewDiscoveryViewModel.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/WebViewDiscoveryViewModel.kt
@@ -21,6 +21,7 @@ class WebViewDiscoveryViewModel(
     private val webViewConfig get() = config.getDiscoveryConfig().webViewConfig
 
     val isPreLogin get() = config.isPreLoginExperienceEnabled() && corePreferences.user == null
+    val isRegistrationEnabled: Boolean get() = config.isRegistrationEnabled()
 
     private var _discoveryUrl = webViewConfig.baseUrl
     val discoveryUrl: String

--- a/discovery/src/main/java/org/openedx/discovery/presentation/detail/CourseDetailsFragment.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/detail/CourseDetailsFragment.kt
@@ -142,6 +142,7 @@ class CourseDetailsFragment : Fragment() {
                     ),
                     hasInternetConnection = viewModel.hasInternetConnection,
                     isUserLoggedIn = viewModel.isUserLoggedIn,
+                    isRegistrationEnabled = viewModel.isRegistrationEnabled,
                     onReloadClick = {
                         viewModel.getCourseDetail()
                     },
@@ -211,6 +212,7 @@ internal fun CourseDetailsScreen(
     htmlBody: String,
     hasInternetConnection: Boolean,
     isUserLoggedIn: Boolean,
+    isRegistrationEnabled: Boolean,
     onReloadClick: () -> Unit,
     onBackClick: () -> Unit,
     onButtonClick: () -> Unit,
@@ -238,7 +240,8 @@ internal fun CourseDetailsScreen(
                 Box(modifier = Modifier.padding(horizontal = 16.dp, vertical = 32.dp)) {
                     AuthButtonsPanel(
                         onRegisterClick = onRegisterClick,
-                        onSignInClick = onSignInClick
+                        onSignInClick = onSignInClick,
+                        showRegisterButton = isRegistrationEnabled
                     )
                 }
             }
@@ -694,6 +697,7 @@ private fun CourseDetailNativeContentPreview() {
             apiHostUrl = "http://localhost:8000",
             hasInternetConnection = false,
             isUserLoggedIn = true,
+            isRegistrationEnabled = true,
             htmlBody = "<b>Preview text</b>",
             onReloadClick = {},
             onBackClick = {},
@@ -716,6 +720,7 @@ private fun CourseDetailNativeContentTabletPreview() {
             apiHostUrl = "http://localhost:8000",
             hasInternetConnection = false,
             isUserLoggedIn = true,
+            isRegistrationEnabled = true,
             htmlBody = "<b>Preview text</b>",
             onReloadClick = {},
             onBackClick = {},

--- a/discovery/src/main/java/org/openedx/discovery/presentation/detail/CourseDetailsViewModel.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/detail/CourseDetailsViewModel.kt
@@ -35,6 +35,7 @@ class CourseDetailsViewModel(
 ) : BaseViewModel() {
     val apiHostUrl get() = config.getApiHostURL()
     val isUserLoggedIn get() = corePreferences.user != null
+    val isRegistrationEnabled: Boolean get() = config.isRegistrationEnabled()
 
     private val _uiState = MutableLiveData<CourseDetailsUIState>(CourseDetailsUIState.Loading)
     val uiState: LiveData<CourseDetailsUIState>

--- a/discovery/src/main/java/org/openedx/discovery/presentation/info/CourseInfoFragment.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/info/CourseInfoFragment.kt
@@ -122,6 +122,7 @@ class CourseInfoFragment : Fragment() {
                     uiMessage = uiMessage,
                     uriScheme = viewModel.uriScheme,
                     hasInternetConnection = hasInternetConnection,
+                    isRegistrationEnabled = viewModel.isRegistrationEnabled,
                     checkInternetConnection = {
                         hasInternetConnection = viewModel.hasInternetConnection
                     },
@@ -222,6 +223,7 @@ private fun CourseInfoScreen(
     uiState: CourseInfoUIState,
     uiMessage: UIMessage?,
     uriScheme: String,
+    isRegistrationEnabled: Boolean,
     hasInternetConnection: Boolean,
     checkInternetConnection: () -> Unit,
     onRegisterClick: () -> Unit,
@@ -250,7 +252,8 @@ private fun CourseInfoScreen(
                 ) {
                     AuthButtonsPanel(
                         onRegisterClick = onRegisterClick,
-                        onSignInClick = onSignInClick
+                        onSignInClick = onSignInClick,
+                        showRegisterButton = isRegistrationEnabled
                     )
                 }
             }
@@ -364,6 +367,7 @@ fun CourseInfoScreenPreview() {
             ),
             uiMessage = null,
             uriScheme = "",
+            isRegistrationEnabled = true,
             hasInternetConnection = false,
             checkInternetConnection = {},
             onRegisterClick = {},

--- a/discovery/src/main/java/org/openedx/discovery/presentation/info/CourseInfoViewModel.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/info/CourseInfoViewModel.kt
@@ -64,6 +64,8 @@ class CourseInfoViewModel(
     val hasInternetConnection: Boolean
         get() = networkConnection.isOnline()
 
+    val isRegistrationEnabled: Boolean get() = config.isRegistrationEnabled()
+
     val uriScheme: String get() = config.getUriScheme()
 
     private val webViewConfig get() = config.getDiscoveryConfig().webViewConfig

--- a/discovery/src/main/java/org/openedx/discovery/presentation/search/CourseSearchFragment.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/search/CourseSearchFragment.kt
@@ -118,6 +118,7 @@ class CourseSearchFragment : Fragment() {
                     refreshing = refreshing,
                     querySearch = querySearch,
                     isUserLoggedIn = viewModel.isUserLoggedIn,
+                    isRegistrationEnabled = viewModel.isRegistrationEnabled,
                     onBackClick = {
                         requireActivity().supportFragmentManager.popBackStack()
                     },
@@ -171,6 +172,7 @@ private fun CourseSearchScreen(
     refreshing: Boolean,
     querySearch: String,
     isUserLoggedIn: Boolean,
+    isRegistrationEnabled: Boolean,
     onBackClick: () -> Unit,
     onSearchTextChanged: (String) -> Unit,
     onSwipeRefresh: () -> Unit,
@@ -222,7 +224,8 @@ private fun CourseSearchScreen(
                 ) {
                     AuthButtonsPanel(
                         onRegisterClick = onRegisterClick,
-                        onSignInClick = onSignInClick
+                        onSignInClick = onSignInClick,
+                        showRegisterButton = isRegistrationEnabled
                     )
                 }
             }
@@ -433,6 +436,7 @@ fun CourseSearchScreenPreview() {
             refreshing = false,
             querySearch = "",
             isUserLoggedIn = true,
+            isRegistrationEnabled = true,
             onBackClick = {},
             onSearchTextChanged = {},
             onSwipeRefresh = {},
@@ -458,6 +462,7 @@ fun CourseSearchScreenTabletPreview() {
             refreshing = false,
             querySearch = "",
             isUserLoggedIn = false,
+            isRegistrationEnabled = true,
             onBackClick = {},
             onSearchTextChanged = {},
             onSwipeRefresh = {},

--- a/discovery/src/main/java/org/openedx/discovery/presentation/search/CourseSearchViewModel.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/search/CourseSearchViewModel.kt
@@ -30,6 +30,7 @@ class CourseSearchViewModel(
 
     val apiHostUrl get() = config.getApiHostURL()
     val isUserLoggedIn get() = corePreferences.user != null
+    val isRegistrationEnabled: Boolean get() = config.isRegistrationEnabled()
 
     private val _uiState =
         MutableLiveData<CourseSearchUIState>(CourseSearchUIState.Courses(emptyList(), 0))


### PR DESCRIPTION
## Description

Some OpenedX operators want user registration disabled from their UIs, so that user registration can be operated through the APIs, from external applications like salesforce. Currently we don't have such an option for this android app.

This PR adds a flag called `REGISTRATION_ENABLED` which controls if Registration option is displayed to users.

## Testing instructions

1. Checkout and setup this branch
2. Set `REGISTRATION_ENABLED` to `true` in config and verify Registration button/link is visible.
3. Set `REGISTRATION_ENABLED` to `false` in config and verify Registration button/link is gone.

## Other information

Private Ref : [BB-9186](https://tasks.opencraft.com/browse/BB-9186)