### PR TITLE
refactor: standardized button styling system in the app

### DIFF
--- a/auth/src/main/java/org/openedx/auth/presentation/restore/RestorePasswordFragment.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/restore/RestorePasswordFragment.kt
@@ -61,7 +61,7 @@ import org.openedx.core.R
 import org.openedx.core.presentation.global.appupgrade.AppUpgradeRequiredScreen
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.HandleUIMessage
-import org.openedx.core.ui.OpenEdXButton
+import org.openedx.core.ui.OpenEdXPrimaryButton
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.statusBarsInset
 import org.openedx.core.ui.theme.OpenEdXTheme
@@ -186,7 +186,7 @@ private fun RestorePasswordScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(200.dp),
-            painter = painterResource(id = org.openedx.core.R.drawable.core_top_header),
+            painter = painterResource(id = R.drawable.core_top_header),
             contentScale = ContentScale.FillBounds,
             contentDescription = null
         )
@@ -297,7 +297,7 @@ private fun RestorePasswordScreen(
                                         CircularProgressIndicator(color = MaterialTheme.appColors.primary)
                                     }
                                 } else {
-                                    OpenEdXButton(
+                                    OpenEdXPrimaryButton(
                                         modifier = buttonWidth.testTag("btn_reset_password"),
                                         text = stringResource(id = authR.string.auth_reset_password),
                                         onClick = {
@@ -350,7 +350,7 @@ private fun RestorePasswordScreen(
                                     color = MaterialTheme.appColors.textPrimary
                                 )
                                 Spacer(Modifier.height(48.dp))
-                                OpenEdXButton(
+                                OpenEdXPrimaryButton(
                                     modifier = buttonWidth,
                                     text = stringResource(id = R.string.core_sign_in),
                                     onClick = {

--- a/auth/src/main/java/org/openedx/auth/presentation/signin/compose/SignInView.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signin/compose/SignInView.kt
@@ -66,7 +66,7 @@ import org.openedx.core.extension.TextConverter
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.HyperlinkText
-import org.openedx.core.ui.OpenEdXButton
+import org.openedx.core.ui.OpenEdXPrimaryButton
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.noRippleClickable
 import org.openedx.core.ui.theme.OpenEdXTheme
@@ -292,11 +292,9 @@ private fun AuthForm(
         if (state.showProgress) {
             CircularProgressIndicator(color = MaterialTheme.appColors.primary)
         } else {
-            OpenEdXButton(
+            OpenEdXPrimaryButton(
                 modifier = buttonWidth.testTag("btn_sign_in"),
                 text = stringResource(id = coreR.string.core_sign_in),
-                textColor = MaterialTheme.appColors.primaryButtonText,
-                backgroundColor = MaterialTheme.appColors.secondaryButtonBackground,
                 onClick = {
                     keyboardController?.hide()
                     if (login.isNotEmpty() && password.isNotEmpty()) {

--- a/auth/src/main/java/org/openedx/auth/presentation/signup/compose/SignUpView.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signup/compose/SignUpView.kt
@@ -71,7 +71,7 @@ import org.openedx.core.domain.model.RegistrationField
 import org.openedx.core.domain.model.RegistrationFieldType
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.HandleUIMessage
-import org.openedx.core.ui.OpenEdXButton
+import org.openedx.core.ui.OpenEdXPrimaryButton
 import org.openedx.core.ui.SheetContent
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.isImeVisibleState
@@ -434,11 +434,9 @@ internal fun SignUpView(
                                         CircularProgressIndicator(color = MaterialTheme.appColors.primary)
                                     }
                                 } else {
-                                    OpenEdXButton(
+                                    OpenEdXPrimaryButton(
                                         modifier = buttonWidth.testTag("btn_create_account"),
                                         text = stringResource(id = R.string.auth_create_account),
-                                        textColor = MaterialTheme.appColors.primaryButtonText,
-                                        backgroundColor = MaterialTheme.appColors.secondaryButtonBackground,
                                         onClick = {
                                             keyboardController?.hide()
                                             showErrorMap.clear()

--- a/auth/src/main/java/org/openedx/auth/presentation/ui/SocialAuthView.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/ui/SocialAuthView.kt
@@ -19,8 +19,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.openedx.auth.R
 import org.openedx.auth.data.model.AuthType
-import org.openedx.core.ui.OpenEdXButton
-import org.openedx.core.ui.OpenEdXOutlinedButton
+import org.openedx.core.ui.OpenEdXPrimaryButton
+import org.openedx.core.ui.OpenEdXPrimaryOutlinedButton
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 
@@ -40,7 +40,7 @@ internal fun SocialAuthView(
             } else {
                 R.string.auth_continue_google
             }
-            OpenEdXOutlinedButton(
+            OpenEdXPrimaryOutlinedButton(
                 modifier = Modifier
                     .testTag("btn_google_auth")
                     .padding(top = 24.dp)
@@ -74,7 +74,7 @@ internal fun SocialAuthView(
             } else {
                 R.string.auth_continue_facebook
             }
-            OpenEdXButton(
+            OpenEdXPrimaryButton(
                 modifier = Modifier
                     .testTag("btn_facebook_auth")
                     .padding(top = 12.dp)
@@ -106,7 +106,7 @@ internal fun SocialAuthView(
             } else {
                 R.string.auth_continue_microsoft
             }
-            OpenEdXButton(
+            OpenEdXPrimaryButton(
                 modifier = Modifier
                     .testTag("btn_microsoft_auth")
                     .padding(top = 12.dp)

--- a/auth/src/main/java/org/openedx/auth/presentation/ui/SocialAuthView.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/ui/SocialAuthView.kt
@@ -46,7 +46,6 @@ internal fun SocialAuthView(
                     .padding(top = 24.dp)
                     .fillMaxWidth(),
                 backgroundColor = MaterialTheme.appColors.authGoogleButtonBackground,
-                borderColor = MaterialTheme.appColors.primary,
                 textColor = Color.Unspecified,
                 onClick = {
                     onEvent(AuthType.GOOGLE)

--- a/core/src/main/java/org/openedx/core/presentation/dialog/alert/ActionDialogFragment.kt
+++ b/core/src/main/java/org/openedx/core/presentation/dialog/alert/ActionDialogFragment.kt
@@ -34,8 +34,8 @@ import org.openedx.core.config.Config
 import org.openedx.core.presentation.CoreAnalytics
 import org.openedx.core.presentation.CoreAnalyticsEvent
 import org.openedx.core.presentation.CoreAnalyticsKey
-import org.openedx.core.presentation.global.appupgrade.DefaultTextButton
-import org.openedx.core.presentation.global.appupgrade.TransparentTextButton
+import org.openedx.core.ui.DefaultTextButton
+import org.openedx.core.ui.TransparentTextButton
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appShapes

--- a/core/src/main/java/org/openedx/core/presentation/dialog/alert/InfoDialogFragment.kt
+++ b/core/src/main/java/org/openedx/core/presentation/dialog/alert/InfoDialogFragment.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import org.openedx.core.R
-import org.openedx.core.presentation.global.appupgrade.DefaultTextButton
+import org.openedx.core.ui.DefaultTextButton
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appShapes

--- a/core/src/main/java/org/openedx/core/presentation/dialog/appreview/AppReviewUI.kt
+++ b/core/src/main/java/org/openedx/core/presentation/dialog/appreview/AppReviewUI.kt
@@ -13,8 +13,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedTextField
@@ -48,6 +46,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.openedx.core.R
 import org.openedx.core.presentation.dialog.DefaultDialogBox
+import org.openedx.core.ui.DefaultTextButton
+import org.openedx.core.ui.TransparentTextButton
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appShapes
@@ -213,7 +213,10 @@ fun RateDialog(
             verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
             Text(
-                text = stringResource(R.string.core_rate_dialog_title, stringResource(R.string.app_name)),
+                text = stringResource(
+                    R.string.core_rate_dialog_title,
+                    stringResource(R.string.app_name)
+                ),
                 color = MaterialTheme.appColors.textPrimary,
                 style = MaterialTheme.appTypography.titleMedium
             )
@@ -241,69 +244,6 @@ fun RateDialog(
                     onClick = onSubmitClick
                 )
             }
-        }
-    }
-}
-
-@Composable
-fun TransparentTextButton(
-    text: String,
-    onClick: () -> Unit
-) {
-    Button(
-        modifier = Modifier
-            .height(42.dp),
-        colors = ButtonDefaults.buttonColors(
-            backgroundColor = Color.Transparent
-        ),
-        elevation = null,
-        shape = MaterialTheme.appShapes.navigationButtonShape,
-        onClick = onClick
-    ) {
-        Text(
-            color = MaterialTheme.appColors.textAccent,
-            style = MaterialTheme.appTypography.labelLarge,
-            text = text
-        )
-    }
-}
-
-@Composable
-fun DefaultTextButton(
-    isEnabled: Boolean = true,
-    text: String,
-    onClick: () -> Unit
-) {
-    val textColor: Color
-    val backgroundColor: Color
-    if (isEnabled) {
-        textColor = MaterialTheme.appColors.primaryButtonText
-        backgroundColor = MaterialTheme.appColors.primaryButtonBackground
-    } else {
-        textColor = MaterialTheme.appColors.inactiveButtonText
-        backgroundColor = MaterialTheme.appColors.inactiveButtonBackground
-    }
-
-    Button(
-        modifier = Modifier
-            .height(42.dp),
-        colors = ButtonDefaults.buttonColors(
-            backgroundColor = backgroundColor,
-            contentColor = textColor
-        ),
-        elevation = null,
-        shape = MaterialTheme.appShapes.navigationButtonShape,
-        enabled = isEnabled,
-        onClick = onClick
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Center
-        ) {
-            Text(
-                text = text,
-                style = MaterialTheme.appTypography.labelLarge
-            )
         }
     }
 }

--- a/core/src/main/java/org/openedx/core/presentation/global/appupgrade/AppUpdateUI.kt
+++ b/core/src/main/java/org/openedx/core/presentation/global/appupgrade/AppUpdateUI.kt
@@ -12,12 +12,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Card
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
@@ -39,6 +36,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.openedx.core.R
+import org.openedx.core.ui.DefaultTextButton
+import org.openedx.core.ui.TransparentTextButton
 import org.openedx.core.ui.noRippleClickable
 import org.openedx.core.ui.statusBarsInset
 import org.openedx.core.ui.theme.OpenEdXTheme
@@ -254,61 +253,6 @@ fun AppUpgradeDialogButtons(
             text = stringResource(id = R.string.core_update),
             onClick = onUpdateClick
         )
-    }
-}
-
-@Composable
-fun TransparentTextButton(
-    text: String,
-    onClick: () -> Unit
-) {
-    Button(
-        modifier = Modifier
-            .testTag("btn_secondary")
-            .height(42.dp),
-        colors = ButtonDefaults.buttonColors(
-            backgroundColor = Color.Transparent
-        ),
-        elevation = null,
-        shape = MaterialTheme.appShapes.navigationButtonShape,
-        onClick = onClick
-    ) {
-        Text(
-            modifier = Modifier.testTag("txt_secondary"),
-            color = MaterialTheme.appColors.textAccent,
-            style = MaterialTheme.appTypography.labelLarge,
-            text = text
-        )
-    }
-}
-
-@Composable
-fun DefaultTextButton(
-    text: String,
-    onClick: () -> Unit
-) {
-    Button(
-        modifier = Modifier
-            .testTag("btn_primary")
-            .height(42.dp),
-        colors = ButtonDefaults.buttonColors(
-            backgroundColor = MaterialTheme.appColors.primaryButtonBackground
-        ),
-        elevation = null,
-        shape = MaterialTheme.appShapes.navigationButtonShape,
-        onClick = onClick
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Center
-        ) {
-            Text(
-                modifier = Modifier.testTag("txt_primary"),
-                text = text,
-                color = MaterialTheme.appColors.primaryButtonText,
-                style = MaterialTheme.appTypography.labelLarge
-            )
-        }
     }
 }
 

--- a/core/src/main/java/org/openedx/core/presentation/settings/calendarsync/CalendarSyncDialog.kt
+++ b/core/src/main/java/org/openedx/core/presentation/settings/calendarsync/CalendarSyncDialog.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import org.openedx.core.R
-import org.openedx.core.presentation.global.appupgrade.TransparentTextButton
+import org.openedx.core.ui.TransparentTextButton
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appShapes
@@ -44,7 +44,7 @@ fun CalendarSyncDialog(
     when (syncDialogType) {
         CalendarSyncDialogType.SYNC_DIALOG,
         CalendarSyncDialogType.UN_SYNC_DIALOG,
-        -> {
+            -> {
             CalendarAlertDialog(
                 dialogProperties = DialogProperties(
                     title = stringResource(syncDialogType.titleResId),

--- a/core/src/main/java/org/openedx/core/ui/ButtonStyles.kt
+++ b/core/src/main/java/org/openedx/core/ui/ButtonStyles.kt
@@ -1,0 +1,272 @@
+package org.openedx.core.ui
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.ButtonElevation
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import org.openedx.core.ui.theme.appColors
+import org.openedx.core.ui.theme.appShapes
+import org.openedx.core.ui.theme.appTypography
+import org.openedx.foundation.extension.tagId
+
+@Composable
+private fun OpenEdXButton(
+    modifier: Modifier = Modifier.fillMaxWidth(),
+    text: String = "",
+    enabled: Boolean = true,
+    textColor: Color,
+    backgroundColor: Color,
+    elevation: ButtonElevation? = ButtonDefaults.elevation(),
+    onClick: () -> Unit,
+    content: (@Composable RowScope.() -> Unit)? = null,
+) {
+    Button(
+        modifier = Modifier
+            .testTag("btn_${text.tagId()}")
+            .then(modifier)
+            .height(42.dp),
+        shape = MaterialTheme.appShapes.buttonShape,
+        colors = ButtonDefaults.buttonColors(
+            backgroundColor = backgroundColor
+        ),
+        enabled = enabled,
+        elevation = elevation,
+        onClick = onClick
+    ) {
+        if (content == null) {
+            Text(
+                modifier = Modifier.testTag("txt_${text.tagId()}"),
+                text = text,
+                color = textColor,
+                style = MaterialTheme.appTypography.labelLarge
+            )
+        } else {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun OpenEdXOutlinedButton(
+    modifier: Modifier = Modifier.fillMaxWidth(),
+    text: String = "",
+    enabled: Boolean = true,
+    textColor: Color,
+    borderColor: Color,
+    backgroundColor: Color,
+    onClick: () -> Unit,
+    content: (@Composable RowScope.() -> Unit)? = null,
+) {
+    OutlinedButton(
+        modifier = Modifier
+            .testTag("btn_${text.tagId()}")
+            .then(modifier)
+            .height(42.dp),
+        onClick = onClick,
+        enabled = enabled,
+        border = BorderStroke(1.dp, borderColor),
+        shape = MaterialTheme.appShapes.buttonShape,
+        colors = ButtonDefaults.outlinedButtonColors(backgroundColor = backgroundColor)
+    ) {
+        if (content == null) {
+            Text(
+                modifier = Modifier.testTag("txt_${text.tagId()}"),
+                text = text,
+                style = MaterialTheme.appTypography.labelLarge,
+                color = textColor
+            )
+        } else {
+            content()
+        }
+    }
+}
+
+@Composable
+fun OpenEdXPrimaryButton(
+    modifier: Modifier = Modifier.fillMaxWidth(),
+    text: String = "",
+    enabled: Boolean = true,
+    textColor: Color = MaterialTheme.appColors.primaryButtonText,
+    backgroundColor: Color = MaterialTheme.appColors.primaryButtonBackground,
+    onClick: () -> Unit,
+    content: (@Composable RowScope.() -> Unit)? = null,
+) {
+    OpenEdXButton(
+        modifier = modifier,
+        text = text,
+        enabled = enabled,
+        textColor = textColor,
+        backgroundColor = backgroundColor,
+        onClick = onClick,
+        content = content
+    )
+}
+
+@Composable
+fun OpenEdXPrimaryOutlinedButton(
+    modifier: Modifier = Modifier.fillMaxWidth(),
+    text: String = "",
+    enabled: Boolean = true,
+    textColor: Color = MaterialTheme.appColors.primaryButtonBorderedText,
+    borderColor: Color = MaterialTheme.appColors.primaryButtonBorder,
+    backgroundColor: Color = MaterialTheme.appColors.primaryButtonBorderedBackground,
+    onClick: () -> Unit,
+    content: (@Composable RowScope.() -> Unit)? = null,
+) {
+    OpenEdXOutlinedButton(
+        modifier = modifier,
+        text = text,
+        enabled = enabled,
+        textColor = textColor,
+        borderColor = borderColor,
+        backgroundColor = backgroundColor,
+        onClick = onClick,
+        content = content
+    )
+}
+
+@Composable
+fun OpenEdXSecondaryButton(
+    modifier: Modifier = Modifier.fillMaxWidth(),
+    text: String = "",
+    enabled: Boolean = true,
+    textColor: Color = MaterialTheme.appColors.secondaryButtonText,
+    backgroundColor: Color = MaterialTheme.appColors.secondaryButtonBackground,
+    onClick: () -> Unit,
+    content: (@Composable RowScope.() -> Unit)? = null,
+) {
+    OpenEdXButton(
+        modifier = modifier,
+        text = text,
+        enabled = enabled,
+        textColor = textColor,
+        backgroundColor = backgroundColor,
+        onClick = onClick,
+        content = content
+    )
+}
+
+@Composable
+fun OpenEdXSecondaryOutlinedButton(
+    modifier: Modifier = Modifier.fillMaxWidth(),
+    text: String = "",
+    enabled: Boolean = true,
+    textColor: Color = MaterialTheme.appColors.secondaryButtonBorderedText,
+    borderColor: Color = MaterialTheme.appColors.secondaryButtonBorder,
+    backgroundColor: Color = MaterialTheme.appColors.secondaryButtonBorderedBackground,
+    onClick: () -> Unit,
+    content: (@Composable RowScope.() -> Unit)? = null,
+) {
+    OpenEdXOutlinedButton(
+        modifier = modifier,
+        text = text,
+        enabled = enabled,
+        textColor = textColor,
+        borderColor = borderColor,
+        backgroundColor = backgroundColor,
+        onClick = onClick,
+        content = content
+    )
+}
+
+@Composable
+fun OpenEdXErrorOutlinedButton(
+    modifier: Modifier = Modifier.fillMaxWidth(),
+    text: String = "",
+    enabled: Boolean = true,
+    textColor: Color = MaterialTheme.appColors.error,
+    borderColor: Color = MaterialTheme.appColors.error,
+    onClick: () -> Unit,
+    content: (@Composable RowScope.() -> Unit)? = null,
+) {
+    OpenEdXOutlinedButton(
+        modifier = modifier,
+        text = text,
+        enabled = enabled,
+        textColor = textColor,
+        borderColor = borderColor,
+        backgroundColor = Color.Transparent,
+        onClick = onClick,
+        content = content
+    )
+}
+
+@Composable
+fun DefaultTextButton(
+    isEnabled: Boolean = true,
+    text: String,
+    onClick: () -> Unit
+) {
+    val textColor: Color
+    val backgroundColor: Color
+    if (isEnabled) {
+        textColor = MaterialTheme.appColors.primaryButtonText
+        backgroundColor = MaterialTheme.appColors.primaryButtonBackground
+    } else {
+        textColor = MaterialTheme.appColors.inactiveButtonText
+        backgroundColor = MaterialTheme.appColors.inactiveButtonBackground
+    }
+
+    Button(
+        modifier = Modifier
+            .testTag("btn_primary")
+            .height(42.dp),
+        colors = ButtonDefaults.buttonColors(
+            backgroundColor = backgroundColor,
+            contentColor = textColor
+        ),
+        elevation = null,
+        shape = MaterialTheme.appShapes.navigationButtonShape,
+        enabled = isEnabled,
+        onClick = onClick
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = text,
+                style = MaterialTheme.appTypography.labelLarge
+            )
+        }
+    }
+}
+
+@Composable
+fun TransparentTextButton(
+    text: String,
+    onClick: () -> Unit
+) {
+    Button(
+        modifier = Modifier
+            .testTag("btn_secondary")
+            .height(42.dp),
+        colors = ButtonDefaults.buttonColors(
+            backgroundColor = Color.Transparent
+        ),
+        elevation = null,
+        shape = MaterialTheme.appShapes.navigationButtonShape,
+        onClick = onClick
+    ) {
+        Text(
+            modifier = Modifier.testTag("txt_secondary"),
+            color = MaterialTheme.appColors.textAccent,
+            style = MaterialTheme.appTypography.labelLarge,
+            text = text
+        )
+    }
+}

--- a/core/src/main/java/org/openedx/core/ui/ComposeCommon.kt
+++ b/core/src/main/java/org/openedx/core/ui/ComposeCommon.kt
@@ -2,8 +2,6 @@ package org.openedx.core.ui
 
 import android.os.Build
 import android.os.Build.VERSION.SDK_INT
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -14,7 +12,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -39,14 +36,11 @@ import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Button
-import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.OutlinedButton
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.ScaffoldState
 import androidx.compose.material.Text
@@ -1081,87 +1075,13 @@ fun OfflineModeDialog(
 }
 
 @Composable
-fun OpenEdXButton(
-    modifier: Modifier = Modifier.fillMaxWidth(),
-    text: String = "",
-    onClick: () -> Unit,
-    enabled: Boolean = true,
-    textColor: Color = MaterialTheme.appColors.primaryButtonText,
-    backgroundColor: Color = MaterialTheme.appColors.primaryButtonBackground,
-    content: (@Composable RowScope.() -> Unit)? = null
-) {
-    Button(
-        modifier = Modifier
-            .testTag("btn_${text.tagId()}")
-            .then(modifier)
-            .height(42.dp),
-        shape = MaterialTheme.appShapes.buttonShape,
-        colors = ButtonDefaults.buttonColors(
-            backgroundColor = backgroundColor
-        ),
-        enabled = enabled,
-        onClick = onClick
-    ) {
-        if (content == null) {
-            Text(
-                modifier = Modifier.testTag("txt_${text.tagId()}"),
-                text = text,
-                color = textColor,
-                style = MaterialTheme.appTypography.labelLarge
-            )
-        } else {
-            content()
-        }
-    }
-}
-
-@Composable
-fun OpenEdXOutlinedButton(
-    modifier: Modifier = Modifier.fillMaxWidth(),
-    backgroundColor: Color = Color.Transparent,
-    borderColor: Color,
-    textColor: Color,
-    text: String = "",
-    enabled: Boolean = true,
-    onClick: () -> Unit,
-    content: (@Composable RowScope.() -> Unit)? = null,
-) {
-    OutlinedButton(
-        modifier = Modifier
-            .testTag("btn_${text.tagId()}")
-            .then(modifier)
-            .height(42.dp),
-        onClick = onClick,
-        enabled = enabled,
-        border = BorderStroke(1.dp, borderColor),
-        shape = MaterialTheme.appShapes.buttonShape,
-        colors = ButtonDefaults.outlinedButtonColors(backgroundColor = backgroundColor)
-    ) {
-        if (content == null) {
-            Text(
-                modifier = Modifier.testTag("txt_${text.tagId()}"),
-                text = text,
-                style = MaterialTheme.appTypography.labelLarge,
-                color = textColor
-            )
-        } else {
-            content()
-        }
-    }
-}
-
-@Composable
 fun BackBtn(
     modifier: Modifier = Modifier,
     tint: Color = MaterialTheme.appColors.primary,
     onBackClick: () -> Unit,
 ) {
-    IconButton(
-        modifier = modifier.testTag("ib_back"),
-        onClick = {
-            onBackClick()
-        }
-    ) {
+    IconButton(modifier = modifier.testTag("ib_back"),
+        onClick = { onBackClick() }) {
         Icon(
             painter = painterResource(id = R.drawable.core_ic_back),
             contentDescription = stringResource(id = R.string.core_accessibility_btn_back),
@@ -1211,12 +1131,10 @@ fun FullScreenErrorView(
             textAlign = TextAlign.Center
         )
         Spacer(Modifier.height(16.dp))
-        OpenEdXButton(
+        OpenEdXSecondaryButton(
             modifier = Modifier
                 .widthIn(Dp.Unspecified, 162.dp),
             text = stringResource(id = errorType.actionResId),
-            textColor = MaterialTheme.appColors.secondaryButtonText,
-            backgroundColor = MaterialTheme.appColors.secondaryButtonBackground,
             onClick = onReloadClick,
         )
     }
@@ -1265,19 +1183,17 @@ fun AuthButtonsPanel(
 ) {
     Row {
         if (showRegisterButton) {
-            OpenEdXButton(
+            OpenEdXPrimaryButton(
                 modifier = Modifier
                     .testTag("btn_register")
                     .width(0.dp)
                     .weight(1f),
                 text = stringResource(id = R.string.core_register),
-                textColor = MaterialTheme.appColors.primaryButtonText,
-                backgroundColor = MaterialTheme.appColors.secondaryButtonBackground,
                 onClick = { onRegisterClick() }
             )
         }
 
-        OpenEdXOutlinedButton(
+        OpenEdXSecondaryOutlinedButton(
             modifier = Modifier
                 .testTag("btn_sign_in")
                 .then(
@@ -1290,15 +1206,11 @@ fun AuthButtonsPanel(
                     }
                 ),
             text = stringResource(id = R.string.core_sign_in),
-            onClick = { onSignInClick() },
-            textColor = MaterialTheme.appColors.secondaryButtonBorderedText,
-            backgroundColor = MaterialTheme.appColors.secondaryButtonBorderedBackground,
-            borderColor = MaterialTheme.appColors.secondaryButtonBorder,
+            onClick = { onSignInClick() }
         )
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun RoundTabsBar(
     modifier: Modifier = Modifier,
@@ -1484,7 +1396,6 @@ val mockTab = object : TabItem {
     override val icon: ImageVector = Icons.Default.AccountCircle
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Preview
 @Composable
 private fun RoundTabsBarPreview() {

--- a/core/src/main/java/org/openedx/core/ui/ComposeCommon.kt
+++ b/core/src/main/java/org/openedx/core/ui/ComposeCommon.kt
@@ -1080,8 +1080,10 @@ fun BackBtn(
     tint: Color = MaterialTheme.appColors.primary,
     onBackClick: () -> Unit,
 ) {
-    IconButton(modifier = modifier.testTag("ib_back"),
-        onClick = { onBackClick() }) {
+    IconButton(
+        modifier = modifier.testTag("ib_back"),
+        onClick = { onBackClick() }
+    ) {
         Icon(
             painter = painterResource(id = R.drawable.core_ic_back),
             contentDescription = stringResource(id = R.string.core_accessibility_btn_back),

--- a/core/src/main/java/org/openedx/core/ui/theme/AppColors.kt
+++ b/core/src/main/java/org/openedx/core/ui/theme/AppColors.kt
@@ -35,6 +35,9 @@ data class AppColors(
     val secondaryButtonBorderedText: Color,
     val secondaryButtonBorderedBackground: Color,
 
+    val downloadingSuccess: Color,
+    val downloadingNotStarted: Color,
+
     val cardViewBackground: Color,
     val cardViewBorder: Color,
     val divider: Color,

--- a/core/src/main/java/org/openedx/core/ui/theme/AppColors.kt
+++ b/core/src/main/java/org/openedx/core/ui/theme/AppColors.kt
@@ -21,18 +21,19 @@ data class AppColors(
     val textFieldText: Color,
     val textFieldHint: Color,
 
-    val primaryButtonBackground: Color,
     val primaryButtonText: Color,
+    val primaryButtonBackground: Color,
     val primaryButtonBorder: Color,
     val primaryButtonBorderedText: Color,
+    val primaryButtonBorderedBackground: Color,
 
     // The default secondary button styling is identical to the primary button styling.
     // However, you can customize it if your brand utilizes two accent colors.
-    val secondaryButtonBackground: Color,
     val secondaryButtonText: Color,
+    val secondaryButtonBackground: Color,
     val secondaryButtonBorder: Color,
-    val secondaryButtonBorderedBackground: Color,
     val secondaryButtonBorderedText: Color,
+    val secondaryButtonBorderedBackground: Color,
 
     val cardViewBackground: Color,
     val cardViewBorder: Color,

--- a/core/src/main/java/org/openedx/core/ui/theme/Theme.kt
+++ b/core/src/main/java/org/openedx/core/ui/theme/Theme.kt
@@ -40,16 +40,17 @@ private val DarkColorPalette = AppColors(
     textFieldText = dark_text_field_text,
     textFieldHint = dark_text_field_hint,
 
-    primaryButtonBackground = dark_primary_button_background,
     primaryButtonText = dark_primary_button_text,
+    primaryButtonBackground = dark_primary_button_background,
     primaryButtonBorder = dark_primary_button_border,
     primaryButtonBorderedText = dark_primary_button_bordered_text,
+    primaryButtonBorderedBackground = dark_primary_button_bordered_background,
 
-    secondaryButtonBackground = dark_secondary_button_background,
     secondaryButtonText = dark_secondary_button_text,
+    secondaryButtonBackground = dark_secondary_button_background,
     secondaryButtonBorder = dark_secondary_button_border,
-    secondaryButtonBorderedBackground = dark_secondary_button_bordered_background,
     secondaryButtonBorderedText = dark_secondary_button_bordered_text,
+    secondaryButtonBorderedBackground = dark_secondary_button_bordered_background,
 
     cardViewBackground = dark_card_view_background,
     cardViewBorder = dark_card_view_border,
@@ -129,10 +130,11 @@ private val LightColorPalette = AppColors(
     textFieldText = light_text_field_text,
     textFieldHint = light_text_field_hint,
 
-    primaryButtonBackground = light_primary_button_background,
     primaryButtonText = light_primary_button_text,
+    primaryButtonBackground = light_primary_button_background,
     primaryButtonBorder = light_primary_button_border,
     primaryButtonBorderedText = light_primary_button_bordered_text,
+    primaryButtonBorderedBackground = light_primary_button_bordered_background,
 
     secondaryButtonBackground = light_secondary_button_background,
     secondaryButtonText = light_secondary_button_text,

--- a/core/src/main/java/org/openedx/core/ui/theme/Theme.kt
+++ b/core/src/main/java/org/openedx/core/ui/theme/Theme.kt
@@ -52,6 +52,9 @@ private val DarkColorPalette = AppColors(
     secondaryButtonBorderedText = dark_secondary_button_bordered_text,
     secondaryButtonBorderedBackground = dark_secondary_button_bordered_background,
 
+    downloadingSuccess = dark_downloading_success,
+    downloadingNotStarted = dark_downloading_not_started,
+
     cardViewBackground = dark_card_view_background,
     cardViewBorder = dark_card_view_border,
     divider = dark_divider,
@@ -141,6 +144,9 @@ private val LightColorPalette = AppColors(
     secondaryButtonBorder = light_secondary_button_border,
     secondaryButtonBorderedBackground = light_secondary_button_bordered_background,
     secondaryButtonBorderedText = light_secondary_button_bordered_text,
+
+    downloadingSuccess = light_downloading_success,
+    downloadingNotStarted = light_downloading_not_started,
 
     cardViewBackground = light_card_view_background,
     cardViewBorder = light_card_view_border,

--- a/core/src/openedx/org/openedx/core/ui/theme/Colors.kt
+++ b/core/src/openedx/org/openedx/core/ui/theme/Colors.kt
@@ -33,7 +33,7 @@ val light_text_hyper_link = Color(0xFF3C68FF)
 
 val light_primary_button_text = Color.White
 val light_primary_button_background = Color(0xFF3C68FF)
-val light_primary_button_border = Color(0xFF97A5BB)
+val light_primary_button_border = Color(0xFF3C68FF)
 val light_primary_button_bordered_text = Color(0xFF3C68FF)
 val light_primary_button_bordered_background = Color.Transparent
 
@@ -103,9 +103,9 @@ val dark_text_field_hint = Color(0xFF79889F)
 val dark_text_hyper_link = Color(0xFF5478F9)
 
 val dark_primary_button_text = Color.White
-val dark_primary_button_background = Color(0xFF5478F9)
-val dark_primary_button_border = Color(0xFF4E5A70)
-val dark_primary_button_bordered_text = Color(0xFF5478F9)
+val dark_primary_button_background = Color(0xFF3F68F8)
+val dark_primary_button_border = Color(0xFF879FF5)
+val dark_primary_button_bordered_text = Color(0xFF879FF5)
 val dark_primary_button_bordered_background = Color.Transparent
 
 val dark_secondary_button_text = dark_primary_button_text

--- a/core/src/openedx/org/openedx/core/ui/theme/Colors.kt
+++ b/core/src/openedx/org/openedx/core/ui/theme/Colors.kt
@@ -43,6 +43,9 @@ val light_secondary_button_border = light_primary_button_border
 val light_secondary_button_bordered_text = light_primary_button_bordered_text
 val light_secondary_button_bordered_background = light_primary_button_bordered_background
 
+val light_downloading_success = Color(0xFF198571)
+val light_downloading_not_started = Color(0xFF3C68FF)
+
 val light_card_view_background = Color(0xFFF9FAFB)
 val light_card_view_border = Color(0xFFCCD4E0)
 val light_divider = Color(0xFFCCD4E0)
@@ -113,6 +116,9 @@ val dark_secondary_button_background = dark_primary_button_background
 val dark_secondary_button_border = dark_primary_button_border
 val dark_secondary_button_bordered_text = dark_primary_button_bordered_text
 val dark_secondary_button_bordered_background = dark_primary_button_bordered_background
+
+val dark_downloading_success = Color(0xFF198571)
+val dark_downloading_not_started = Color(0xFF879FF5)
 
 val dark_card_view_background = Color(0xFF273346)
 val dark_card_view_border = Color(0xFF4E5A70)

--- a/core/src/openedx/org/openedx/core/ui/theme/Colors.kt
+++ b/core/src/openedx/org/openedx/core/ui/theme/Colors.kt
@@ -31,16 +31,17 @@ val light_text_field_text = Color(0xFF3D4964)
 val light_text_field_hint = Color(0xFF97A5BB)
 val light_text_hyper_link = Color(0xFF3C68FF)
 
+val light_primary_button_text = Color.White
 val light_primary_button_background = Color(0xFF3C68FF)
 val light_primary_button_border = Color(0xFF97A5BB)
-val light_primary_button_text = Color.White
 val light_primary_button_bordered_text = Color(0xFF3C68FF)
+val light_primary_button_bordered_background = Color.Transparent
 
-val light_secondary_button_background = light_primary_button_background
 val light_secondary_button_text = light_primary_button_text
+val light_secondary_button_background = light_primary_button_background
 val light_secondary_button_border = light_primary_button_border
-val light_secondary_button_bordered_background = Color.White
 val light_secondary_button_bordered_text = light_primary_button_bordered_text
+val light_secondary_button_bordered_background = light_primary_button_bordered_background
 
 val light_card_view_background = Color(0xFFF9FAFB)
 val light_card_view_border = Color(0xFFCCD4E0)
@@ -101,16 +102,17 @@ val dark_text_field_text = Color.White
 val dark_text_field_hint = Color(0xFF79889F)
 val dark_text_hyper_link = Color(0xFF5478F9)
 
-val dark_primary_button_background = Color(0xFF5478F9)
 val dark_primary_button_text = Color.White
+val dark_primary_button_background = Color(0xFF5478F9)
 val dark_primary_button_border = Color(0xFF4E5A70)
 val dark_primary_button_bordered_text = Color(0xFF5478F9)
+val dark_primary_button_bordered_background = Color.Transparent
 
-val dark_secondary_button_background = dark_primary_button_background
 val dark_secondary_button_text = dark_primary_button_text
+val dark_secondary_button_background = dark_primary_button_background
 val dark_secondary_button_border = dark_primary_button_border
-val dark_secondary_button_bordered_background = Color(0xFF19212F)
 val dark_secondary_button_bordered_text = dark_primary_button_bordered_text
+val dark_secondary_button_bordered_background = dark_primary_button_bordered_background
 
 val dark_card_view_background = Color(0xFF273346)
 val dark_card_view_border = Color(0xFF4E5A70)

--- a/course/src/main/java/org/openedx/course/presentation/ChapterEndFragmentDialog.kt
+++ b/course/src/main/java/org/openedx/course/presentation/ChapterEndFragmentDialog.kt
@@ -41,8 +41,8 @@ import androidx.compose.ui.unit.dp
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import org.openedx.core.ui.AutoSizeText
-import org.openedx.core.ui.OpenEdXButton
-import org.openedx.core.ui.OpenEdXOutlinedButton
+import org.openedx.core.ui.OpenEdXPrimaryButton
+import org.openedx.core.ui.OpenEdXPrimaryOutlinedButton
 import org.openedx.core.ui.TextIcon
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
@@ -203,7 +203,7 @@ private fun ChapterEndDialogScreen(
             )
             Spacer(Modifier.height(42.dp))
             if (nextSectionName.isNotEmpty()) {
-                OpenEdXButton(
+                OpenEdXPrimaryButton(
                     text = stringResource(id = R.string.course_next_section),
                     content = {
                         TextIcon(
@@ -218,10 +218,9 @@ private fun ChapterEndDialogScreen(
                 )
                 Spacer(Modifier.height(16.dp))
             }
-            OpenEdXOutlinedButton(
-                borderColor = MaterialTheme.appColors.primaryButtonBackground,
-                textColor = MaterialTheme.appColors.primaryButtonBackground,
+            OpenEdXPrimaryOutlinedButton(
                 text = stringResource(id = R.string.course_back_to_outline),
+                borderColor = MaterialTheme.appColors.primaryButtonBackground,
                 onClick = onBackButtonClick,
                 content = {
                     AutoSizeText(
@@ -319,7 +318,7 @@ private fun ChapterEndDialogScreenLandscape(
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     if (nextSectionName.isNotEmpty()) {
-                        OpenEdXButton(
+                        OpenEdXPrimaryButton(
                             text = stringResource(id = R.string.course_next_section),
                             content = {
                                 TextIcon(
@@ -333,10 +332,9 @@ private fun ChapterEndDialogScreenLandscape(
                         )
                         Spacer(Modifier.height(16.dp))
                     }
-                    OpenEdXOutlinedButton(
-                        borderColor = MaterialTheme.appColors.primaryButtonBackground,
-                        textColor = MaterialTheme.appColors.primaryButtonBackground,
+                    OpenEdXPrimaryOutlinedButton(
                         text = stringResource(id = R.string.course_back_to_outline),
+                        borderColor = MaterialTheme.appColors.primaryButtonBackground,
                         onClick = onBackButtonClick,
                         content = {
                             AutoSizeText(

--- a/course/src/main/java/org/openedx/course/presentation/ChapterEndFragmentDialog.kt
+++ b/course/src/main/java/org/openedx/course/presentation/ChapterEndFragmentDialog.kt
@@ -220,7 +220,6 @@ private fun ChapterEndDialogScreen(
             }
             OpenEdXPrimaryOutlinedButton(
                 text = stringResource(id = R.string.course_back_to_outline),
-                borderColor = MaterialTheme.appColors.primaryButtonBackground,
                 onClick = onBackButtonClick,
                 content = {
                     AutoSizeText(
@@ -334,7 +333,6 @@ private fun ChapterEndDialogScreenLandscape(
                     }
                     OpenEdXPrimaryOutlinedButton(
                         text = stringResource(id = R.string.course_back_to_outline),
-                        borderColor = MaterialTheme.appColors.primaryButtonBackground,
                         onClick = onBackButtonClick,
                         content = {
                             AutoSizeText(

--- a/course/src/main/java/org/openedx/course/presentation/container/CourseContainerFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/container/CourseContainerFragment.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -73,7 +72,7 @@ import org.openedx.core.extension.isFalse
 import org.openedx.core.presentation.global.viewBinding
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.OfflineModeDialog
-import org.openedx.core.ui.OpenEdXButton
+import org.openedx.core.ui.OpenEdXPrimaryButton
 import org.openedx.core.ui.RoundTabsBar
 import org.openedx.core.ui.statusBarsInset
 import org.openedx.core.ui.theme.OpenEdXTheme
@@ -238,7 +237,7 @@ class CourseContainerFragment : Fragment(R.layout.fragment_course_container) {
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun CourseDashboard(
     viewModel: CourseContainerViewModel,
@@ -345,7 +344,7 @@ fun CourseDashboard(
                                 CourseAccessError.AUDIT_EXPIRED_NOT_UPGRADABLE,
                                 CourseAccessError.NOT_YET_STARTED,
                                 CourseAccessError.UNKNOWN,
-                                -> {
+                                    -> {
                                     CourseAccessErrorView(
                                         viewModel = viewModel,
                                         accessError = accessStatus.value,
@@ -413,7 +412,6 @@ fun CourseDashboard(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun DashboardPager(
     windowSize: WindowSize,
@@ -609,8 +607,8 @@ private fun SetupCourseAccessErrorButtons(
     when (accessError) {
         CourseAccessError.AUDIT_EXPIRED_NOT_UPGRADABLE,
         CourseAccessError.NOT_YET_STARTED,
-        -> {
-            OpenEdXButton(
+            -> {
+            OpenEdXPrimaryButton(
                 text = stringResource(R.string.course_label_back),
                 onClick = { fragmentManager.popBackStack() },
             )
@@ -618,7 +616,7 @@ private fun SetupCourseAccessErrorButtons(
 
         CourseAccessError.UNKNOWN -> {
             if (viewModel.hasInternetConnection) {
-                OpenEdXButton(
+                OpenEdXPrimaryButton(
                     text = stringResource(R.string.course_label_back),
                     onClick = { fragmentManager.popBackStack() },
                 )
@@ -629,7 +627,6 @@ private fun SetupCourseAccessErrorButtons(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 private fun scrollToDates(scope: CoroutineScope, pagerState: PagerState) {
     scope.launch {
         pagerState.animateScrollToPage(CourseContainerTab.entries.indexOf(CourseContainerTab.DATES))

--- a/course/src/main/java/org/openedx/course/presentation/download/DownloadConfirmDialogFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/download/DownloadConfirmDialogFragment.kt
@@ -36,8 +36,8 @@ import androidx.fragment.app.DialogFragment
 import org.openedx.core.presentation.dialog.DefaultDialogBox
 import org.openedx.core.ui.AutoSizeText
 import org.openedx.core.ui.IconText
-import org.openedx.core.ui.OpenEdXButton
-import org.openedx.core.ui.OpenEdXOutlinedButton
+import org.openedx.core.ui.OpenEdXPrimaryButton
+import org.openedx.core.ui.OpenEdXPrimaryOutlinedButton
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appTypography
@@ -61,8 +61,10 @@ class DownloadConfirmDialogFragment : DialogFragment() {
         setContent {
             OpenEdXTheme {
                 val dialogType =
-                    requireArguments().parcelable<DownloadConfirmDialogType>(ARG_DIALOG_TYPE) ?: return@OpenEdXTheme
-                val uiState = requireArguments().parcelable<DownloadDialogUIState>(ARG_UI_STATE) ?: return@OpenEdXTheme
+                    requireArguments().parcelable<DownloadConfirmDialogType>(ARG_DIALOG_TYPE)
+                        ?: return@OpenEdXTheme
+                val uiState = requireArguments().parcelable<DownloadDialogUIState>(ARG_UI_STATE)
+                    ?: return@OpenEdXTheme
                 val sizeSumString = uiState.sizeSum.toFileSize(1, false)
                 val dialogData = when (dialogType) {
                     DownloadConfirmDialogType.CONFIRM -> DownloadDialogResource(
@@ -201,7 +203,7 @@ private fun DownloadConfirmDialogView(
                     onClick = onConfirmClick
                 }
             }
-            OpenEdXButton(
+            OpenEdXPrimaryButton(
                 text = buttonText,
                 backgroundColor = buttonColor,
                 onClick = onClick,
@@ -214,12 +216,10 @@ private fun DownloadConfirmDialogView(
                     )
                 }
             )
-            OpenEdXOutlinedButton(
+            OpenEdXPrimaryOutlinedButton(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = coreR.string.core_cancel),
-                backgroundColor = MaterialTheme.appColors.background,
                 borderColor = MaterialTheme.appColors.primaryButtonBackground,
-                textColor = MaterialTheme.appColors.primaryButtonBackground,
                 onClick = {
                     onCancelClick()
                 }

--- a/course/src/main/java/org/openedx/course/presentation/download/DownloadConfirmDialogFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/download/DownloadConfirmDialogFragment.kt
@@ -219,7 +219,6 @@ private fun DownloadConfirmDialogView(
             OpenEdXPrimaryOutlinedButton(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = coreR.string.core_cancel),
-                borderColor = MaterialTheme.appColors.primaryButtonBackground,
                 onClick = {
                     onCancelClick()
                 }

--- a/course/src/main/java/org/openedx/course/presentation/download/DownloadErrorDialogFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/download/DownloadErrorDialogFragment.kt
@@ -31,8 +31,8 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import org.openedx.core.presentation.dialog.DefaultDialogBox
 import org.openedx.core.ui.AutoSizeText
-import org.openedx.core.ui.OpenEdXButton
-import org.openedx.core.ui.OpenEdXOutlinedButton
+import org.openedx.core.ui.OpenEdXPrimaryOutlinedButton
+import org.openedx.core.ui.OpenEdXSecondaryButton
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appTypography
@@ -54,8 +54,10 @@ class DownloadErrorDialogFragment : DialogFragment() {
         setContent {
             OpenEdXTheme {
                 val dialogType =
-                    requireArguments().parcelable<DownloadErrorDialogType>(ARG_DIALOG_TYPE) ?: return@OpenEdXTheme
-                val uiState = requireArguments().parcelable<DownloadDialogUIState>(ARG_UI_STATE) ?: return@OpenEdXTheme
+                    requireArguments().parcelable<DownloadErrorDialogType>(ARG_DIALOG_TYPE)
+                        ?: return@OpenEdXTheme
+                val uiState = requireArguments().parcelable<DownloadDialogUIState>(ARG_UI_STATE)
+                    ?: return@OpenEdXTheme
                 val downloadDialogResource = when (dialogType) {
                     DownloadErrorDialogType.NO_CONNECTION -> DownloadDialogResource(
                         title = stringResource(id = coreR.string.core_no_internet_connection),
@@ -166,18 +168,15 @@ private fun DownloadErrorDialogView(
                 color = MaterialTheme.appColors.textDark
             )
             if (dialogType == DownloadErrorDialogType.DOWNLOAD_FAILED) {
-                OpenEdXButton(
+                OpenEdXSecondaryButton(
                     text = stringResource(id = coreR.string.core_error_try_again),
-                    backgroundColor = MaterialTheme.appColors.secondaryButtonBackground,
                     onClick = onTryAgainClick,
                 )
             }
-            OpenEdXOutlinedButton(
+            OpenEdXPrimaryOutlinedButton(
                 modifier = Modifier.fillMaxWidth(),
                 text = dismissButtonText,
-                backgroundColor = MaterialTheme.appColors.background,
                 borderColor = MaterialTheme.appColors.primaryButtonBackground,
-                textColor = MaterialTheme.appColors.primaryButtonBackground,
                 onClick = {
                     onCancelClick()
                 }

--- a/course/src/main/java/org/openedx/course/presentation/download/DownloadErrorDialogFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/download/DownloadErrorDialogFragment.kt
@@ -176,7 +176,6 @@ private fun DownloadErrorDialogView(
             OpenEdXPrimaryOutlinedButton(
                 modifier = Modifier.fillMaxWidth(),
                 text = dismissButtonText,
-                borderColor = MaterialTheme.appColors.primaryButtonBackground,
                 onClick = {
                     onCancelClick()
                 }

--- a/course/src/main/java/org/openedx/course/presentation/download/DownloadStorageErrorDialogFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/download/DownloadStorageErrorDialogFragment.kt
@@ -160,7 +160,6 @@ private fun DownloadStorageErrorDialogView(
             OpenEdXPrimaryOutlinedButton(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = coreR.string.core_cancel),
-                borderColor = MaterialTheme.appColors.primaryButtonBorder,
                 onClick = {
                     onCancelClick()
                 }

--- a/course/src/main/java/org/openedx/course/presentation/download/DownloadStorageErrorDialogFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/download/DownloadStorageErrorDialogFragment.kt
@@ -44,7 +44,7 @@ import androidx.fragment.app.DialogFragment
 import org.openedx.core.presentation.dialog.DefaultDialogBox
 import org.openedx.core.system.StorageManager
 import org.openedx.core.ui.AutoSizeText
-import org.openedx.core.ui.OpenEdXOutlinedButton
+import org.openedx.core.ui.OpenEdXPrimaryOutlinedButton
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appTypography
@@ -68,7 +68,8 @@ class DownloadStorageErrorDialogFragment : DialogFragment() {
         setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
         setContent {
             OpenEdXTheme {
-                val uiState = requireArguments().parcelable<DownloadDialogUIState>(ARG_UI_STATE) ?: return@OpenEdXTheme
+                val uiState = requireArguments().parcelable<DownloadDialogUIState>(ARG_UI_STATE)
+                    ?: return@OpenEdXTheme
                 val downloadDialogResource = DownloadDialogResource(
                     title = stringResource(id = R.string.course_device_storage_full),
                     description = stringResource(id = R.string.course_download_device_storage_full_dialog_description),
@@ -156,12 +157,10 @@ private fun DownloadStorageErrorDialogView(
                 style = MaterialTheme.appTypography.bodyMedium,
                 color = MaterialTheme.appColors.textDark
             )
-            OpenEdXOutlinedButton(
+            OpenEdXPrimaryOutlinedButton(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = coreR.string.core_cancel),
-                backgroundColor = MaterialTheme.appColors.background,
-                borderColor = MaterialTheme.appColors.primaryButtonBackground,
-                textColor = MaterialTheme.appColors.primaryButtonBackground,
+                borderColor = MaterialTheme.appColors.primaryButtonBorder,
                 onClick = {
                     onCancelClick()
                 }
@@ -214,7 +213,12 @@ private fun StorageBar(
                 modifier = Modifier
                     .weight(freePercentage)
                     .fillMaxHeight()
-                    .padding(top = boxPadding, bottom = boxPadding, start = boxPadding, end = boxPadding / 2)
+                    .padding(
+                        top = boxPadding,
+                        bottom = boxPadding,
+                        start = boxPadding,
+                        end = boxPadding / 2
+                    )
                     .clip(RoundedCornerShape(topStart = cornerRadius, bottomStart = cornerRadius))
                     .background(MaterialTheme.appColors.cardViewBorder)
             )
@@ -222,7 +226,12 @@ private fun StorageBar(
                 modifier = Modifier
                     .weight(animReqPercentage.value)
                     .fillMaxHeight()
-                    .padding(top = boxPadding, bottom = boxPadding, end = boxPadding, start = boxPadding / 2)
+                    .padding(
+                        top = boxPadding,
+                        bottom = boxPadding,
+                        end = boxPadding,
+                        start = boxPadding / 2
+                    )
                     .clip(RoundedCornerShape(topEnd = cornerRadius, bottomEnd = cornerRadius))
                     .background(MaterialTheme.appColors.error)
             )

--- a/course/src/main/java/org/openedx/course/presentation/offline/CourseOfflineScreen.kt
+++ b/course/src/main/java/org/openedx/course/presentation/offline/CourseOfflineScreen.kt
@@ -53,8 +53,8 @@ import org.openedx.core.module.db.DownloadModel
 import org.openedx.core.module.db.DownloadedState
 import org.openedx.core.module.db.FileType
 import org.openedx.core.ui.IconText
-import org.openedx.core.ui.OpenEdXButton
-import org.openedx.core.ui.OpenEdXOutlinedButton
+import org.openedx.core.ui.OpenEdXErrorOutlinedButton
+import org.openedx.core.ui.OpenEdXSecondaryButton
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
@@ -158,9 +158,8 @@ private fun CourseOfflineUI(
                         }
                         if (uiState.progressBarValue != 1f && !uiState.isDownloading && hasInternetConnection) {
                             Spacer(modifier = Modifier.height(20.dp))
-                            OpenEdXButton(
+                            OpenEdXSecondaryButton(
                                 text = stringResource(R.string.course_download_all),
-                                backgroundColor = MaterialTheme.appColors.secondaryButtonBackground,
                                 onClick = onDownloadAllClick,
                                 enabled = uiState.isHaveDownloadableBlocks,
                                 content = {
@@ -179,12 +178,9 @@ private fun CourseOfflineUI(
                             )
                         } else if (uiState.isDownloading) {
                             Spacer(modifier = Modifier.height(20.dp))
-                            OpenEdXOutlinedButton(
+                            OpenEdXErrorOutlinedButton(
                                 modifier = Modifier.fillMaxWidth(),
                                 text = stringResource(R.string.course_cancel_course_download),
-                                backgroundColor = MaterialTheme.appColors.background,
-                                borderColor = MaterialTheme.appColors.error,
-                                textColor = MaterialTheme.appColors.error,
                                 onClick = onCancelDownloadClick,
                                 content = {
                                     IconText(
@@ -262,12 +258,9 @@ private fun LargestDownloads(
             )
         }
         if (!isDownloading) {
-            OpenEdXOutlinedButton(
+            OpenEdXErrorOutlinedButton(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(R.string.course_remove_all_downloads),
-                backgroundColor = MaterialTheme.appColors.background,
-                borderColor = MaterialTheme.appColors.error,
-                textColor = MaterialTheme.appColors.error,
                 onClick = onDeleteAllClick,
                 content = {
                     IconText(

--- a/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineScreen.kt
+++ b/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineScreen.kt
@@ -58,7 +58,7 @@ import org.openedx.core.presentation.course.CourseViewMode
 import org.openedx.core.ui.CircularProgress
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.NoContentScreen
-import org.openedx.core.ui.OpenEdXButton
+import org.openedx.core.ui.OpenEdXPrimaryButton
 import org.openedx.core.ui.TextIcon
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.theme.OpenEdXTheme
@@ -389,7 +389,7 @@ private fun ResumeCourse(
             )
         }
         Spacer(Modifier.height(24.dp))
-        OpenEdXButton(
+        OpenEdXPrimaryButton(
             text = stringResource(id = R.string.course_resume),
             onClick = {
                 onResumeClick(block.id)
@@ -447,7 +447,7 @@ private fun ResumeCourseTablet(
                 )
             }
         }
-        OpenEdXButton(
+        OpenEdXPrimaryButton(
             modifier = Modifier.width(210.dp),
             text = stringResource(id = R.string.course_resume),
             onClick = {

--- a/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineScreen.kt
+++ b/course/src/main/java/org/openedx/course/presentation/outline/CourseOutlineScreen.kt
@@ -59,6 +59,7 @@ import org.openedx.core.ui.CircularProgress
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.NoContentScreen
 import org.openedx.core.ui.OpenEdXPrimaryButton
+import org.openedx.core.ui.OpenEdXSecondaryButton
 import org.openedx.core.ui.TextIcon
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.theme.OpenEdXTheme
@@ -389,7 +390,7 @@ private fun ResumeCourse(
             )
         }
         Spacer(Modifier.height(24.dp))
-        OpenEdXPrimaryButton(
+        OpenEdXSecondaryButton(
             text = stringResource(id = R.string.course_resume),
             onClick = {
                 onResumeClick(block.id)
@@ -398,7 +399,7 @@ private fun ResumeCourse(
                 TextIcon(
                     text = stringResource(id = R.string.course_resume),
                     painter = painterResource(id = CoreR.drawable.core_ic_forward),
-                    color = MaterialTheme.appColors.primaryButtonText,
+                    color = MaterialTheme.appColors.secondaryButtonText,
                     textStyle = MaterialTheme.appTypography.labelLarge
                 )
             }
@@ -457,7 +458,7 @@ private fun ResumeCourseTablet(
                 TextIcon(
                     text = stringResource(id = R.string.course_resume),
                     painter = painterResource(id = CoreR.drawable.core_ic_forward),
-                    color = MaterialTheme.appColors.primaryButtonText,
+                    color = MaterialTheme.appColors.secondaryButtonText,
                     textStyle = MaterialTheme.appTypography.labelLarge
                 )
             }

--- a/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
+++ b/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
@@ -89,8 +89,8 @@ import org.openedx.core.module.db.DownloadedState
 import org.openedx.core.module.db.FileType
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.IconText
-import org.openedx.core.ui.OpenEdXButton
-import org.openedx.core.ui.OpenEdXOutlinedButton
+import org.openedx.core.ui.OpenEdXPrimaryButton
+import org.openedx.core.ui.OpenEdXPrimaryOutlinedButton
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.noRippleClickable
 import org.openedx.core.ui.theme.OpenEdXTheme
@@ -176,11 +176,12 @@ fun CourseSectionCard(
                     } else {
                         Icons.Outlined.CloudDownload
                     }
-                    val downloadIconDescription = if (downloadedState == DownloadedState.DOWNLOADED) {
-                        stringResource(id = R.string.course_accessibility_remove_course_section)
-                    } else {
-                        stringResource(id = R.string.course_accessibility_download_course_section)
-                    }
+                    val downloadIconDescription =
+                        if (downloadedState == DownloadedState.DOWNLOADED) {
+                            stringResource(id = R.string.course_accessibility_remove_course_section)
+                        } else {
+                            stringResource(id = R.string.course_accessibility_download_course_section)
+                        }
                     IconButton(
                         modifier = iconModifier,
                         onClick = { onDownloadClick(block) }
@@ -691,7 +692,8 @@ fun CourseExpandableChapterCard(
         if (block.isCompleted()) {
             val completedIconPainter = painterResource(R.drawable.course_ic_task_alt)
             val completedIconColor = MaterialTheme.appColors.successGreen
-            val completedIconDescription = stringResource(id = R.string.course_accessibility_section_completed)
+            val completedIconDescription =
+                stringResource(id = R.string.course_accessibility_section_completed)
 
             Icon(
                 painter = completedIconPainter,
@@ -792,9 +794,11 @@ fun CourseSubSectionItem(
         MaterialTheme.appColors.onSurface
     }
     val due by rememberSaveable {
-        mutableStateOf(block.due?.let { TimeUtils.formatToString(context, it, useRelativeDates) } ?: "")
+        mutableStateOf(block.due?.let { TimeUtils.formatToString(context, it, useRelativeDates) }
+            ?: "")
     }
-    val isAssignmentEnable = !block.isCompleted() && block.assignmentProgress != null && due.isNotEmpty()
+    val isAssignmentEnable =
+        !block.isCompleted() && block.assignmentProgress != null && due.isNotEmpty()
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -1055,7 +1059,7 @@ fun CourseDatesBanner(
         }
 
         banner.bannerType.buttonResId.nonZero()?.let {
-            OpenEdXButton(
+            OpenEdXPrimaryButton(
                 text = stringResource(id = it),
                 onClick = resetDates,
             )
@@ -1109,7 +1113,7 @@ fun CourseDatesBannerTablet(
             }
         }
         banner.bannerType.buttonResId.nonZero()?.let {
-            OpenEdXButton(
+            OpenEdXPrimaryButton(
                 modifier = Modifier.width(210.dp),
                 text = stringResource(id = it),
                 onClick = resetDates,
@@ -1155,14 +1159,12 @@ fun DatesShiftedSnackBar(
                 style = MaterialTheme.appTypography.titleSmall,
             )
             if (showAction) {
-                OpenEdXOutlinedButton(
+                OpenEdXPrimaryOutlinedButton(
                     modifier = Modifier
                         .padding(top = 16.dp)
                         .fillMaxWidth(),
                     text = stringResource(id = coreR.string.core_dates_view_all_dates),
-                    backgroundColor = MaterialTheme.appColors.background,
-                    textColor = MaterialTheme.appColors.primary,
-                    borderColor = MaterialTheme.appColors.primary,
+                    borderColor = MaterialTheme.appColors.primaryButtonBackground,
                     onClick = {
                         onViewDates()
                     }

--- a/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
+++ b/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
@@ -89,8 +89,8 @@ import org.openedx.core.module.db.DownloadedState
 import org.openedx.core.module.db.FileType
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.IconText
-import org.openedx.core.ui.OpenEdXPrimaryButton
 import org.openedx.core.ui.OpenEdXPrimaryOutlinedButton
+import org.openedx.core.ui.OpenEdXSecondaryButton
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.noRippleClickable
 import org.openedx.core.ui.theme.OpenEdXTheme
@@ -725,9 +725,9 @@ fun CourseExpandableChapterCard(
                     stringResource(id = R.string.course_accessibility_download_course_section)
                 }
                 val downloadIconTint = if (downloadedState == DownloadedState.DOWNLOADED) {
-                    MaterialTheme.appColors.successGreen
+                    MaterialTheme.appColors.downloadingSuccess
                 } else {
-                    MaterialTheme.appColors.textAccent
+                    MaterialTheme.appColors.downloadingNotStarted
                 }
                 IconButton(
                     modifier = iconModifier,
@@ -1061,7 +1061,7 @@ fun CourseDatesBanner(
         }
 
         banner.bannerType.buttonResId.nonZero()?.let {
-            OpenEdXPrimaryButton(
+            OpenEdXSecondaryButton(
                 text = stringResource(id = it),
                 onClick = resetDates,
             )
@@ -1115,7 +1115,7 @@ fun CourseDatesBannerTablet(
             }
         }
         banner.bannerType.buttonResId.nonZero()?.let {
-            OpenEdXPrimaryButton(
+            OpenEdXSecondaryButton(
                 modifier = Modifier.width(210.dp),
                 text = stringResource(id = it),
                 onClick = resetDates,

--- a/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
+++ b/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
@@ -1166,7 +1166,6 @@ fun DatesShiftedSnackBar(
                         .padding(top = 16.dp)
                         .fillMaxWidth(),
                     text = stringResource(id = coreR.string.core_dates_view_all_dates),
-                    borderColor = MaterialTheme.appColors.primaryButtonBackground,
                     onClick = {
                         onViewDates()
                     }

--- a/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
+++ b/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
@@ -794,8 +794,10 @@ fun CourseSubSectionItem(
         MaterialTheme.appColors.onSurface
     }
     val due by rememberSaveable {
-        mutableStateOf(block.due?.let { TimeUtils.formatToString(context, it, useRelativeDates) }
-            ?: "")
+        mutableStateOf(
+            block.due?.let { TimeUtils.formatToString(context, it, useRelativeDates) }
+                ?: ""
+        )
     }
     val isAssignmentEnable =
         !block.isCompleted() && block.assignmentProgress != null && due.isNotEmpty()

--- a/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryView.kt
+++ b/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryView.kt
@@ -662,7 +662,7 @@ private fun ResumeButton(
             .fillMaxWidth()
             .clickable { onClick() }
             .heightIn(min = 60.dp)
-            .background(MaterialTheme.appColors.primary)
+            .background(MaterialTheme.appColors.primaryButtonBackground)
             .padding(12.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp)

--- a/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryView.kt
+++ b/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryView.kt
@@ -87,7 +87,7 @@ import org.openedx.core.domain.model.Pagination
 import org.openedx.core.domain.model.Progress
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.OfflineModeDialog
-import org.openedx.core.ui.OpenEdXButton
+import org.openedx.core.ui.OpenEdXPrimaryButton
 import org.openedx.core.ui.TextIcon
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
@@ -237,7 +237,12 @@ private fun DashboardGalleryView(
                                     onAction(DashboardGalleryScreenAction.NavigateToDates(it))
                                 },
                                 resumeBlockId = { course, blockId ->
-                                    onAction(DashboardGalleryScreenAction.OpenBlock(course, blockId))
+                                    onAction(
+                                        DashboardGalleryScreenAction.OpenBlock(
+                                            course,
+                                            blockId
+                                        )
+                                    )
                                 }
                             )
                         }
@@ -620,7 +625,11 @@ private fun PrimaryCourseCard(
                         nearestAssignment.assignmentType ?: "",
                         stringResource(
                             id = CoreR.string.core_date_format_assignment_due,
-                            TimeUtils.formatToString(context, nearestAssignment.date, useRelativeDates)
+                            TimeUtils.formatToString(
+                                context,
+                                nearestAssignment.date,
+                                useRelativeDates
+                            )
                         )
                     )
                 )
@@ -631,7 +640,10 @@ private fun PrimaryCourseCard(
                     if (primaryCourse.courseStatus == null) {
                         openCourse(primaryCourse)
                     } else {
-                        resumeBlockId(primaryCourse, primaryCourse.courseStatus?.lastVisitedBlockId ?: "")
+                        resumeBlockId(
+                            primaryCourse,
+                            primaryCourse.courseStatus?.lastVisitedBlockId ?: ""
+                        )
                     }
                 }
             )
@@ -743,19 +755,13 @@ private fun FindACourseButton(
     modifier: Modifier = Modifier,
     findACourseClick: () -> Unit
 ) {
-    OpenEdXButton(
+    OpenEdXPrimaryButton(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 8.dp, vertical = 20.dp),
-        onClick = {
-            findACourseClick()
-        }
-    ) {
-        Text(
-            color = MaterialTheme.appColors.primaryButtonText,
-            text = stringResource(id = R.string.dashboard_find_a_course)
-        )
-    }
+        text = stringResource(id = R.string.dashboard_find_a_course),
+        onClick = { findACourseClick() }
+    )
 }
 
 @Composable

--- a/discovery/src/main/java/org/openedx/discovery/presentation/detail/CourseDetailsFragment.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/detail/CourseDetailsFragment.kt
@@ -83,7 +83,7 @@ import org.openedx.core.domain.model.Media
 import org.openedx.core.ui.AuthButtonsPanel
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.OfflineModeDialog
-import org.openedx.core.ui.OpenEdXButton
+import org.openedx.core.ui.OpenEdXPrimaryButton
 import org.openedx.core.ui.Toolbar
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.isPreview
@@ -488,7 +488,7 @@ private fun CourseDetailNativeContent(
             )
             if (!(enrollmentEnd != null && Date() > enrollmentEnd)) {
                 Spacer(Modifier.height(32.dp))
-                OpenEdXButton(
+                OpenEdXPrimaryButton(
                     modifier = buttonWidth,
                     text = buttonText,
                     onClick = onButtonClick
@@ -565,7 +565,7 @@ private fun CourseDetailNativeContentLandscape(
                 EnrollOverLabel()
                 Spacer(Modifier.height(24.dp))
             } else {
-                OpenEdXButton(
+                OpenEdXPrimaryButton(
                     modifier = buttonWidth,
                     text = buttonText,
                     onClick = onButtonClick

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionAddThreadFragment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionAddThreadFragment.kt
@@ -74,8 +74,8 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.HandleUIMessage
-import org.openedx.core.ui.OpenEdXButton
 import org.openedx.core.ui.OpenEdXOutlinedTextField
+import org.openedx.core.ui.OpenEdXPrimaryButton
 import org.openedx.core.ui.SheetContent
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.isImeVisibleState
@@ -440,7 +440,7 @@ private fun DiscussionAddThreadScreen(
                                 if (isLoading) {
                                     CircularProgressIndicator(color = MaterialTheme.appColors.primary)
                                 } else {
-                                    OpenEdXButton(
+                                    OpenEdXPrimaryButton(
                                         modifier = buttonWidth,
                                         text = if (currentPage == 0) {
                                             stringResource(id = discussionR.string.discussion_create_post)

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsFragment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsFragment.kt
@@ -78,7 +78,7 @@ import org.openedx.core.extension.TextConverter
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.IconText
-import org.openedx.core.ui.OpenEdXOutlinedButton
+import org.openedx.core.ui.OpenEdXPrimaryOutlinedButton
 import org.openedx.core.ui.SheetContent
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.isImeVisibleState
@@ -626,7 +626,7 @@ private fun DiscussionThreadsScreen(
                                                         textAlign = TextAlign.Center
                                                     )
                                                     Spacer(Modifier.height(40.dp))
-                                                    OpenEdXOutlinedButton(
+                                                    OpenEdXPrimaryOutlinedButton(
                                                         modifier = Modifier
                                                             .widthIn(184.dp, Dp.Unspecified),
                                                         text = stringResource(
@@ -652,8 +652,6 @@ private fun DiscussionThreadsScreen(
                                                                 style = MaterialTheme.appTypography.labelLarge
                                                             )
                                                         },
-                                                        borderColor = MaterialTheme.appColors.primary,
-                                                        textColor = MaterialTheme.appColors.primary
                                                     )
                                                 }
                                             }

--- a/profile/src/main/java/org/openedx/profile/presentation/calendar/CalendarAccessDialogFragment.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/calendar/CalendarAccessDialogFragment.kt
@@ -35,8 +35,8 @@ import androidx.fragment.app.DialogFragment
 import org.koin.android.ext.android.inject
 import org.openedx.core.config.Config
 import org.openedx.core.presentation.dialog.DefaultDialogBox
-import org.openedx.core.ui.OpenEdXButton
-import org.openedx.core.ui.OpenEdXOutlinedButton
+import org.openedx.core.ui.OpenEdXPrimaryButton
+import org.openedx.core.ui.OpenEdXPrimaryOutlinedButton
 import org.openedx.core.ui.TextIcon
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
@@ -123,7 +123,7 @@ private fun CalendarAccessDialog(
                 style = MaterialTheme.appTypography.bodyMedium,
                 color = MaterialTheme.appColors.textDark
             )
-            OpenEdXButton(
+            OpenEdXPrimaryButton(
                 modifier = Modifier.fillMaxWidth(),
                 onClick = {
                     onGrantCalendarAccessClick()
@@ -138,12 +138,10 @@ private fun CalendarAccessDialog(
                     )
                 }
             )
-            OpenEdXOutlinedButton(
+            OpenEdXPrimaryOutlinedButton(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = CoreR.string.core_cancel),
-                backgroundColor = MaterialTheme.appColors.background,
-                borderColor = MaterialTheme.appColors.primaryButtonBackground,
-                textColor = MaterialTheme.appColors.primaryButtonBackground,
+                borderColor = MaterialTheme.appColors.primaryButtonBorderedText,
                 onClick = {
                     onCancelClick()
                 }

--- a/profile/src/main/java/org/openedx/profile/presentation/calendar/CalendarAccessDialogFragment.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/calendar/CalendarAccessDialogFragment.kt
@@ -141,7 +141,6 @@ private fun CalendarAccessDialog(
             OpenEdXPrimaryOutlinedButton(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = CoreR.string.core_cancel),
-                borderColor = MaterialTheme.appColors.primaryButtonBorderedText,
                 onClick = {
                     onCancelClick()
                 }

--- a/profile/src/main/java/org/openedx/profile/presentation/calendar/CalendarSetUpView.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/calendar/CalendarSetUpView.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import org.openedx.core.ui.OpenEdXButton
+import org.openedx.core.ui.OpenEdXPrimaryButton
 import org.openedx.core.ui.Toolbar
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.settingsHeaderBackground
@@ -184,7 +184,7 @@ fun CalendarSetUpView(
                                     color = MaterialTheme.appColors.textDark
                                 )
                                 Spacer(modifier = Modifier.height(16.dp))
-                                OpenEdXButton(
+                                OpenEdXPrimaryButton(
                                     modifier = Modifier.fillMaxWidth(fraction = 0.75f),
                                     text = stringResource(id = R.string.profile_set_up_calendar_sync),
                                     onClick = {

--- a/profile/src/main/java/org/openedx/profile/presentation/calendar/CalendarSettingsView.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/calendar/CalendarSettingsView.kt
@@ -266,7 +266,6 @@ fun SyncOptionsButton(
     OpenEdXPrimaryOutlinedButton(
         modifier = Modifier.fillMaxWidth(),
         text = stringResource(R.string.profile_change_sync_options),
-        borderColor = MaterialTheme.appColors.primaryButtonBorderedText,
         onClick = {
             onChangeSyncOptionClick()
         }

--- a/profile/src/main/java/org/openedx/profile/presentation/calendar/CalendarSettingsView.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/calendar/CalendarSettingsView.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.openedx.core.domain.model.CalendarData
 import org.openedx.core.presentation.settings.calendarsync.CalendarSyncState
-import org.openedx.core.ui.OpenEdXOutlinedButton
+import org.openedx.core.ui.OpenEdXPrimaryOutlinedButton
 import org.openedx.core.ui.Toolbar
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.settingsHeaderBackground
@@ -263,12 +263,10 @@ fun CalendarSyncSection(
 fun SyncOptionsButton(
     onChangeSyncOptionClick: () -> Unit
 ) {
-    OpenEdXOutlinedButton(
+    OpenEdXPrimaryOutlinedButton(
         modifier = Modifier.fillMaxWidth(),
         text = stringResource(R.string.profile_change_sync_options),
-        backgroundColor = MaterialTheme.appColors.background,
-        borderColor = MaterialTheme.appColors.primaryButtonBackground,
-        textColor = MaterialTheme.appColors.primaryButtonBackground,
+        borderColor = MaterialTheme.appColors.primaryButtonBorderedText,
         onClick = {
             onChangeSyncOptionClick()
         }

--- a/profile/src/main/java/org/openedx/profile/presentation/calendar/DisableCalendarSyncDialogFragment.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/calendar/DisableCalendarSyncDialogFragment.kt
@@ -36,8 +36,8 @@ import androidx.fragment.app.DialogFragment
 import org.koin.androidx.compose.koinViewModel
 import org.openedx.core.domain.model.CalendarData
 import org.openedx.core.presentation.dialog.DefaultDialogBox
-import org.openedx.core.ui.OpenEdXButton
-import org.openedx.core.ui.OpenEdXOutlinedButton
+import org.openedx.core.ui.OpenEdXPrimaryButton
+import org.openedx.core.ui.OpenEdXPrimaryOutlinedButton
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appShapes
@@ -159,17 +159,15 @@ private fun DisableCalendarSyncDialogView(
                 style = MaterialTheme.appTypography.bodyMedium,
                 color = MaterialTheme.appColors.textDark
             )
-            OpenEdXOutlinedButton(
+            OpenEdXPrimaryOutlinedButton(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = R.string.profile_disable_syncing),
-                backgroundColor = MaterialTheme.appColors.background,
-                borderColor = MaterialTheme.appColors.primaryButtonBackground,
-                textColor = MaterialTheme.appColors.primaryButtonBackground,
+                borderColor = MaterialTheme.appColors.primaryButtonBorderedText,
                 onClick = {
                     onDisableSyncingClick()
                 }
             )
-            OpenEdXButton(
+            OpenEdXPrimaryButton(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = coreR.string.core_cancel),
                 onClick = {

--- a/profile/src/main/java/org/openedx/profile/presentation/calendar/DisableCalendarSyncDialogFragment.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/calendar/DisableCalendarSyncDialogFragment.kt
@@ -162,7 +162,6 @@ private fun DisableCalendarSyncDialogView(
             OpenEdXPrimaryOutlinedButton(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = R.string.profile_disable_syncing),
-                borderColor = MaterialTheme.appColors.primaryButtonBorderedText,
                 onClick = {
                     onDisableSyncingClick()
                 }

--- a/profile/src/main/java/org/openedx/profile/presentation/calendar/NewCalendarDialogFragment.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/calendar/NewCalendarDialogFragment.kt
@@ -216,7 +216,6 @@ private fun NewCalendarDialog(
             OpenEdXPrimaryOutlinedButton(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = CoreR.string.core_cancel),
-                borderColor = MaterialTheme.appColors.primaryButtonBorderedText,
                 onClick = {
                     onCancelClick()
                 }

--- a/profile/src/main/java/org/openedx/profile/presentation/calendar/NewCalendarDialogFragment.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/calendar/NewCalendarDialogFragment.kt
@@ -65,8 +65,8 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import org.koin.androidx.compose.koinViewModel
 import org.openedx.core.presentation.dialog.DefaultDialogBox
-import org.openedx.core.ui.OpenEdXButton
-import org.openedx.core.ui.OpenEdXOutlinedButton
+import org.openedx.core.ui.OpenEdXPrimaryButton
+import org.openedx.core.ui.OpenEdXPrimaryOutlinedButton
 import org.openedx.core.ui.crop
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
@@ -109,7 +109,9 @@ class NewCalendarDialogFragment : DialogFragment() {
                 }
 
                 NewCalendarDialog(
-                    newCalendarDialogType = requireArguments().parcelable<NewCalendarDialogType>(ARG_DIALOG_TYPE)
+                    newCalendarDialogType = requireArguments().parcelable<NewCalendarDialogType>(
+                        ARG_DIALOG_TYPE
+                    )
                         ?: NewCalendarDialogType.CREATE_NEW,
                     onCancelClick = {
                         dismiss()
@@ -211,22 +213,24 @@ private fun NewCalendarDialog(
                 textAlign = TextAlign.Center,
                 color = MaterialTheme.appColors.textDark
             )
-            OpenEdXOutlinedButton(
+            OpenEdXPrimaryOutlinedButton(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = CoreR.string.core_cancel),
-                backgroundColor = MaterialTheme.appColors.background,
-                borderColor = MaterialTheme.appColors.primaryButtonBackground,
-                textColor = MaterialTheme.appColors.primaryButtonBackground,
+                borderColor = MaterialTheme.appColors.primaryButtonBorderedText,
                 onClick = {
                     onCancelClick()
                 }
             )
-            OpenEdXButton(
+            OpenEdXPrimaryButton(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = R.string.profile_begin_syncing),
                 onClick = {
                     onBeginSyncingClick(
-                        calendarTitle.ifEmpty { NewCalendarDialogFragment.getDefaultCalendarTitle(context) },
+                        calendarTitle.ifEmpty {
+                            NewCalendarDialogFragment.getDefaultCalendarTitle(
+                                context
+                            )
+                        },
                         calendarColor
                     )
                 }

--- a/profile/src/main/java/org/openedx/profile/presentation/delete/DeleteProfileFragment.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/delete/DeleteProfileFragment.kt
@@ -57,8 +57,8 @@ import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.openedx.core.R
 import org.openedx.core.ui.HandleUIMessage
-import org.openedx.core.ui.OpenEdXButton
 import org.openedx.core.ui.OpenEdXOutlinedTextField
+import org.openedx.core.ui.OpenEdXPrimaryButton
 import org.openedx.core.ui.Toolbar
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.settingsHeaderBackground
@@ -274,7 +274,7 @@ fun DeleteProfileScreen(
                             errorText = errorText
                         )
                         Spacer(Modifier.height(38.dp))
-                        OpenEdXButton(
+                        OpenEdXPrimaryButton(
                             text = stringResource(id = profileR.string.profile_yes_delete_account),
                             enabled = uiState !is DeleteProfileFragmentUIState.Loading && password.isNotEmpty(),
                             backgroundColor = MaterialTheme.appColors.error,

--- a/profile/src/main/java/org/openedx/profile/presentation/edit/EditProfileFragment.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/edit/EditProfileFragment.kt
@@ -114,6 +114,7 @@ import org.openedx.core.ui.AutoSizeText
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.IconText
+import org.openedx.core.ui.OpenEdXErrorOutlinedButton
 import org.openedx.core.ui.OpenEdXPrimaryButton
 import org.openedx.core.ui.OpenEdXPrimaryOutlinedButton
 import org.openedx.core.ui.SheetContent
@@ -872,8 +873,7 @@ private fun ChangeImageDialog(
                     }
                 )
                 Spacer(Modifier.height(16.dp))
-                OpenEdXPrimaryOutlinedButton(
-                    borderColor = MaterialTheme.appColors.error,
+                OpenEdXErrorOutlinedButton(
                     text = stringResource(id = R.string.profile_remove_photo),
                     onClick = onRemoveImageClick,
                     content = {
@@ -1138,13 +1138,11 @@ private fun LeaveProfile(
                 )
                 Spacer(Modifier.size(40.dp))
                 OpenEdXPrimaryButton(
-                    backgroundColor = MaterialTheme.appColors.primary,
                     text = stringResource(id = R.string.profile_leave),
                     onClick = onLeaveClick
                 )
                 Spacer(Modifier.height(24.dp))
                 OpenEdXPrimaryOutlinedButton(
-                    textColor = MaterialTheme.appColors.textPrimary,
                     text = stringResource(id = R.string.profile_keep_editing),
                     onClick = onDismissRequest
                 )
@@ -1221,7 +1219,6 @@ private fun LeaveProfileLandscape(
                     ) {
                         OpenEdXPrimaryButton(
                             text = stringResource(id = R.string.profile_leave),
-                            backgroundColor = MaterialTheme.appColors.primary,
                             content = {
                                 AutoSizeText(
                                     modifier = Modifier.testTag("txt_leave_profile_dialog_leave"),

--- a/profile/src/main/java/org/openedx/profile/presentation/edit/EditProfileFragment.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/edit/EditProfileFragment.kt
@@ -114,8 +114,8 @@ import org.openedx.core.ui.AutoSizeText
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.IconText
-import org.openedx.core.ui.OpenEdXButton
-import org.openedx.core.ui.OpenEdXOutlinedButton
+import org.openedx.core.ui.OpenEdXPrimaryButton
+import org.openedx.core.ui.OpenEdXPrimaryOutlinedButton
 import org.openedx.core.ui.SheetContent
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.isImeVisibleState
@@ -858,7 +858,7 @@ private fun ChangeImageDialog(
                     color = MaterialTheme.appColors.textPrimary
                 )
                 Spacer(Modifier.height(20.dp))
-                OpenEdXButton(
+                OpenEdXPrimaryButton(
                     text = stringResource(id = R.string.profile_select_from_gallery),
                     onClick = onSelectFromGalleryClick,
                     content = {
@@ -872,9 +872,8 @@ private fun ChangeImageDialog(
                     }
                 )
                 Spacer(Modifier.height(16.dp))
-                OpenEdXOutlinedButton(
+                OpenEdXPrimaryOutlinedButton(
                     borderColor = MaterialTheme.appColors.error,
-                    textColor = MaterialTheme.appColors.textPrimary,
                     text = stringResource(id = R.string.profile_remove_photo),
                     onClick = onRemoveImageClick,
                     content = {
@@ -888,9 +887,7 @@ private fun ChangeImageDialog(
                     }
                 )
                 Spacer(Modifier.height(40.dp))
-                OpenEdXOutlinedButton(
-                    borderColor = MaterialTheme.appColors.textPrimaryVariant,
-                    textColor = MaterialTheme.appColors.textPrimary,
+                OpenEdXPrimaryOutlinedButton(
                     text = stringResource(id = coreR.string.core_cancel),
                     onClick = onCancelClick
                 )
@@ -1140,25 +1137,13 @@ private fun LeaveProfile(
                     textAlign = TextAlign.Center
                 )
                 Spacer(Modifier.size(40.dp))
-                OpenEdXButton(
-                    text = stringResource(id = R.string.profile_leave),
-                    onClick = onLeaveClick,
+                OpenEdXPrimaryButton(
                     backgroundColor = MaterialTheme.appColors.primary,
-                    content = {
-                        Text(
-                            modifier = Modifier
-                                .testTag("txt_leave")
-                                .fillMaxWidth(),
-                            text = stringResource(id = R.string.profile_leave),
-                            color = MaterialTheme.appColors.primaryButtonText,
-                            style = MaterialTheme.appTypography.labelLarge,
-                            textAlign = TextAlign.Center
-                        )
-                    }
+                    text = stringResource(id = R.string.profile_leave),
+                    onClick = onLeaveClick
                 )
                 Spacer(Modifier.height(24.dp))
-                OpenEdXOutlinedButton(
-                    borderColor = MaterialTheme.appColors.textFieldBorder,
+                OpenEdXPrimaryOutlinedButton(
                     textColor = MaterialTheme.appColors.textPrimary,
                     text = stringResource(id = R.string.profile_keep_editing),
                     onClick = onDismissRequest
@@ -1234,7 +1219,7 @@ private fun LeaveProfileLandscape(
                         Modifier.weight(1f),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        OpenEdXButton(
+                        OpenEdXPrimaryButton(
                             text = stringResource(id = R.string.profile_leave),
                             backgroundColor = MaterialTheme.appColors.primary,
                             content = {
@@ -1248,9 +1233,7 @@ private fun LeaveProfileLandscape(
                             onClick = onLeaveClick
                         )
                         Spacer(Modifier.height(16.dp))
-                        OpenEdXOutlinedButton(
-                            borderColor = MaterialTheme.appColors.textFieldBorder,
-                            textColor = MaterialTheme.appColors.textPrimary,
+                        OpenEdXPrimaryOutlinedButton(
                             text = stringResource(id = R.string.profile_keep_editing),
                             onClick = onDismissRequest,
                             content = {

--- a/profile/src/main/java/org/openedx/profile/presentation/manageaccount/compose/ManageAccountView.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/manageaccount/compose/ManageAccountView.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.unit.dp
 import org.openedx.core.R
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.IconText
-import org.openedx.core.ui.OpenEdXOutlinedButton
+import org.openedx.core.ui.OpenEdXPrimaryOutlinedButton
 import org.openedx.core.ui.Toolbar
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.settingsHeaderBackground
@@ -168,15 +168,13 @@ internal fun ManageAccountView(
                                         title = uiState.account.name,
                                         subtitle = uiState.account.email ?: ""
                                     )
-                                    OpenEdXOutlinedButton(
+                                    OpenEdXPrimaryOutlinedButton(
                                         modifier = Modifier
                                             .fillMaxWidth(),
                                         text = stringResource(id = ProfileR.string.profile_edit_profile),
                                         onClick = {
                                             onAction(ManageAccountViewAction.EditAccountClick)
-                                        },
-                                        borderColor = MaterialTheme.appColors.primaryButtonBackground,
-                                        textColor = MaterialTheme.appColors.textAccent
+                                        }
                                     )
                                     Spacer(modifier = Modifier.height(12.dp))
                                     IconText(

--- a/profile/src/main/java/org/openedx/profile/presentation/profile/compose/ProfileView.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/profile/compose/ProfileView.kt
@@ -150,8 +150,6 @@ internal fun ProfileView(
                                         onClick = {
                                             onAction(ProfileViewAction.EditAccountClick)
                                         },
-                                        borderColor = MaterialTheme.appColors.primaryButtonBackground,
-                                        textColor = MaterialTheme.appColors.textAccent
                                     )
                                     Spacer(modifier = Modifier.height(12.dp))
                                 }

--- a/profile/src/main/java/org/openedx/profile/presentation/profile/compose/ProfileView.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/profile/compose/ProfileView.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.openedx.core.R
 import org.openedx.core.ui.HandleUIMessage
-import org.openedx.core.ui.OpenEdXOutlinedButton
+import org.openedx.core.ui.OpenEdXPrimaryOutlinedButton
 import org.openedx.core.ui.Toolbar
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.statusBarsInset
@@ -143,7 +143,7 @@ internal fun ProfileView(
                                         subtitle = "@${uiState.account.username}"
                                     )
                                     ProfileInfoSection(uiState.account)
-                                    OpenEdXOutlinedButton(
+                                    OpenEdXPrimaryOutlinedButton(
                                         modifier = Modifier
                                             .fillMaxWidth(),
                                         text = stringResource(id = org.openedx.profile.R.string.profile_edit_profile),

--- a/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsScreenUI.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsScreenUI.kt
@@ -54,7 +54,7 @@ import org.openedx.core.R
 import org.openedx.core.domain.model.AgreementUrls
 import org.openedx.core.presentation.global.AppData
 import org.openedx.core.system.notifier.app.AppUpgradeEvent
-import org.openedx.core.ui.OpenEdXButton
+import org.openedx.core.ui.OpenEdXPrimaryButton
 import org.openedx.core.ui.Toolbar
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.settingsHeaderBackground
@@ -428,7 +428,7 @@ private fun LogoutDialog(
                     textAlign = TextAlign.Center
                 )
                 Spacer(Modifier.size(36.dp))
-                OpenEdXButton(
+                OpenEdXPrimaryButton(
                     text = stringResource(id = profileR.string.profile_logout),
                     backgroundColor = MaterialTheme.appColors.warning,
                     onClick = onLogoutClick,


### PR DESCRIPTION
### Description

**Standardized button styling system in the app**

- Define styling for button types (primary, secondary, tertiary, error, etc.) to make button styles configurable.
- Update the button color scheme according to the [Mobile App v2.3 [Open edX]](https://www.figma.com/design/iZ56YMjbRMShCCDxqrqRrR/Mobile-App-v2.3-%5BOpen-edX%5D?node-id=12066-291368&node-type=frame&t=50TmZyWmh7yBaZSN-0) button styles.

**Samples**
| Before  | After |
| ------------- | ------------- |
| ![Screenshot_20241204_153214](https://github.com/user-attachments/assets/88d30954-94ac-4ba4-aa75-7027f22ce726) | ![Screenshot_20241204_153203](https://github.com/user-attachments/assets/d2bc5398-10bb-485e-9459-dc49b29c347a) |
| ![Screenshot_20241204_153350](https://github.com/user-attachments/assets/411ba400-4df5-4872-8854-cdaf179281e0) | ![Screenshot_20241204_153559](https://github.com/user-attachments/assets/3796e3cd-9fed-4d28-a61e-03c02e104cb4) |
| ![Screenshot_20241204_153749](https://github.com/user-attachments/assets/98e5b671-b0a9-40f2-b07b-07cb68ce56a7) | ![Screenshot_20241204_153801](https://github.com/user-attachments/assets/d5014554-22e7-4912-9992-dcd65a8a7255) |
