### PR TITLE
fix: Hide download size for videos reporting size 0

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/offline/CourseOfflineScreen.kt
+++ b/course/src/main/java/org/openedx/course/presentation/offline/CourseOfflineScreen.kt
@@ -155,13 +155,17 @@ private fun CourseOfflineUI(
                         } else {
                             NoDownloadableBlocksProgress()
                         }
-                        if (uiState.progressBarValue != 1f && !uiState.isDownloading && hasInternetConnection) {
+                        if (
+                            uiState.progressBarValue != 1f &&
+                            !uiState.isDownloading &&
+                            hasInternetConnection &&
+                            !uiState.isAllDownloaded
+                        ) {
                             Spacer(modifier = Modifier.height(20.dp))
                             OpenEdXButton(
                                 text = stringResource(R.string.core_download_all),
                                 backgroundColor = MaterialTheme.appColors.secondaryButtonBackground,
                                 onClick = onDownloadAllClick,
-                                enabled = uiState.isHaveDownloadableBlocks,
                                 content = {
                                     val textColor = if (uiState.isHaveDownloadableBlocks) {
                                         MaterialTheme.appColors.primaryButtonText
@@ -365,15 +369,17 @@ private fun DownloadProgress(
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Text(
-                text = uiState.downloadedSize,
+                text = uiState.downloadedSize.toFileSize(1, false),
                 style = MaterialTheme.appTypography.titleLarge,
                 color = MaterialTheme.appColors.successGreen
             )
-            Text(
-                text = uiState.readyToDownloadSize,
-                style = MaterialTheme.appTypography.titleLarge,
-                color = MaterialTheme.appColors.textDark
-            )
+            if (uiState.readyToDownloadSize > 0) {
+                Text(
+                    text = uiState.readyToDownloadSize.toFileSize(1, false),
+                    style = MaterialTheme.appTypography.titleLarge,
+                    color = MaterialTheme.appColors.textDark
+                )
+            }
         }
         Spacer(modifier = Modifier.height(4.dp))
         Row(
@@ -388,20 +394,22 @@ private fun DownloadProgress(
                 color = MaterialTheme.appColors.successGreen,
                 textStyle = MaterialTheme.appTypography.labelLarge
             )
-            if (!uiState.isDownloading) {
-                IconText(
-                    text = stringResource(R.string.core_ready_to_download),
-                    icon = Icons.Outlined.CloudDownload,
-                    color = MaterialTheme.appColors.textDark,
-                    textStyle = MaterialTheme.appTypography.labelLarge
-                )
-            } else {
-                IconText(
-                    text = stringResource(R.string.core_downloading),
-                    icon = Icons.Outlined.CloudDownload,
-                    color = MaterialTheme.appColors.textDark,
-                    textStyle = MaterialTheme.appTypography.labelLarge
-                )
+            if (uiState.readyToDownloadSize > 0) {
+                if (!uiState.isDownloading) {
+                    IconText(
+                        text = stringResource(R.string.core_ready_to_download),
+                        icon = Icons.Outlined.CloudDownload,
+                        color = MaterialTheme.appColors.textDark,
+                        textStyle = MaterialTheme.appTypography.labelLarge
+                    )
+                } else {
+                    IconText(
+                        text = stringResource(R.string.core_downloading),
+                        icon = Icons.Outlined.CloudDownload,
+                        color = MaterialTheme.appColors.textDark,
+                        textStyle = MaterialTheme.appTypography.labelLarge
+                    )
+                }
             }
         }
         if (uiState.progressBarValue != 0f) {
@@ -462,10 +470,11 @@ private fun CourseOfflineUIPreview() {
             hasInternetConnection = true,
             uiState = CourseOfflineUIState(
                 isHaveDownloadableBlocks = true,
-                readyToDownloadSize = "159MB",
-                downloadedSize = "0MB",
+                readyToDownloadSize = 100000L,
+                downloadedSize = 0L,
                 progressBarValue = 0f,
                 isDownloading = true,
+                isAllDownloaded = true,
                 largestDownloads = listOf(
                     DownloadModel(
                         "",

--- a/course/src/main/java/org/openedx/course/presentation/offline/CourseOfflineUIState.kt
+++ b/course/src/main/java/org/openedx/course/presentation/offline/CourseOfflineUIState.kt
@@ -4,9 +4,10 @@ import org.openedx.core.module.db.DownloadModel
 
 data class CourseOfflineUIState(
     val isHaveDownloadableBlocks: Boolean,
+    val isAllDownloaded: Boolean,
     val largestDownloads: List<DownloadModel>,
     val isDownloading: Boolean,
-    val readyToDownloadSize: String,
-    val downloadedSize: String,
+    val readyToDownloadSize: Long,
+    val downloadedSize: Long,
     val progressBarValue: Float,
 )

--- a/course/src/main/java/org/openedx/course/presentation/offline/CourseOfflineViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/offline/CourseOfflineViewModel.kt
@@ -18,6 +18,7 @@ import org.openedx.core.extension.safeDivBy
 import org.openedx.core.module.DownloadWorkerController
 import org.openedx.core.module.db.DownloadDao
 import org.openedx.core.module.db.DownloadModel
+import org.openedx.core.module.db.DownloadedState
 import org.openedx.core.module.db.FileType
 import org.openedx.core.module.download.BaseDownloadViewModel
 import org.openedx.core.module.download.DownloadHelper
@@ -28,7 +29,6 @@ import org.openedx.core.system.connection.NetworkConnection
 import org.openedx.core.system.notifier.CourseNotifier
 import org.openedx.core.system.notifier.CourseStructureGot
 import org.openedx.course.domain.interactor.CourseInteractor
-import org.openedx.foundation.extension.toFileSize
 import org.openedx.foundation.utils.FileUtil
 
 class CourseOfflineViewModel(
@@ -56,8 +56,9 @@ class CourseOfflineViewModel(
             isHaveDownloadableBlocks = false,
             largestDownloads = emptyList(),
             isDownloading = false,
-            readyToDownloadSize = "",
-            downloadedSize = "",
+            isAllDownloaded = false,
+            readyToDownloadSize = 0L,
+            downloadedSize = 0L,
             progressBarValue = 0f,
         )
     )
@@ -163,20 +164,24 @@ class CourseOfflineViewModel(
         viewModelScope.launch {
             val courseStructure = courseInteractor.getCourseStructureFromCache(courseId)
             val totalDownloadableSize = getFilesSize(courseStructure.blockData)
-
-            if (totalDownloadableSize == 0L) return@launch
-
             courseInteractor.getDownloadModels().collect { downloadModels ->
+                val courseDownloadModels = downloadModels.filter { it.courseId == courseId }
                 val completedDownloads =
-                    downloadModels.filter { it.downloadedState.isDownloaded && it.courseId == courseId }
-                val completedDownloadIds = completedDownloads.map { it.id }
-                val downloadedBlocks =
-                    courseStructure.blockData.filter { it.id in completedDownloadIds }
+                    courseDownloadModels.filter { it.downloadedState.isDownloaded }
+                val downloadedBlocks = courseStructure.blockData.filter {
+                    it.id in completedDownloads.map { it.id }
+                }
+                val isAllDownloaded =
+                    courseDownloadModels.all { it.downloadedState == DownloadedState.DOWNLOADED } &&
+                            courseDownloadModels.isNotEmpty()
+                val isHaveDownloadableBlocks = courseStructure.blockData.any { it.isDownloadable }
 
                 updateUIState(
                     totalDownloadableSize,
                     completedDownloads,
-                    downloadedBlocks
+                    downloadedBlocks,
+                    isAllDownloaded,
+                    isHaveDownloadableBlocks
                 )
             }
         }
@@ -185,7 +190,9 @@ class CourseOfflineViewModel(
     private fun updateUIState(
         totalDownloadableSize: Long,
         completedDownloads: List<DownloadModel>,
-        downloadedBlocks: List<Block>
+        downloadedBlocks: List<Block>,
+        isAllDownloaded: Boolean,
+        isHaveDownloadableBlocks: Boolean,
     ) {
         val downloadedSize = getFilesSize(downloadedBlocks).toFloat()
         val realDownloadedSize = completedDownloads.sumOf { it.size }
@@ -200,10 +207,11 @@ class CourseOfflineViewModel(
         }
         _uiState.update {
             it.copy(
-                isHaveDownloadableBlocks = true,
+                isHaveDownloadableBlocks = isHaveDownloadableBlocks,
+                isAllDownloaded = isAllDownloaded,
                 largestDownloads = largestDownloads,
-                readyToDownloadSize = readyToDownloadSize.toFileSize(1, false),
-                downloadedSize = realDownloadedSize.toFileSize(1, false),
+                readyToDownloadSize = readyToDownloadSize,
+                downloadedSize = realDownloadedSize,
                 progressBarValue = progressBarValue
             )
         }


### PR DESCRIPTION
Issue:
Some videos return a download size of 0, even though they can still be downloaded.

Solution:
When the reported size is 0, hide the downloadable size string to avoid misleading information.