### PR TITLE
chore: bump foundation version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -138,7 +138,7 @@ dependencies {
     implementation "com.braze:android-sdk-ui:30.2.0"
 
     // Plugins
-    implementation("com.github.openedx:openedx-app-firebase-analytics-android:1.0.0")
+    implementation("com.github.openedx:openedx-app-firebase-analytics-android:1.0.1")
 
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -117,7 +117,7 @@ dependencies {
     api "net.lingala.zip4j:zip4j:$zip_version"
 
     //  OpenEdx libs
-    api("com.github.openedx:openedx-app-foundation-android:1.0.0")
+    api("com.github.openedx:openedx-app-foundation-android:1.0.1")
 
     // Preview
     debugApi "androidx.compose.ui:ui-tooling:$compose_ui_tooling"


### PR DESCRIPTION
This PR bumps the dependency versions for the two Open edX Android libraries:

| Dependency | Old version | New version |
| ------------- | ------------- | ------------- | 
| com.github.openedx:openedx-app-foundation-android  | 1.0.0  | 1.0.1 |
| com.github.openedx:openedx-app-firebase-analytics-android | 1.0.0  | 1.0.1 |

The latest releases of both libraries include [a critical fix for the file-handling bug](https://github.com/openedx/openedx-app-foundation-android/pull/16) that could cause crashes or incorrect paths when reading/writing files.