### PR TITLE
Locked Content Support

### DIFF
--- a/app/src/main/java/org/openedx/app/di/ScreenModule.kt
+++ b/app/src/main/java/org/openedx/app/di/ScreenModule.kt
@@ -293,6 +293,7 @@ val screenModule = module {
             get(),
             get(),
             get(),
+            get(),
         )
     }
     viewModel { (courseId: String, unitId: String) ->

--- a/core/src/main/java/org/openedx/core/data/api/CourseApi.kt
+++ b/core/src/main/java/org/openedx/core/data/api/CourseApi.kt
@@ -12,6 +12,7 @@ import org.openedx.core.data.model.CourseStructureModel
 import org.openedx.core.data.model.EnrollmentStatus
 import org.openedx.core.data.model.HandoutsModel
 import org.openedx.core.data.model.ResetCourseDates
+import org.openedx.core.data.model.SequenceModel
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
@@ -100,4 +101,7 @@ interface CourseApi {
     suspend fun getEnrollmentDetails(
         @Path("course_id") courseId: String,
     ): CourseEnrollmentDetails
+
+    @GET("api/courseware/sequence/{sequence_id}/")
+    suspend fun getSequence(@Path("sequence_id") sequenceId: String): SequenceModel
 }

--- a/core/src/main/java/org/openedx/core/data/model/GatedContentModel.kt
+++ b/core/src/main/java/org/openedx/core/data/model/GatedContentModel.kt
@@ -1,0 +1,27 @@
+package org.openedx.core.data.model
+
+import com.google.gson.annotations.SerializedName
+import org.openedx.core.domain.model.GatedContent
+
+data class GatedContentModel(
+    @SerializedName("prereq_id")
+    val prereqId: String?,
+    @SerializedName("prereq_url")
+    val prereqUrl: String?,
+    @SerializedName("prereq_section_name")
+    val prereqSectionName: String?,
+    @SerializedName("gated")
+    val gated: Boolean,
+    @SerializedName("gated_section_name")
+    val gatedSectionName: String?,
+) {
+    fun mapToDomain(): GatedContent {
+        return GatedContent(
+            prereqId = prereqId,
+            prereqUrl = prereqUrl,
+            prereqSubsectionName = prereqSectionName,
+            gated = gated,
+            gatedSubsectionName = gatedSectionName
+        )
+    }
+}

--- a/core/src/main/java/org/openedx/core/data/model/SequenceModel.kt
+++ b/core/src/main/java/org/openedx/core/data/model/SequenceModel.kt
@@ -1,0 +1,30 @@
+package org.openedx.core.data.model
+
+import com.google.gson.annotations.SerializedName
+import org.openedx.core.domain.model.Subsection
+
+data class SequenceModel(
+    @SerializedName("element_id")
+    val elementId: String,
+    @SerializedName("item_id")
+    val itemId: String,
+    @SerializedName("banner_text")
+    val bannerText: String?,
+    @SerializedName("gated_content")
+    val gatedContentModel: GatedContentModel,
+    @SerializedName("sequence_name")
+    val sequenceName: String,
+    @SerializedName("display_name")
+    val displayName: String,
+) {
+    fun mapToDomain(): Subsection {
+        return Subsection(
+            elementId = elementId,
+            itemId = itemId,
+            bannerText = bannerText,
+            subsectionName = sequenceName,
+            displayName = displayName,
+            gatedContent = gatedContentModel.mapToDomain(),
+        )
+    }
+}

--- a/core/src/main/java/org/openedx/core/domain/model/GatedContent.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/GatedContent.kt
@@ -1,0 +1,13 @@
+package org.openedx.core.domain.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class GatedContent(
+    val prereqId: String?,
+    val prereqUrl: String?,
+    val prereqSubsectionName: String?,
+    val gated: Boolean,
+    val gatedSubsectionName: String?
+) : Parcelable

--- a/core/src/main/java/org/openedx/core/domain/model/Subsection.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/Subsection.kt
@@ -1,0 +1,14 @@
+package org.openedx.core.domain.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class Subsection(
+    val elementId: String,
+    val itemId: String,
+    val bannerText: String?,
+    val gatedContent: GatedContent,
+    val subsectionName: String,
+    val displayName: String
+) : Parcelable

--- a/course/src/main/java/org/openedx/course/data/repository/CourseRepository.kt
+++ b/course/src/main/java/org/openedx/course/data/repository/CourseRepository.kt
@@ -139,4 +139,6 @@ class CourseRepository(
             downloadDao.removeOfflineXBlockProgress(listOf(blockId))
         }
     }
