### PR TITLE
feat: dependencies upgrade

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,9 +91,11 @@ android {
         sourceCompatibility java_version
         targetCompatibility java_version
     }
-    kotlinOptions {
-        jvmTarget = java_version
-        freeCompilerArgs = List.of("-Xstring-concat=inline")
+    kotlin {
+        compilerOptions {
+            jvmTarget = jvm_target_version
+            freeCompilerArgs = ['-XXLanguage:+PropertyParamAnnotationDefaultTargetMode']
+        }
     }
     buildFeatures {
         viewBinding true

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -69,3 +69,7 @@
 -dontwarn org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter
 -dontwarn com.android.billingclient.api.BillingClientStateListener
 -dontwarn com.android.billingclient.api.PurchasesUpdatedListener
+-dontwarn com.google.crypto.tink.subtle.XChaCha20Poly1305
+-dontwarn net.jcip.annotations.GuardedBy
+-dontwarn net.jcip.annotations.Immutable
+-dontwarn net.jcip.annotations.ThreadSafe

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -41,8 +41,11 @@ android {
         sourceCompatibility java_version
         targetCompatibility java_version
     }
-    kotlinOptions {
-        jvmTarget = java_version
+    kotlin {
+        compilerOptions {
+            jvmTarget = jvm_target_version
+            freeCompilerArgs = ['-XXLanguage:+PropertyParamAnnotationDefaultTargetMode']
+        }
     }
     buildFeatures {
         viewBinding true

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import org.edx.builder.ConfigHelper
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 import java.util.regex.Matcher
 import java.util.regex.Pattern
@@ -7,21 +8,21 @@ import java.util.regex.Pattern
 buildscript {
     ext {
         // Plugin versions
-        android_gradle_plugin_version = '8.12.0'
+        android_gradle_plugin_version = '8.12.2'
         google_services_version = '4.4.3'
         firebase_crashlytics_version = '3.0.6'
-        ksp_version = '2.0.0-1.0.24'
+        ksp_version = '2.2.10-2.0.2'
 
         //Depends on versions in OEXFoundation
-        kotlin_version = '2.0.0'
-        room_version = '2.6.1'
-        detekt_version = '1.23.7'
+        kotlin_version = '2.2.10'
+        room_version = '2.7.2'
+        detekt_version = '1.23.8'
 
         // Library versions
         media3_version = "1.8.0"
         youtubeplayer_version = "11.1.0"
         firebase_version = "33.0.0"
-        jsoup_version = '1.21.1'
+        jsoup_version = '1.21.2'
         in_app_review = '2.0.2'
         extented_spans_version = "1.4.0"
         zip_version = '2.11.5'
@@ -31,7 +32,7 @@ buildscript {
         play_services_ads_identifier_version = '18.2.0'
         install_referrer_version = '2.2'
         snakeyaml_version = '2.4'
-        openedx_foundation_version = '1.0.1'
+        openedx_foundation_version = '1.0.2'
         openedx_firebase_analytics_version = '1.0.1'
         braze_sdk_version = '37.0.0'
 
@@ -84,6 +85,7 @@ ext {
     target_sdk_version = 36
     min_sdk_version = 24
     java_version = JavaVersion.VERSION_17
+    jvm_target_version = JvmTarget.JVM_17
 
     configHelper = new ConfigHelper(projectDir, getCurrentFlavor())
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -79,11 +79,12 @@ android {
         sourceCompatibility java_version
         targetCompatibility java_version
     }
-    kotlinOptions {
-        jvmTarget = java_version
-        freeCompilerArgs = List.of("-Xstring-concat=inline")
+    kotlin {
+        compilerOptions {
+            jvmTarget = jvm_target_version
+            freeCompilerArgs = ['-XXLanguage:+PropertyParamAnnotationDefaultTargetMode']
+        }
     }
-
     buildFeatures {
         viewBinding true
         compose true

--- a/core/src/main/java/org/openedx/core/ui/theme/Theme.kt
+++ b/core/src/main/java/org/openedx/core/ui/theme/Theme.kt
@@ -1,7 +1,7 @@
 package org.openedx.core.ui.theme
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.LocalOverscrollConfiguration
+import androidx.compose.foundation.LocalOverscrollFactory
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.darkColors
@@ -210,7 +210,7 @@ fun OpenEdXTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composabl
         shapes = LocalShapes.current.material,
     ) {
         CompositionLocalProvider(
-            LocalOverscrollConfiguration provides null,
+            LocalOverscrollFactory provides null,
             content = content
         )
     }

--- a/course/build.gradle
+++ b/course/build.gradle
@@ -28,8 +28,11 @@ android {
         sourceCompatibility java_version
         targetCompatibility java_version
     }
-    kotlinOptions {
-        jvmTarget = java_version
+    kotlin {
+        compilerOptions {
+            jvmTarget = jvm_target_version
+            freeCompilerArgs = ['-XXLanguage:+PropertyParamAnnotationDefaultTargetMode']
+        }
     }
 
     buildFeatures {

--- a/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/unit/container/CourseUnitContainerFragment.kt
@@ -169,7 +169,7 @@ class CourseUnitContainerFragment : Fragment(R.layout.fragment_course_unit_conta
     }
 
     private fun setupMediaRouteButton() {
-        binding.mediaRouteButton.setAlwaysVisible(true)
+        binding.mediaRouteButton.visibility = View.VISIBLE
         CastButtonFactory.setUpMediaRouteButton(requireContext(), binding.mediaRouteButton)
     }
 

--- a/dashboard/build.gradle
+++ b/dashboard/build.gradle
@@ -27,8 +27,11 @@ android {
         sourceCompatibility java_version
         targetCompatibility java_version
     }
-    kotlinOptions {
-        jvmTarget = java_version
+    kotlin {
+        compilerOptions {
+            jvmTarget = jvm_target_version
+            freeCompilerArgs = ['-XXLanguage:+PropertyParamAnnotationDefaultTargetMode']
+        }
     }
 
     buildFeatures {

--- a/discovery/build.gradle
+++ b/discovery/build.gradle
@@ -29,8 +29,11 @@ android {
         sourceCompatibility java_version
         targetCompatibility java_version
     }
-    kotlinOptions {
-        jvmTarget = java_version
+    kotlin {
+        compilerOptions {
+            jvmTarget = jvm_target_version
+            freeCompilerArgs = ['-XXLanguage:+PropertyParamAnnotationDefaultTargetMode']
+        }
     }
 
     buildFeatures {

--- a/discussion/build.gradle
+++ b/discussion/build.gradle
@@ -27,8 +27,11 @@ android {
         sourceCompatibility java_version
         targetCompatibility java_version
     }
-    kotlinOptions {
-        jvmTarget = java_version
+    kotlin {
+        compilerOptions {
+            jvmTarget = jvm_target_version
+            freeCompilerArgs = ['-XXLanguage:+PropertyParamAnnotationDefaultTargetMode']
+        }
     }
 
     buildFeatures {

--- a/downloads/build.gradle
+++ b/downloads/build.gradle
@@ -29,8 +29,11 @@ android {
         sourceCompatibility java_version
         targetCompatibility java_version
     }
-    kotlinOptions {
-        jvmTarget = java_version
+    kotlin {
+        compilerOptions {
+            jvmTarget = jvm_target_version
+            freeCompilerArgs = ['-XXLanguage:+PropertyParamAnnotationDefaultTargetMode']
+        }
     }
 
     buildFeatures {

--- a/profile/build.gradle
+++ b/profile/build.gradle
@@ -27,8 +27,11 @@ android {
         sourceCompatibility java_version
         targetCompatibility java_version
     }
-    kotlinOptions {
-        jvmTarget = java_version
+    kotlin {
+        compilerOptions {
+            jvmTarget = jvm_target_version
+            freeCompilerArgs = ['-XXLanguage:+PropertyParamAnnotationDefaultTargetMode']
+        }
     }
 
     buildFeatures {

--- a/whatsnew/build.gradle
+++ b/whatsnew/build.gradle
@@ -27,9 +27,11 @@ android {
         sourceCompatibility java_version
         targetCompatibility java_version
     }
-    kotlinOptions {
-        jvmTarget = java_version
-        freeCompilerArgs = List.of("-Xstring-concat=inline")
+    kotlin {
+        compilerOptions {
+            jvmTarget = jvm_target_version
+            freeCompilerArgs = ['-XXLanguage:+PropertyParamAnnotationDefaultTargetMode']
+        }
     }
 
     buildFeatures {


### PR DESCRIPTION
This PR upgrades multiple dependencies and updates the Kotlin compiler configuration across the Open edX Android app modules.

🔧 Dependencies Upgraded
Android Gradle Plugin: 8.12.0 → 8.12.2
Kotlin: 2.0.0 → 2.2.10 (major version upgrade)
KSP: 2.0.0-1.0.24 → 2.2.10-2.0.2
Detekt: 1.23.7 → 1.23.8
Room: 2.6.1 → 2.7.2
JSoup: 1.21.1 → 1.21.2
Open edX Foundation: 1.0.1 → 1.0.2

🚀 Kotlin Compiler Updates
Updated Kotlin compiler configuration across all modules to use the new syntax:
Replaced deprecated kotlinOptions with kotlin.compilerOptions
Updated JVM target to use jvm_target_version constant
Changed compiler arguments from -Xstring-concat=inline to -XXLanguage:+PropertyParamAnnotationDefaultTargetMode (according new kotlin feature [KT-73255](https://youtrack.jetbrains.com/issue/KT-73255))

🛡️ ProGuard Rules Updates
Added new ProGuard rules for:
Google Crypto Tink library (XChaCha20Poly1305)
JCIP annotations
