### PR TITLE
fix: crash current must not be NaN during bulk download

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/ui/CourseVideosUI.kt
+++ b/course/src/main/java/org/openedx/course/presentation/ui/CourseVideosUI.kt
@@ -543,7 +543,12 @@ private fun AllVideosDownloadItem(
         )
     }
     if (isDownloadingAllVideos) {
-        val progress = 1 - downloadModelsSize.remainingSize.toFloat() / downloadModelsSize.allSize
+        val progress =
+            if (downloadModelsSize.allSize == 0L) {
+                0f
+            } else {
+                1 - downloadModelsSize.remainingSize.toFloat() / downloadModelsSize.allSize
+            }
 
         val animatedProgress by animateFloatAsState(
             targetValue = progress,


### PR DESCRIPTION
### Description

[LEARNER-10248](https://2u-internal.atlassian.net/browse/LEARNER-10248)

Fix crash of `IllegalArgumentException - current must not be NaN` during bulk download.

- Add validation to ensure that the progress value is not NaN.

**Steps to reproduce (specific courses)**

**Variant-1**
- Open the course named `Quantum Mechanics for Scientists and Engineers 1`
- Click on the video tab and start that bulk download.
- Try to expand the sections from the video tab, that lead the app to the crash.

**Variant-2**
- Open the course named `Quantum Mechanics for Scientists and Engineers 1`
- Click on the video tab and start that bulk download.
- Rapidly click on the arrow icon to expand the `section` from the Home tab, and the action leads the app to the crash.