+
+    suspend fun getSequence(sequenceId: String) = api.getSequence(sequenceId).mapToDomain()
 }

--- a/course/src/main/java/org/openedx/course/domain/interactor/CourseInteractor.kt
+++ b/course/src/main/java/org/openedx/course/domain/interactor/CourseInteractor.kt
@@ -82,6 +82,8 @@ class CourseInteractor(
 
     suspend fun removeDownloadModel(id: String) = repository.removeDownloadModel(id)
 
+    suspend fun getSubsection(subsectionId: String) = repository.getSequence(subsectionId)
+
     fun getDownloadModels() = repository.getDownloadModels()
 
     suspend fun getAllDownloadModels() = repository.getAllDownloadModels()

--- a/course/src/main/java/org/openedx/course/presentation/CourseAnalytics.kt
+++ b/course/src/main/java/org/openedx/course/presentation/CourseAnalytics.kt
@@ -78,6 +78,10 @@ enum class CourseAnalyticsEvent(val eventName: String, val biValue: String) {
         "Course:Unit Detail",
         "edx.bi.app.course.unit_detail"
     ),
+    PREREQUISITE(
+        "Course:Prerequisite",
+        "edx.bi.app.course.prerequisite"
+    ),
     VIEW_CERTIFICATE(
         "Course:View Certificate Clicked",
         "edx.bi.app.course.view_certificate.clicked"

--- a/course/src/main/java/org/openedx/course/presentation/section/CourseSectionFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/section/CourseSectionFragment.kt
@@ -4,6 +4,7 @@ import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -17,6 +18,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
@@ -61,6 +63,7 @@ import org.openedx.core.domain.model.BlockCounts
 import org.openedx.core.presentation.course.CourseViewMode
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.HandleUIMessage
+import org.openedx.core.ui.OpenEdXButton
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.statusBarsInset
 import org.openedx.core.ui.theme.OpenEdXTheme
@@ -124,6 +127,15 @@ class CourseSectionFragment : Fragment() {
                             )
                         }
                     },
+                    onGoToPrerequisiteClick = { subSectionId ->
+                        viewModel.goToPrerequisiteSectionClickedEvent(subSectionId)
+                        router.navigateToCourseSubsections(
+                            fm = requireActivity().supportFragmentManager,
+                            courseId = viewModel.courseId,
+                            subSectionId = subSectionId,
+                            mode = CourseViewMode.FULL
+                        )
+                    }
                 )
 
                 LaunchedEffect(rememberSaveable { true }) {
@@ -176,6 +188,7 @@ private fun CourseSectionScreen(
     uiMessage: UIMessage?,
     onBackClick: () -> Unit,
     onItemClick: (Block) -> Unit,
+    onGoToPrerequisiteClick: (String) -> Unit
 ) {
     val scaffoldState = rememberScaffoldState()
     val title = when (uiState) {
@@ -253,6 +266,41 @@ private fun CourseSectionScreen(
                                 contentAlignment = Alignment.Center
                             ) {
                                 CircularProgressIndicator(color = MaterialTheme.appColors.primary)
+                            }
+                        }
+
+                        is CourseSectionUIState.Gated -> {
+                            Column(
+                                modifier = Modifier.fillMaxSize(),
+                                verticalArrangement = Arrangement.Center,
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Image(
+                                    painter = painterResource(id = R.drawable.ic_course_gated),
+                                    contentDescription = "gated",
+                                    modifier = Modifier.size(48.dp)
+                                )
+                                Spacer(modifier = Modifier.height(16.dp))
+                                Text(
+                                    modifier = Modifier
+                                        .padding(horizontal = 16.dp)
+                                        .fillMaxWidth(),
+                                    text = stringResource(
+                                        id = R.string.course_gated_subsection,
+                                        uiState.prereqSubsectionName ?: ""
+                                    ),
+                                    textAlign = TextAlign.Center,
+                                    style = MaterialTheme.appTypography.titleMedium,
+                                    color = MaterialTheme.appColors.textPrimary,
+                                )
+                                Spacer(modifier = Modifier.height(16.dp))
+                                OpenEdXButton(
+                                    text = stringResource(id = R.string.course_go_to_prerequisite_section),
+                                    onClick = {
+                                        onGoToPrerequisiteClick(uiState.prereqId ?: "")
+                                    },
+                                    modifier = Modifier.padding(top = 16.dp)
+                                )
                             }
                         }
 
@@ -361,6 +409,7 @@ private fun CourseSectionScreenPreview() {
             uiMessage = null,
             onBackClick = {},
             onItemClick = {},
+            onGoToPrerequisiteClick = {}
         )
     }
 }
