### PR TITLE
fix: issue to load the video through chrome-cast device

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/EncodedVideoUnitViewModel.kt
@@ -106,6 +106,7 @@ class EncodedVideoUnitViewModel(
         CastContext.getSharedInstance(context, executor).addOnCompleteListener {
             it.result?.let { castContext ->
                 castPlayer = CastPlayer(castContext)
+                isUpdatedMutable.value = true
             }
         }
     }

--- a/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/video/VideoUnitViewModel.kt
@@ -40,9 +40,9 @@ open class VideoUnitViewModel(
     val currentVideoTime: LiveData<Long>
         get() = _currentVideoTime
 
-    private val _isUpdated = MutableLiveData(true)
+    protected val isUpdatedMutable = MutableLiveData(true)
     val isUpdated: LiveData<Boolean>
-        get() = _isUpdated
+        get() = isUpdatedMutable
 
     private val _currentIndex = MutableStateFlow(0)
     val currentIndex = _currentIndex.asStateFlow()
@@ -63,9 +63,9 @@ open class VideoUnitViewModel(
         viewModelScope.launch {
             notifier.notifier.collect {
                 if (it is CourseVideoPositionChanged && videoUrl == it.videoUrl) {
-                    _isUpdated.value = false
+                    isUpdatedMutable.value = false
                     _currentVideoTime.value = it.videoTime
-                    _isUpdated.value = true
+                    isUpdatedMutable.value = true
                     isPlaying = it.isPlaying
                 } else if (it is CourseSubtitleLanguageChanged) {
                     transcriptLanguage = it.value


### PR DESCRIPTION
### Description

 - Fix the issue by loading the video through the Chrome-cast device.
- This issue arises due to race conditions between the `setSessionAvailabilityListener` and `castPlayer` initialization.

**Steps to Reproduce:**

- Load the edX app 
- Connect the mobile device with the chrome-cast 
- After the device is connected successfully, try to play any video through chrome-cast
- Notice the video will play on the device instead of the LCD
