### PR TITLE
fix: Remove student_view_mutli_device dependency for HTML XBlocks

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerAdapter.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerAdapter.kt
@@ -45,10 +45,6 @@ class CourseUnitContainerAdapter(
                 createDiscussionFragment(block)
             }
 
-            !block.studentViewMultiDevice -> {
-                createNotAvailableUnitFragment(block, NotAvailableUnitType.MOBILE_UNSUPPORTED)
-            }
-
             block.isHTMLBlock || block.isProblemBlock || block.isOpenAssessmentBlock || block.isDragAndDropBlock ||
                     block.isWordCloudBlock || block.isLTIConsumerBlock || block.isSurveyBlock -> {
                 val lastModified = if (downloadedModel != null && noNetwork) {


### PR DESCRIPTION
### Description:

- Going forward, all HTML Xblocks will be visible on the mobile side, regardless of `student_view_multi_device`.

fix: LEARNER-10232