### PR TITLE
feat: [FC-0078] AllEnrolledCoursesView and DashboardGalleryView tablet layout paddings

### DIFF
--- a/dashboard/src/main/java/org/openedx/courses/presentation/AllEnrolledCoursesView.kt
+++ b/dashboard/src/main/java/org/openedx/courses/presentation/AllEnrolledCoursesView.kt
@@ -230,7 +230,7 @@ private fun AllEnrolledCoursesView(
         val contentWidth by remember(key1 = windowSize) {
             mutableStateOf(
                 windowSize.windowSizeValue(
-                    expanded = Modifier.widthIn(Dp.Unspecified, 650.dp),
+                    expanded = Modifier.widthIn(Dp.Unspecified, 560.dp),
                     compact = Modifier.fillMaxWidth(),
                 )
             )
@@ -274,7 +274,9 @@ private fun AllEnrolledCoursesView(
                             Header(
                                 modifier = Modifier
                                     .padding(
-                                        start = contentPaddings.calculateStartPadding(layoutDirection),
+                                        start = contentPaddings.calculateStartPadding(
+                                            layoutDirection
+                                        ),
                                         end = contentPaddings.calculateEndPadding(layoutDirection)
                                     ),
                                 onSearchClick = {
@@ -305,50 +307,52 @@ private fun AllEnrolledCoursesView(
 
                                 !state.courses.isNullOrEmpty() -> {
                                     Box(
-                                        modifier = Modifier
-                                            .fillMaxSize()
-                                            .padding(contentPaddings),
-                                        contentAlignment = Alignment.Center
+                                        modifier = Modifier.fillMaxSize(),
+                                        contentAlignment = Alignment.TopCenter
                                     ) {
-                                        Column(
-                                            modifier = Modifier.fillMaxWidth(),
-                                            horizontalAlignment = Alignment.CenterHorizontally
-                                        ) {
-                                            LazyVerticalGrid(
-                                                modifier = Modifier
-                                                    .fillMaxHeight(),
-                                                state = scrollState,
-                                                columns = GridCells.Fixed(columns),
-                                                verticalArrangement = Arrangement.spacedBy(12.dp),
-                                                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                                                content = {
-                                                    items(state.courses) { course ->
-                                                        CourseItem(
-                                                            course = course,
-                                                            apiHostUrl = apiHostUrl,
-                                                            onClick = {
-                                                                onAction(AllEnrolledCoursesAction.OpenCourse(it))
-                                                            }
-                                                        )
-                                                    }
-                                                    item(span = { GridItemSpan(columns) }) {
-                                                        if (state.canLoadMore) {
-                                                            Box(
-                                                                modifier = Modifier
-                                                                    .fillMaxWidth()
-                                                                    .height(180.dp),
-                                                                contentAlignment = Alignment.Center
-                                                            ) {
-                                                                CircularProgressIndicator(
-                                                                    color = MaterialTheme.appColors.primary
+                                        LazyVerticalGrid(
+                                            modifier = Modifier
+                                                .fillMaxHeight(),
+                                            state = scrollState,
+                                            columns = GridCells.Fixed(columns),
+                                            verticalArrangement = Arrangement.spacedBy(12.dp),
+                                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                            contentPadding = contentPaddings,
+                                            content = {
+                                                items(state.courses) { course ->
+                                                    CourseItem(
+                                                        course = course,
+                                                        apiHostUrl = apiHostUrl,
+                                                        onClick = {
+                                                            onAction(
+                                                                AllEnrolledCoursesAction.OpenCourse(
+                                                                    it
                                                                 )
-                                                            }
+                                                            )
+                                                        }
+                                                    )
+                                                }
+                                                item(span = { GridItemSpan(columns) }) {
+                                                    if (state.canLoadMore) {
+                                                        Box(
+                                                            modifier = Modifier
+                                                                .fillMaxWidth()
+                                                                .height(180.dp),
+                                                            contentAlignment = Alignment.Center
+                                                        ) {
+                                                            CircularProgressIndicator(
+                                                                color = MaterialTheme.appColors.primary
+                                                            )
                                                         }
                                                     }
                                                 }
+                                            }
+                                        )
+                                        if (scrollState.shouldLoadMore(
+                                                firstVisibleIndex,
+                                                LOAD_MORE_THRESHOLD
                                             )
-                                        }
-                                        if (scrollState.shouldLoadMore(firstVisibleIndex, LOAD_MORE_THRESHOLD)) {
+                                        ) {
                                             onAction(AllEnrolledCoursesAction.EndOfPage)
                                         }
                                     }

--- a/downloads/src/main/java/org/openedx/downloads/presentation/download/DownloadsViewModel.kt
+++ b/downloads/src/main/java/org/openedx/downloads/presentation/download/DownloadsViewModel.kt
@@ -4,7 +4,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.School
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -171,7 +170,7 @@ class DownloadsViewModel(
     }
 
     private fun fetchDownloads(refresh: Boolean) {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             updateLoadingState(isLoading = !refresh, isRefreshing = refresh)
             interactor.getDownloadCoursesPreview(refresh)
                 .onCompletion {

--- a/downloads/src/test/java/org/openedx/downloads/DownloadsViewModelTest.kt
+++ b/downloads/src/test/java/org/openedx/downloads/DownloadsViewModelTest.kt
@@ -265,6 +265,7 @@ class DownloadsViewModelTest {
             workerController,
             downloadHelper
         )
+        advanceUntilIdle()
         val fragmentManager = mockk<FragmentManager>(relaxed = true)
         viewModel.downloadCourse(fragmentManager, "course1")
         advanceUntilIdle()


### PR DESCRIPTION
- Added padding to the Learn screen.
- Updated the padding on the All Enrolled Courses screen for consistency with other screens.

|BEFORE|AFTER|
|--------|----------|
|<img width="474" alt="Screenshot 2025-03-20 at 18 20 46" src="https://github.com/user-attachments/assets/416c011d-b0ee-4634-8dd6-a78ed451583e" />|<img width="455" alt="Screenshot 2025-03-20 at 18 16 56" src="https://github.com/user-attachments/assets/6cc6c39a-34e3-4832-a3e2-d79645f9e20f" />|
|<img width="347" alt="Screenshot 2025-03-20 at 18 19 32" src="https://github.com/user-attachments/assets/2bf988ab-27a2-4141-aed8-3974aeb6f82e" />|<img width="347" alt="Screenshot 2025-03-20 at 18 18 38" src="https://github.com/user-attachments/assets/612ea62b-05d8-4fd2-ac81-50b92b7caa35" />|


