### PR TITLE
Memory Leak Fix: ViewPager2 Fragment Management

### DIFF
--- a/core/src/main/java/org/openedx/core/adapter/NavigationFragmentAdapter.kt
+++ b/core/src/main/java/org/openedx/core/adapter/NavigationFragmentAdapter.kt
@@ -5,13 +5,13 @@ import androidx.viewpager2.adapter.FragmentStateAdapter
 
 class NavigationFragmentAdapter(fragment: Fragment) : FragmentStateAdapter(fragment) {
 
-    private val fragments = ArrayList<Fragment>()
+    private val fragmentFactories = ArrayList<() -> Fragment>()
 
-    override fun getItemCount(): Int = fragments.size
+    override fun getItemCount(): Int = fragmentFactories.size
 
-    override fun createFragment(position: Int): Fragment = fragments[position]
+    override fun createFragment(position: Int): Fragment = fragmentFactories[position].invoke()
 
-    fun addFragment(fragment: Fragment) {
-        fragments.add(fragment)
+    fun addFragment(fragmentFactory: () -> Fragment) {
+        fragmentFactories.add(fragmentFactory)
     }
 }

--- a/dashboard/src/main/java/org/openedx/learn/presentation/LearnFragment.kt
+++ b/dashboard/src/main/java/org/openedx/learn/presentation/LearnFragment.kt
@@ -91,8 +91,8 @@ class LearnFragment : Fragment(R.layout.fragment_learn) {
         binding.viewPager.offscreenPageLimit = 2
 
         adapter = NavigationFragmentAdapter(this).apply {
-            addFragment(viewModel.getDashboardFragment)
-            addFragment(viewModel.getProgramFragment)
+            addFragment { viewModel.getDashboardFragment }
+            addFragment { viewModel.getProgramFragment }
         }
         binding.viewPager.adapter = adapter
         binding.viewPager.setUserInputEnabled(false)


### PR DESCRIPTION
**Problem**
Memory leaks detected across all MainFragment pager screens (LearnFragment, ProgramFragment, NativeDiscoveryFragment, DashboardGalleryFragment, DownloadsFragment, ProfileFragment) due to improper fragment lifecycle management in ViewPager2.

**Root Cause**
NavigationFragmentAdapter was storing strong references to Fragment instances in ArrayList<Fragment>, preventing garbage collection when fragments were destroyed.

**Changes**
NavigationFragmentAdapter: Use fragment factories instead of storing instances
MainFragment: Updated to use factory pattern and added adapter cleanup
LearnFragment: Applied same pattern with proper cleanup

**Benefits**
✅ Eliminates memory leaks across all pager screens
✅ Proper fragment lifecycle management
✅ Lazy fragment creation (only when needed)
✅ Better performance and memory usage

**Testing**
Memory profiler shows no more leaks in MainFragment pager screens.

|BEFORE|AFTER|
|-------|--------|
|<img width="504" height="248" alt="Screenshot 2025-07-31 at 17 55 34" src="https://github.com/user-attachments/assets/0a58015a-9771-4e9d-8945-4fba37501805" />|<img width="593" height="240" alt="Screenshot 2025-07-31 at 17 57 19" src="https://github.com/user-attachments/assets/dfcbe00e-da6a-49d4-9f3e-bb9eb71b712e" />|
