### PR TITLE
fix: ProgressBarRangeInfo IllegalArgumentException

### DIFF
--- a/core/src/main/java/org/openedx/core/domain/model/Progress.kt
+++ b/core/src/main/java/org/openedx/core/domain/model/Progress.kt
@@ -3,6 +3,7 @@ package org.openedx.core.domain.model
 import android.os.Parcelable
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
+import org.openedx.core.extension.safeDivBy
 
 @Parcelize
 data class Progress(
@@ -11,11 +12,7 @@ data class Progress(
 ) : Parcelable {
 
     @IgnoredOnParcel
-    val value: Float = try {
-        assignmentsCompleted.toFloat() / totalAssignmentsCount.toFloat()
-    } catch (_: ArithmeticException) {
-        0f
-    }
+    val value: Float = assignmentsCompleted.toFloat().safeDivBy(totalAssignmentsCount.toFloat())
 
     companion object {
         val DEFAULT_PROGRESS = Progress(0, 0)

--- a/core/src/main/java/org/openedx/core/extension/FloatExt.kt
+++ b/core/src/main/java/org/openedx/core/extension/FloatExt.kt
@@ -1,0 +1,19 @@
+package org.openedx.core.extension
+
+/**
+ * Safely divides this Float by [divisor], returning 0f if:
+ *  - [divisor] is zero,
+ *  - the result is NaN.
+ *
+ * Workaround for accessibility issue:
+ * https://github.com/openedx/openedx-app-android/issues/442
+ */
+fun Float.safeDivBy(divisor: Float): Float = try {
+    var result = this / divisor
+    if (result.isNaN()) {
+        result = 0f
+    }
+    result
+} catch (_: ArithmeticException) {
+    0f
+}

--- a/course/src/main/java/org/openedx/course/presentation/offline/CourseOfflineViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/offline/CourseOfflineViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 import org.openedx.core.BlockType
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.Block
+import org.openedx.core.extension.safeDivBy
 import org.openedx.core.module.DownloadWorkerController
 import org.openedx.core.module.db.DownloadDao
 import org.openedx.core.module.db.DownloadModel
@@ -187,12 +188,12 @@ class CourseOfflineViewModel(
         completedDownloads: List<DownloadModel>,
         downloadedBlocks: List<Block>
     ) {
-        val downloadedSize = getFilesSize(downloadedBlocks)
+        val downloadedSize = getFilesSize(downloadedBlocks).toFloat()
         val realDownloadedSize = completedDownloads.sumOf { it.size }
         val largestDownloads = completedDownloads
             .sortedByDescending { it.size }
             .take(n = 5)
-        val progressBarValue = downloadedSize.toFloat() / totalDownloadableSize.toFloat()
+        val progressBarValue = downloadedSize.safeDivBy(totalDownloadableSize.toFloat())
         val readyToDownloadSize = if (progressBarValue >= 1) {
             0
         } else {

--- a/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
+++ b/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
@@ -84,6 +84,7 @@ import org.openedx.core.domain.model.AssignmentProgress
 import org.openedx.core.domain.model.Block
 import org.openedx.core.domain.model.BlockCounts
 import org.openedx.core.domain.model.CourseDatesBannerInfo
+import org.openedx.core.extension.safeDivBy
 import org.openedx.core.module.db.DownloadModel
 import org.openedx.core.module.db.DownloadedState
 import org.openedx.core.module.db.FileType
@@ -260,11 +261,7 @@ fun OfflineQueueCard(
                 maxLines = 1
             )
 
-            val progress = if (progressSize == 0L) {
-                0f
-            } else {
-                progressValue.toFloat() / progressSize
-            }
+            val progress = progressValue.toFloat().safeDivBy(progressSize.toFloat())
             LinearProgressIndicator(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/dashboard/src/main/java/org/openedx/courses/presentation/AllEnrolledCoursesView.kt
+++ b/dashboard/src/main/java/org/openedx/courses/presentation/AllEnrolledCoursesView.kt
@@ -435,16 +435,11 @@ fun CourseItem(
                         .fillMaxWidth()
                         .height(90.dp)
                 )
-                val progress: Float = try {
-                    course.progress.assignmentsCompleted.toFloat() / course.progress.totalAssignmentsCount.toFloat()
-                } catch (_: ArithmeticException) {
-                    0f
-                }
                 LinearProgressIndicator(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(8.dp),
-                    progress = progress,
+                    progress = course.progress.value,
                     color = MaterialTheme.appColors.primary,
                     backgroundColor = MaterialTheme.appColors.divider
                 )

--- a/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryView.kt
+++ b/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryView.kt
@@ -734,17 +734,11 @@ private fun PrimaryCourseCaption(
             contentScale = ContentScale.Crop,
             modifier = imageModifier,
         )
-        val progress: Float = try {
-            primaryCourse.progress.assignmentsCompleted.toFloat() /
-                    primaryCourse.progress.totalAssignmentsCount.toFloat()
-        } catch (_: ArithmeticException) {
-            0f
-        }
         LinearProgressIndicator(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(8.dp),
-            progress = progress,
+            progress = primaryCourse.progress.value,
             color = MaterialTheme.appColors.primary,
             backgroundColor = MaterialTheme.appColors.divider
         )

--- a/downloads/src/main/java/org/openedx/downloads/presentation/download/DownloadsScreen.kt
+++ b/downloads/src/main/java/org/openedx/downloads/presentation/download/DownloadsScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import org.openedx.core.domain.model.DownloadCoursePreview
+import org.openedx.core.extension.safeDivBy
 import org.openedx.core.module.db.DownloadModel
 import org.openedx.core.module.db.DownloadedState
 import org.openedx.core.module.db.DownloadedState.LOADING_COURSE_STRUCTURE
@@ -285,11 +286,7 @@ private fun CourseItem(
         .sumOf { it.size }
     val availableSize = downloadCoursePreview.totalSize - downloadedSize
     val availableSizeString = availableSize.toFileSize(space = false, round = 1)
-    val progress: Float = try {
-        downloadedSize.toFloat() / downloadCoursePreview.totalSize.toFloat()
-    } catch (_: ArithmeticException) {
-        0f
-    }
+    val progress = downloadedSize.toFloat().safeDivBy(downloadCoursePreview.totalSize.toFloat())
     Card(
         modifier = modifier
             .fillMaxWidth(),


### PR DESCRIPTION
This pull request addresses the critical issue https://github.com/openedx/openedx-app-android/issues/442, which crashes the app when the screen reader is turned on.

![Image](https://github.com/user-attachments/assets/61659189-bf29-4cbe-9795-ca4995b8d12e)

This PR adds a check to the progress division passed to `LinearProgressIndicator` because `LinearProgressIndicator` can handle `NaN`, but `Compose Semantics` cannot, which leads to an error.