### PR TITLE
fix: bug when unable to see downloaded html content

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/unit/html/HtmlUnitFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/html/HtmlUnitFragment.kt
@@ -169,7 +169,7 @@ class HtmlUnitFragment : Fragment() {
                                         if (isAdded) viewModel.setWebPageLoaded(requireContext().assets)
                                     },
                                     onWebPageLoadError = {
-                                        viewModel.onWebPageLoadError()
+                                        if (!fromDownloadedContent) viewModel.onWebPageLoadError()
                                     },
                                     saveXBlockProgress = { jsonProgress ->
                                         viewModel.saveXBlockProgress(jsonProgress)


### PR DESCRIPTION
Fixed a bug that started to occur after merging this [https://github.com/openedx/openedx-app-android/pull/392](PR)