### PR TITLE
Fix: Logout video removing

### DIFF
--- a/core/src/main/java/org/openedx/core/module/download/AbstractDownloader.kt
+++ b/core/src/main/java/org/openedx/core/module/download/AbstractDownloader.kt
@@ -73,6 +73,7 @@ abstract class AbstractDownloader : KoinComponent {
     private fun closeResources() {
         fos?.close()
         input?.close()
+        currentDownloadingFilePath = null
     }
 
     suspend fun cancelDownloading() {


### PR DESCRIPTION
Fixed removing video after user logs out. 

`AbstractDownloader` kept a reference to the last file so it could delete incomplete downloads, but it didn’t clear that reference after a file was successfully downloaded, which caused the most recently downloaded file to be deleted on logout.

`SettingsViewModel#logout() -> WorkerController#removeModels() -> FileDownloader#cancelDownloading()`

