### PR TITLE
fix: [FC-0078] fetch future course dates for calendar

### DIFF
--- a/core/src/main/java/org/openedx/core/data/api/CourseApi.kt
+++ b/core/src/main/java/org/openedx/core/data/api/CourseApi.kt
@@ -61,7 +61,10 @@ interface CourseApi {
     )
 
     @GET("/api/course_home/v1/dates/{course_id}")
-    suspend fun getCourseDates(@Path("course_id") courseId: String): CourseDates
+    suspend fun getCourseDates(
+        @Path("course_id") courseId: String,
+        @Query("allow_not_started_courses") allowNotStartedCourses: Boolean = true
+    ): CourseDates
 
     @POST("/api/course_experience/v1/reset_course_deadlines")
     suspend fun resetCourseDates(@Body courseBody: Map<String, String>): ResetCourseDates


### PR DESCRIPTION
Allow learners to sync course dates for courses that have yet to start so they can receive a calendar notification when the course starts.

API response before fix:
<img width="725" alt="before" src="https://github.com/user-attachments/assets/fa80297a-14be-451f-8d4c-d0bd3218e233" />

API response after fix:
<img width="725" alt="after" src="https://github.com/user-attachments/assets/5012fd0a-b9d2-4177-86ce-7701ce240058" />