@@ -385,6 +434,29 @@ private fun CourseSectionScreenTabletPreview() {
             uiMessage = null,
             onBackClick = {},
             onItemClick = {},
+            onGoToPrerequisiteClick = {}
+        )
+    }
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO, device = Devices.NEXUS_9)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES, device = Devices.NEXUS_9)
+@Composable
+private fun CourseSectionScreenGatedPreview() {
+    OpenEdXTheme {
+        CourseSectionScreen(
+            windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
+            uiState = CourseSectionUIState.Gated(
+                "Gated Subsection",
+                "Prerequisite Subsection",
+                "Prerequisite Id"
+            ),
+            uiMessage = null,
+            onBackClick = {},
+            onItemClick = {},
+            onGoToPrerequisiteClick = {}
         )
     }
 }

--- a/course/src/main/java/org/openedx/course/presentation/section/CourseSectionUIState.kt
+++ b/course/src/main/java/org/openedx/course/presentation/section/CourseSectionUIState.kt
@@ -9,4 +9,9 @@ sealed class CourseSectionUIState {
         val courseName: String
     ) : CourseSectionUIState()
     data object Loading : CourseSectionUIState()
+    data class Gated(
+        val gatedSubsectionName: String?,
+        val prereqSubsectionName: String?,
+        val prereqId: String?,
+    ) : CourseSectionUIState()
 }

--- a/course/src/main/res/values/strings.xml
+++ b/course/src/main/res/values/strings.xml
@@ -34,6 +34,8 @@
     <string name="course_resume">Resume</string>
     <string name="course_to_proceed">To proceed with \"%s\" press \"Next section\".</string>
     <string name="course_gated_content_label">Some content in this part of the course is locked for upgraded users only.</string>
+    <string name="course_gated_subsection">Content locked. You must complete the prerequisite: \“%s\” to access this content.</string>
+    <string name="course_go_to_prerequisite_section">Go To Prerequisite Section</string>
     <string name="course_change_quality_when_downloading">You cannot change the download video quality when all videos are downloading</string>
     <string name="course_dates_shifted_message">Dates Shifted</string>
 


### PR DESCRIPTION
## Description
Here is what happens when you try to access any section before completing prerequisites in LMS:
![image](https://github.com/user-attachments/assets/3bdb36ec-d168-4765-bee1-e9122ff0dcae)
Here is what happens when you try to access any unit in a gated subsection using the mobile app (the first subsection on the video is a prerequisite to the second):

https://github.com/user-attachments/assets/a97560a3-a773-4462-b78b-a78f1378aa00

---

With the fix from this PR:


https://github.com/user-attachments/assets/09b6fa36-38f7-49e5-96ee-b361a0862f8e

## Testing instructions
1. Setup the latest version of Tutor locally with https://github.com/overhangio/tutor-android. It doesn't matter if it can't build an image. We only need it to create OAuth application.
2. Create and configure a course like this: 
https://github.com/user-attachments/assets/0e943622-0577-4c98-a538-e407f53a9e96
3. Launch the app in the Android emulator. Be sure to make [this](https://gist.github.com/0x29a/c8d651178bbade38cc24f3c23a64dae6) and [this](https://gist.github.com/0x29a/2f8e19aa8619c8b966d415a1cc97cc0b) local changes to allow it to connect to a local Tutor instance.
4. Run `./adb reverse tcp:8000 tcp:8000` from `~/Android/Sdk/platform-tools` (if you're on Linux) directory to allow your virtual device communicate with the Tutor instance.
5. Replicate the behavior from the "after.mp4" video above in the description.