### PR TITLE
chore: reusing mocks

### DIFF
--- a/app/src/test/java/org/openedx/AppViewModelTest.kt
+++ b/app/src/test/java/org/openedx/AppViewModelTest.kt
@@ -26,9 +26,9 @@ import org.openedx.app.AppViewModel
 import org.openedx.app.data.storage.PreferencesManager
 import org.openedx.app.deeplink.DeepLinkRouter
 import org.openedx.app.room.AppDatabase
+import org.openedx.core.CoreMocks
 import org.openedx.core.config.Config
 import org.openedx.core.config.FirebaseConfig
-import org.openedx.core.data.model.User
 import org.openedx.core.system.notifier.DownloadNotifier
 import org.openedx.core.system.notifier.app.AppNotifier
 import org.openedx.core.system.notifier.app.LogoutEvent
@@ -52,8 +52,6 @@ class AppViewModelTest {
     private val context = mockk<Context>()
     private val downloadNotifier = mockk<DownloadNotifier>()
 
-    private val user = User(0, "", "", "")
-
     @Before
     fun before() {
         Dispatchers.setMain(dispatcher)
@@ -68,7 +66,7 @@ class AppViewModelTest {
     @Test
     fun setIdSuccess() = runTest {
         every { analytics.setUserIdForSession(any()) } returns Unit
-        every { preferencesManager.user } returns user
+        every { preferencesManager.user } returns CoreMocks.mockUser
         every { notifier.notifier } returns flow { }
         every { preferencesManager.canResetAppDirectory } returns false
         every { preferencesManager.pushToken } returns ""
@@ -102,7 +100,7 @@ class AppViewModelTest {
         }
         every { preferencesManager.clearCorePreferences() } returns Unit
         every { analytics.setUserIdForSession(any()) } returns Unit
-        every { preferencesManager.user } returns user
+        every { preferencesManager.user } returns CoreMocks.mockUser
         every { room.clearAllTables() } returns Unit
         every { analytics.logoutEvent(true) } returns Unit
         every { preferencesManager.canResetAppDirectory } returns false
@@ -140,7 +138,7 @@ class AppViewModelTest {
         }
         every { preferencesManager.clearCorePreferences() } returns Unit
         every { analytics.setUserIdForSession(any()) } returns Unit
-        every { preferencesManager.user } returns user
+        every { preferencesManager.user } returns CoreMocks.mockUser
         every { room.clearAllTables() } returns Unit
         every { analytics.logoutEvent(true) } returns Unit
         every { preferencesManager.canResetAppDirectory } returns false

--- a/auth/src/test/java/org/openedx/auth/presentation/signin/SignInViewModelTest.kt
+++ b/auth/src/test/java/org/openedx/auth/presentation/signin/SignInViewModelTest.kt
@@ -28,12 +28,12 @@ import org.openedx.auth.presentation.AuthAnalytics
 import org.openedx.auth.presentation.AuthRouter
 import org.openedx.auth.presentation.sso.BrowserAuthHelper
 import org.openedx.auth.presentation.sso.OAuthHelper
+import org.openedx.core.CoreMocks
 import org.openedx.core.Validator
 import org.openedx.core.config.Config
 import org.openedx.core.config.FacebookConfig
 import org.openedx.core.config.GoogleConfig
 import org.openedx.core.config.MicrosoftConfig
-import org.openedx.core.data.model.User
 import org.openedx.core.data.storage.CalendarPreferences
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.interactor.CalendarInteractor
@@ -75,8 +75,6 @@ class SignInViewModelTest {
     private val invalidEmailOrUsername = "Invalid email or username"
     private val invalidPassword = "Password too short"
 
-    private val user = User(0, "", "", "")
-
     @Before
     fun before() {
         Dispatchers.setMain(dispatcher)
@@ -109,7 +107,7 @@ class SignInViewModelTest {
     @Test
     fun `login empty credentials validation error`() = runTest {
         every { validator.isEmailOrUserNameValid(any()) } returns false
-        every { preferencesManager.user } returns user
+        every { preferencesManager.user } returns CoreMocks.mockUser
         every { analytics.setUserIdForSession(any()) } returns Unit
         every { analytics.logEvent(any(), any()) } returns Unit
         val viewModel = SignInViewModel(
@@ -147,7 +145,7 @@ class SignInViewModelTest {
     @Test
     fun `login invalid email validation error`() = runTest {
         every { validator.isEmailOrUserNameValid(any()) } returns false
-        every { preferencesManager.user } returns user
+        every { preferencesManager.user } returns CoreMocks.mockUser
         every { analytics.setUserIdForSession(any()) } returns Unit
         every { analytics.logEvent(any(), any()) } returns Unit
         val viewModel = SignInViewModel(
@@ -184,7 +182,7 @@ class SignInViewModelTest {
     fun `login empty password validation error`() = runTest {
         every { validator.isEmailOrUserNameValid(any()) } returns true
         every { validator.isPasswordValid(any()) } returns false
-        every { preferencesManager.user } returns user
+        every { preferencesManager.user } returns CoreMocks.mockUser
         every { analytics.setUserIdForSession(any()) } returns Unit
         every { analytics.logEvent(any(), any()) } returns Unit
         coVerify(exactly = 0) { interactor.login(any(), any()) }
@@ -222,7 +220,7 @@ class SignInViewModelTest {
     fun `login invalid password validation error`() = runTest {
         every { validator.isEmailOrUserNameValid(any()) } returns true
         every { validator.isPasswordValid(any()) } returns false
-        every { preferencesManager.user } returns user
+        every { preferencesManager.user } returns CoreMocks.mockUser
         every { analytics.setUserIdForSession(any()) } returns Unit
         every { analytics.logEvent(any(), any()) } returns Unit
         val viewModel = SignInViewModel(
@@ -262,7 +260,7 @@ class SignInViewModelTest {
     fun `login success`() = runTest {
         every { validator.isEmailOrUserNameValid(any()) } returns true
         every { validator.isPasswordValid(any()) } returns true
-        every { preferencesManager.user } returns user
+        every { preferencesManager.user } returns CoreMocks.mockUser
         every { analytics.setUserIdForSession(any()) } returns Unit
         every { analytics.logEvent(any(), any()) } returns Unit
         coEvery { appNotifier.send(any<SignInEvent>()) } returns Unit
@@ -304,7 +302,7 @@ class SignInViewModelTest {
     fun `login network error`() = runTest {
         every { validator.isEmailOrUserNameValid(any()) } returns true
         every { validator.isPasswordValid(any()) } returns true
-        every { preferencesManager.user } returns user
+        every { preferencesManager.user } returns CoreMocks.mockUser
         every { analytics.setUserIdForSession(any()) } returns Unit
         every { analytics.logEvent(any(), any()) } returns Unit
         val viewModel = SignInViewModel(
@@ -347,7 +345,7 @@ class SignInViewModelTest {
     fun `login invalid grant error`() = runTest {
         every { validator.isEmailOrUserNameValid(any()) } returns true
         every { validator.isPasswordValid(any()) } returns true
-        every { preferencesManager.user } returns user
+        every { preferencesManager.user } returns CoreMocks.mockUser
         every { analytics.setUserIdForSession(any()) } returns Unit
         every { analytics.logEvent(any(), any()) } returns Unit
         val viewModel = SignInViewModel(
@@ -390,7 +388,7 @@ class SignInViewModelTest {
     fun `login unknown exception`() = runTest {
         every { validator.isEmailOrUserNameValid(any()) } returns true
         every { validator.isPasswordValid(any()) } returns true
-        every { preferencesManager.user } returns user
+        every { preferencesManager.user } returns CoreMocks.mockUser
         every { analytics.setUserIdForSession(any()) } returns Unit
         every { analytics.logEvent(any(), any()) } returns Unit
         val viewModel = SignInViewModel(

--- a/auth/src/test/java/org/openedx/auth/presentation/signup/SignUpViewModelTest.kt
+++ b/auth/src/test/java/org/openedx/auth/presentation/signup/SignUpViewModelTest.kt
@@ -32,12 +32,12 @@ import org.openedx.auth.presentation.AuthAnalytics
 import org.openedx.auth.presentation.AuthRouter
 import org.openedx.auth.presentation.sso.OAuthHelper
 import org.openedx.core.ApiConstants
+import org.openedx.core.CoreMocks
 import org.openedx.core.R
 import org.openedx.core.config.Config
 import org.openedx.core.config.FacebookConfig
 import org.openedx.core.config.GoogleConfig
 import org.openedx.core.config.MicrosoftConfig
-import org.openedx.core.data.model.User
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.AgreementUrls
 import org.openedx.core.domain.model.RegistrationField
@@ -98,8 +98,6 @@ class SignUpViewModelTest {
         )
     )
 
-    private val user = User(0, "", "", "")
-
     //endregion
 
     private val noInternet = "Slow or no internet connection"
@@ -149,7 +147,7 @@ class SignUpViewModelTest {
         every { analytics.logEvent(any(), any()) } returns Unit
         coEvery { interactor.register(parametersMap) } returns Unit
         coEvery { interactor.login("", "") } returns Unit
-        every { preferencesManager.user } returns user
+        every { preferencesManager.user } returns CoreMocks.mockUser
         every { analytics.setUserIdForSession(any()) } returns Unit
         viewModel.getRegistrationFields()
         advanceUntilIdle()
@@ -198,7 +196,7 @@ class SignUpViewModelTest {
             )
         } returns Unit
         every { analytics.logEvent(any(), any()) } returns Unit
-        every { preferencesManager.user } returns user
+        every { preferencesManager.user } returns CoreMocks.mockUser
         every { analytics.setUserIdForSession(any()) } returns Unit
         viewModel.getRegistrationFields()
         advanceUntilIdle()
@@ -242,7 +240,7 @@ class SignUpViewModelTest {
         coEvery { interactor.register(parametersMap) } returns Unit
         coEvery { interactor.login("", "") } returns Unit
         every { analytics.logEvent(any(), any()) } returns Unit
-        every { preferencesManager.user } returns user
+        every { preferencesManager.user } returns CoreMocks.mockUser
         every { analytics.setUserIdForSession(any()) } returns Unit
         viewModel.register()
         advanceUntilIdle()
@@ -288,7 +286,7 @@ class SignUpViewModelTest {
                 parametersMap.getValue(ApiConstants.PASSWORD)
             )
         } returns Unit
-        every { preferencesManager.user } returns user
+        every { preferencesManager.user } returns CoreMocks.mockUser
         every { analytics.setUserIdForSession(any()) } returns Unit
         viewModel.getRegistrationFields()
         advanceUntilIdle()

--- a/core/src/main/java/org/openedx/core/CoreMocks.kt
+++ b/core/src/main/java/org/openedx/core/CoreMocks.kt
@@ -1,17 +1,25 @@
 package org.openedx.core
 
+import org.openedx.core.data.model.User
 import org.openedx.core.data.model.room.VideoProgressEntity
+import org.openedx.core.domain.model.AppConfig
 import org.openedx.core.domain.model.AssignmentProgress
 import org.openedx.core.domain.model.Block
 import org.openedx.core.domain.model.BlockCounts
+import org.openedx.core.domain.model.CourseAccessDetails
 import org.openedx.core.domain.model.CourseComponentStatus
 import org.openedx.core.domain.model.CourseDatesBannerInfo
+import org.openedx.core.domain.model.CourseDatesCalendarSync
 import org.openedx.core.domain.model.CourseDatesResult
+import org.openedx.core.domain.model.CourseEnrollmentDetails
+import org.openedx.core.domain.model.CourseInfoOverview
 import org.openedx.core.domain.model.CourseProgress
+import org.openedx.core.domain.model.CourseSharingUtmParameters
 import org.openedx.core.domain.model.CourseStructure
 import org.openedx.core.domain.model.CoursewareAccess
+import org.openedx.core.domain.model.DownloadCoursePreview
 import org.openedx.core.domain.model.EncodedVideos
-import org.openedx.core.domain.model.OfflineDownload
+import org.openedx.core.domain.model.EnrollmentDetails
 import org.openedx.core.domain.model.Progress
 import org.openedx.core.domain.model.ResetCourseDates
 import org.openedx.core.domain.model.StudentViewData
@@ -19,14 +27,31 @@ import org.openedx.core.domain.model.VideoInfo
 import org.openedx.core.module.db.DownloadModel
 import org.openedx.core.module.db.DownloadedState
 import org.openedx.core.module.db.FileType
+import org.openedx.core.module.download.DownloadModelsSize
 import java.util.Date
 
-object Mock {
-    private val mockAssignmentProgress = AssignmentProgress(
+object CoreMocks {
+    val mockAssignmentProgress = AssignmentProgress(
         assignmentType = "Home",
         numPointsEarned = 1f,
         numPointsPossible = 3f,
         shortLabel = "HM1"
+    )
+
+    val mockUser = User(
+        id = 0,
+        username = "",
+        email = "",
+        name = ""
+    )
+
+    val mockAppConfig = AppConfig(
+        courseDatesCalendarSync = CourseDatesCalendarSync(
+            isEnabled = true,
+            isSelfPacedEnabled = true,
+            isInstructorPacedEnabled = true,
+            isDeepLinkEnabled = false,
+        )
     )
     val mockChapterBlock = Block(
         id = "id",
@@ -40,7 +65,7 @@ object Mock {
         studentViewData = null,
         studentViewMultiDevice = false,
         blockCounts = BlockCounts(1),
-        descendants = emptyList(),
+        descendants = listOf("1"),
         descendantsType = BlockType.CHAPTER,
         completion = 0.0,
         containsGatedContent = false,
@@ -48,30 +73,61 @@ object Mock {
         due = Date(),
         offlineDownload = null
     )
-    private val mockSequentialBlock = Block(
-        id = "id",
-        blockId = "blockId",
-        lmsWebUrl = "lmsWebUrl",
-        legacyWebUrl = "legacyWebUrl",
-        studentViewUrl = "studentViewUrl",
-        type = BlockType.SEQUENTIAL,
-        displayName = "Sequential",
-        graded = false,
-        studentViewData = null,
-        studentViewMultiDevice = false,
-        blockCounts = BlockCounts(1),
-        descendants = emptyList(),
-        descendantsType = BlockType.CHAPTER,
-        completion = 0.0,
-        containsGatedContent = false,
-        assignmentProgress = mockAssignmentProgress,
-        due = Date(),
-        offlineDownload = OfflineDownload("fileUrl", "", 1),
+
+    val mockBlockData = listOf(
+        mockChapterBlock.copy(
+            id = "id",
+            type = BlockType.HTML,
+            blockCounts = BlockCounts(0),
+            descendants = listOf("id2", "id1"),
+            descendantsType = BlockType.HTML,
+            assignmentProgress = mockAssignmentProgress.copy(
+                assignmentType = "Homework",
+                shortLabel = "HW1"
+            ),
+            due = Date()
+        ),
+        mockChapterBlock.copy(
+            id = "id1",
+            type = BlockType.VERTICAL,
+            blockCounts = BlockCounts(0),
+            descendants = listOf("id2", "id"),
+            descendantsType = BlockType.HTML,
+            assignmentProgress = mockAssignmentProgress.copy(
+                assignmentType = "Homework",
+                shortLabel = "HW1"
+            ),
+            due = Date()
+        ),
+        mockChapterBlock.copy(
+            id = "id2",
+            type = BlockType.SEQUENTIAL,
+            blockCounts = BlockCounts(0),
+            descendants = emptyList(),
+            descendantsType = BlockType.HTML,
+            assignmentProgress = mockAssignmentProgress.copy(
+                assignmentType = "Homework",
+                shortLabel = "HW1"
+            ),
+            due = Date()
+        ),
+        mockChapterBlock.copy(
+            id = "id3",
+            type = BlockType.HTML,
+            blockCounts = BlockCounts(0),
+            descendants = emptyList(),
+            descendantsType = BlockType.HTML,
+            assignmentProgress = mockAssignmentProgress.copy(
+                assignmentType = "Homework",
+                shortLabel = "HW1"
+            ),
+            due = Date()
+        )
     )
 
     val mockCourseStructure = CourseStructure(
         root = "",
-        blockData = listOf(mockSequentialBlock, mockSequentialBlock),
+        blockData = mockBlockData,
         id = "id",
         name = "Course name",
         number = "",
@@ -111,6 +167,15 @@ object Mock {
         courseBanner = mockCourseDatesBannerInfo
     )
 
+    val mockCoursewareAccess = CoursewareAccess(
+        hasAccess = true,
+        errorCode = "",
+        developerMessage = "",
+        userMessage = "",
+        userFragment = "",
+        additionalContextUserMessage = ""
+    )
+
     val mockCourseProgress = CourseProgress(
         verifiedMode = "audit",
         accessExpiration = "",
@@ -128,6 +193,46 @@ object Mock {
         userHasPassingGrade = false,
         verificationData = null,
         disableProgressGraph = false
+    )
+
+    val mockCourseAccessDetails = CourseAccessDetails(
+        hasUnmetPrerequisites = false,
+        isTooEarly = false,
+        isStaff = false,
+        auditAccessExpires = null,
+        coursewareAccess = mockCoursewareAccess
+    )
+
+    val mockEnrollmentDetails = EnrollmentDetails(
+        created = Date(),
+        mode = "audit",
+        isActive = true,
+        upgradeDeadline = Date()
+    )
+
+    val mockCourseInfoOverview = CourseInfoOverview(
+        name = "Open edX Demo Course",
+        number = "DemoX",
+        org = "edX",
+        start = Date(),
+        startDisplay = "Today",
+        startType = "",
+        end = null,
+        isSelfPaced = false,
+        media = null,
+        courseSharingUtmParameters = CourseSharingUtmParameters("", ""),
+        courseAbout = "About course"
+    )
+
+    val mockCourseEnrollmentDetails = CourseEnrollmentDetails(
+        id = "course-id",
+        courseUpdates = "Course updates",
+        courseHandouts = "Course handouts",
+        discussionUrl = "https://example.com/discussion",
+        courseAccessDetails = mockCourseAccessDetails,
+        certificate = null,
+        enrollmentDetails = mockEnrollmentDetails,
+        courseInfoOverview = mockCourseInfoOverview
     )
 
     val mockVideoProgress = VideoProgressEntity(
@@ -259,5 +364,20 @@ object Mock {
         certificate = null,
         isSelfPaced = false,
         progress = null
+    )
+
+    val coursePreview = DownloadCoursePreview(
+        id = "course-id",
+        name = "Preview Course",
+        image = "",
+        totalSize = 100L
+    )
+
+    val mockDownloadModelsSize = DownloadModelsSize(
+        isAllBlocksDownloadedOrDownloading = false,
+        remainingCount = 0,
+        remainingSize = 0,
+        allCount = 1,
+        allSize = 0
     )
 }

--- a/course/src/main/java/org/openedx/course/CourseMocks.kt
+++ b/course/src/main/java/org/openedx/course/CourseMocks.kt
@@ -1,0 +1,83 @@
+package org.openedx.course
+
+import org.openedx.core.BlockType
+import org.openedx.core.data.model.DateType
+import org.openedx.core.domain.model.AssignmentProgress
+import org.openedx.core.domain.model.Block
+import org.openedx.core.domain.model.BlockCounts
+import org.openedx.core.domain.model.CourseDateBlock
+import org.openedx.core.domain.model.CourseDatesBannerInfo
+import org.openedx.core.domain.model.CourseDatesResult
+import org.openedx.core.domain.model.CoursewareAccess
+import org.openedx.core.domain.model.DatesSection
+import org.openedx.core.domain.model.Progress
+import java.util.Date
+
+object CourseMocks {
+
+    val sequentialBlock: Block = Block(
+        id = "sequential-id",
+        blockId = "sequential-id",
+        lmsWebUrl = "lmsWebUrl",
+        legacyWebUrl = "legacyWebUrl",
+        studentViewUrl = "studentViewUrl",
+        type = BlockType.SEQUENTIAL,
+        displayName = "Sequential",
+        graded = false,
+        studentViewData = null,
+        studentViewMultiDevice = false,
+        blockCounts = BlockCounts(1),
+        descendants = emptyList(),
+        descendantsType = BlockType.SEQUENTIAL,
+        completion = 0.0,
+        containsGatedContent = false,
+        assignmentProgress = AssignmentProgress(
+            assignmentType = "Homework",
+            numPointsEarned = 1f,
+            numPointsPossible = 3f,
+            shortLabel = "HM1"
+        ),
+        due = Date(),
+        offlineDownload = null
+    )
+
+    val coursewareAccess = CoursewareAccess(
+        hasAccess = true,
+        errorCode = "",
+        developerMessage = "",
+        userMessage = "",
+        additionalContextUserMessage = "",
+        userFragment = ""
+    )
+
+    val progress: Progress = Progress.DEFAULT_PROGRESS
+
+    val assignmentProgress = Progress(1, 3)
+    val assignmentProgressTablet = Progress(2, 3)
+
+    val courseDateBlock = CourseDateBlock(
+        complete = false,
+        date = Date(),
+        dateType = DateType.TODAY_DATE,
+        description = "Mocked Course Date Description"
+    )
+
+    val courseDateBlocks = linkedMapOf(
+        Pair(DatesSection.COMPLETED, listOf(courseDateBlock, courseDateBlock)),
+        Pair(DatesSection.PAST_DUE, listOf(courseDateBlock, courseDateBlock)),
+        Pair(DatesSection.TODAY, listOf(courseDateBlock, courseDateBlock))
+    )
+
+    val courseDatesBannerInfoWithData = CourseDatesBannerInfo(
+        missedDeadlines = true,
+        missedGatedContent = false,
+        verifiedUpgradeLink = "",
+        contentTypeGatingEnabled = false,
+        hasEnded = true,
+    )
+
+    val courseDatesResultWithData = CourseDatesResult(
+        datesSection = courseDateBlocks,
+        courseBanner = courseDatesBannerInfoWithData,
+    )
+}

--- a/course/src/main/java/org/openedx/course/presentation/assignments/CourseContentAssignmentScreen.kt
+++ b/course/src/main/java/org/openedx/course/presentation/assignments/CourseContentAssignmentScreen.kt
@@ -52,17 +52,15 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.FragmentManager
-import org.openedx.core.BlockType
-import org.openedx.core.domain.model.AssignmentProgress
+import org.openedx.core.CoreMocks
 import org.openedx.core.domain.model.Block
-import org.openedx.core.domain.model.BlockCounts
-import org.openedx.core.domain.model.CourseProgress
 import org.openedx.core.domain.model.Progress
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appShapes
 import org.openedx.core.ui.theme.appTypography
 import org.openedx.core.utils.TimeUtils
+import org.openedx.course.CourseMocks
 import org.openedx.course.R
 import org.openedx.course.presentation.contenttab.CourseContentAssignmentEmptyState
 import org.openedx.course.presentation.ui.CourseProgress
@@ -78,9 +76,6 @@ private const val POINTER_ICON_SIZE_DP = 10
 private const val POINTER_ICON_PADDING_TOP_DP = 4
 private const val PROGRESS_HEIGHT_DP = 6
 private const val ASSIGNMENT_BUTTON_CARD_BACKGROUND_ALPHA = 0.5f
-private const val COMPLETED_ASSIGNMENTS_COUNT = 1
-private const val COMPLETED_ASSIGNMENTS_COUNT_TABLET = 2
-private const val TOTAL_ASSIGNMENTS_COUNT = 3
 
 @Composable
 fun CourseContentAssignmentScreen(
@@ -524,11 +519,11 @@ private fun CourseContentAssignmentScreenPreview() {
         CourseContentAssignmentScreen(
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
             uiState = CourseAssignmentUIState.CourseData(
-                progress = Progress(COMPLETED_ASSIGNMENTS_COUNT, TOTAL_ASSIGNMENTS_COUNT),
+                progress = CourseMocks.assignmentProgress,
                 groupedAssignments = mapOf(
-                    "Homework" to listOf(mockChapterBlock, mockSequentialBlock)
+                    "Homework" to listOf(CoreMocks.mockChapterBlock, CourseMocks.sequentialBlock)
                 ),
-                courseProgress = mockCourseProgress,
+                courseProgress = CoreMocks.mockCourseProgress,
                 sectionNames = mapOf()
             ),
             onAssignmentClick = {},
@@ -557,12 +552,12 @@ private fun CourseContentAssignmentScreenTabletPreview() {
         CourseContentAssignmentScreen(
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
             uiState = CourseAssignmentUIState.CourseData(
-                progress = Progress(COMPLETED_ASSIGNMENTS_COUNT_TABLET, TOTAL_ASSIGNMENTS_COUNT),
+                progress = CourseMocks.assignmentProgressTablet,
                 groupedAssignments = mapOf(
-                    "Homework" to listOf(mockChapterBlock),
-                    "Quiz" to listOf(mockSequentialBlock)
+                    "Homework" to listOf(CoreMocks.mockChapterBlock),
+                    "Quiz" to listOf(CourseMocks.sequentialBlock)
                 ),
-                courseProgress = mockCourseProgress,
+                courseProgress = CoreMocks.mockCourseProgress,
                 sectionNames = mapOf()
             ),
             onAssignmentClick = {},
@@ -570,138 +565,3 @@ private fun CourseContentAssignmentScreenTabletPreview() {
         )
     }
 }
-
-private val mockCourseProgress = CourseProgress(
-    verifiedMode = "verified",
-    accessExpiration = "2024-12-31",
-    certificateData = CourseProgress.CertificateData(
-        certStatus = "downloadable",
-        certWebViewUrl = "https://example.com/cert",
-        downloadUrl = "https://example.com/cert.pdf",
-        certificateAvailableDate = "2024-06-01"
-    ),
-    completionSummary = CourseProgress.CompletionSummary(
-        completeCount = 5,
-        incompleteCount = 3,
-        lockedCount = 1
-    ),
-    courseGrade = CourseProgress.CourseGrade(
-        letterGrade = "B+",
-        percent = 85.5,
-        isPassing = true
-    ),
-    creditCourseRequirements = "Complete all assignments",
-    end = "2024-12-31",
-    enrollmentMode = "verified",
-    gradingPolicy = CourseProgress.GradingPolicy(
-        assignmentPolicies = listOf(
-            CourseProgress.GradingPolicy.AssignmentPolicy(
-                numDroppable = 1,
-                numTotal = 5,
-                shortLabel = "HW",
-                type = "Homework",
-                weight = 0.4
-            ),
-            CourseProgress.GradingPolicy.AssignmentPolicy(
-                numDroppable = 0,
-                numTotal = 3,
-                shortLabel = "Quiz",
-                type = "Quiz",
-                weight = 0.6
-            )
-        ),
-        gradeRange = mapOf(
-            "A" to 0.9f,
-            "B" to 0.8f,
-            "C" to 0.7f,
-            "D" to 0.6f
-        ),
-        assignmentColors = listOf(Color(0xFF2196F3), Color(0xFF4CAF50))
-    ),
-    hasScheduledContent = false,
-    sectionScores = listOf(
-        CourseProgress.SectionScore(
-            displayName = "Week 1",
-            subsections = listOf(
-                CourseProgress.SectionScore.Subsection(
-                    assignmentType = "Homework",
-                    blockKey = "block1",
-                    displayName = "Homework 1",
-                    hasGradedAssignment = true,
-                    override = "",
-                    learnerHasAccess = true,
-                    numPointsEarned = 8f,
-                    numPointsPossible = 10f,
-                    percentGraded = 80.0,
-                    problemScores = listOf(
-                        CourseProgress.SectionScore.Subsection.ProblemScore(
-                            earned = 8.0,
-                            possible = 10.0
-                        )
-                    ),
-                    showCorrectness = "always",
-                    showGrades = true,
-                    url = "https://example.com/hw1"
-                )
-            )
-        )
-    ),
-    studioUrl = "https://studio.example.com",
-    username = "testuser",
-    userHasPassingGrade = true,
-    verificationData = CourseProgress.VerificationData(
-        link = "https://example.com/verify",
-        status = "approved",
-        statusDate = "2024-01-15"
-    ),
-    disableProgressGraph = false
-)
-
-private val mockAssignmentProgress = AssignmentProgress(
-    assignmentType = "Home",
-    numPointsEarned = 1f,
-    numPointsPossible = 3f,
-    shortLabel = "HM1"
-)
-
-private val mockChapterBlock = Block(
-    id = "id",
-    blockId = "blockId",
-    lmsWebUrl = "lmsWebUrl",
-    legacyWebUrl = "legacyWebUrl",
-    studentViewUrl = "studentViewUrl",
-    type = BlockType.CHAPTER,
-    displayName = "Chapter",
-    graded = false,
-    studentViewData = null,
-    studentViewMultiDevice = false,
-    blockCounts = BlockCounts(1),
-    descendants = emptyList(),
-    descendantsType = BlockType.CHAPTER,
-    completion = 0.0,
-    containsGatedContent = false,
-    assignmentProgress = mockAssignmentProgress,
-    due = Date(),
-    offlineDownload = null
-)
-
-private val mockSequentialBlock = Block(
-    id = "id",
-    blockId = "blockId",
-    lmsWebUrl = "lmsWebUrl",
-    legacyWebUrl = "legacyWebUrl",
-    studentViewUrl = "studentViewUrl",
-    type = BlockType.SEQUENTIAL,
-    displayName = "Sequential",
-    graded = false,
-    studentViewData = null,
-    studentViewMultiDevice = false,
-    blockCounts = BlockCounts(1),
-    descendants = emptyList(),
-    descendantsType = BlockType.SEQUENTIAL,
-    completion = 0.0,
-    containsGatedContent = false,
-    assignmentProgress = mockAssignmentProgress,
-    due = Date(),
-    offlineDownload = null
-)

--- a/course/src/main/java/org/openedx/course/presentation/dates/CourseDatesScreen.kt
+++ b/course/src/main/java/org/openedx/course/presentation/dates/CourseDatesScreen.kt
@@ -61,10 +61,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.FragmentManager
 import org.openedx.core.NoContentScreenType
-import org.openedx.core.data.model.DateType
 import org.openedx.core.domain.model.CourseDateBlock
-import org.openedx.core.domain.model.CourseDatesBannerInfo
-import org.openedx.core.domain.model.CourseDatesResult
 import org.openedx.core.domain.model.DatesSection
 import org.openedx.core.presentation.CoreAnalyticsScreen
 import org.openedx.core.presentation.dialog.alert.ActionDialogFragment
@@ -76,9 +73,9 @@ import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appTypography
-import org.openedx.core.utils.TimeUtils
 import org.openedx.core.utils.TimeUtils.formatToString
 import org.openedx.core.utils.clearTime
+import org.openedx.course.CourseMocks
 import org.openedx.course.presentation.ui.CourseDatesBanner
 import org.openedx.course.presentation.ui.CourseDatesBannerTablet
 import org.openedx.course.presentation.unit.container.CourseViewMode
@@ -87,7 +84,6 @@ import org.openedx.foundation.presentation.UIMessage
 import org.openedx.foundation.presentation.WindowSize
 import org.openedx.foundation.presentation.WindowType
 import org.openedx.foundation.presentation.windowSizeValue
-import java.util.Date
 import org.openedx.core.R as CoreR
 
 @Composable
@@ -473,7 +469,11 @@ private fun CourseDateBlockSection(
             if (sectionKey != DatesSection.COMPLETED) {
                 DateBullet(section = sectionKey)
             }
-            DateBlock(dateBlocks = sectionDates, onItemClick = onItemClick, useRelativeDates = useRelativeDates)
+            DateBlock(
+                dateBlocks = sectionDates,
+                onItemClick = onItemClick,
+                useRelativeDates = useRelativeDates
+            )
         }
     }
 }
@@ -645,7 +645,7 @@ private fun CourseDatesScreenPreview() {
         CourseDatesUI(
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
             uiState = CourseDatesUIState.CourseDates(
-                CourseDatesResult(mockedResponse, mockedCourseBannerInfo),
+                CourseMocks.courseDatesResultWithData,
                 CalendarSyncState.SYNCED
             ),
             uiMessage = null,
@@ -667,7 +667,7 @@ private fun CourseDatesScreenTabletPreview() {
         CourseDatesUI(
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
             uiState = CourseDatesUIState.CourseDates(
-                CourseDatesResult(mockedResponse, mockedCourseBannerInfo),
+                CourseMocks.courseDatesResultWithData,
                 CalendarSyncState.SYNCED
             ),
             uiMessage = null,
@@ -680,108 +680,3 @@ private fun CourseDatesScreenTabletPreview() {
         )
     }
 }
-
-val mockedCourseBannerInfo = CourseDatesBannerInfo(
-    missedDeadlines = true,
-    missedGatedContent = false,
-    verifiedUpgradeLink = "",
-    contentTypeGatingEnabled = false,
-    hasEnded = false,
-)
-
-private val mockedResponse: LinkedHashMap<DatesSection, List<CourseDateBlock>> =
-    linkedMapOf(
-        Pair(
-            DatesSection.COMPLETED,
-            listOf(
-                CourseDateBlock(
-                    title = "Homework 1: ABCD",
-                    description = "After this date, course content will be archived",
-                    date = TimeUtils.iso8601ToDate("2023-10-20T15:08:07Z")!!,
-                )
-            )
-        ),
-
-        Pair(
-            DatesSection.COMPLETED,
-            listOf(
-                CourseDateBlock(
-                    title = "Homework 1: ABCD",
-                    description = "After this date, course content will be archived",
-                    date = TimeUtils.iso8601ToDate("2023-10-20T15:08:07Z")!!,
-                )
-            )
-        ),
-
-        Pair(
-            DatesSection.PAST_DUE,
-            listOf(
-                CourseDateBlock(
-                    title = "Homework 1: ABCD",
-                    description = "After this date, course content will be archived",
-                    date = Date(),
-                    dateType = DateType.ASSIGNMENT_DUE_DATE,
-                )
-            )
-        ),
-
-        Pair(
-            DatesSection.TODAY,
-            listOf(
-                CourseDateBlock(
-                    title = "Homework 2: ABCD",
-                    description = "After this date, course content will be archived",
-                    date = TimeUtils.iso8601ToDate("2023-10-21T15:08:07Z")!!,
-                )
-            )
-        ),
-
-        Pair(
-            DatesSection.THIS_WEEK,
-            listOf(
-                CourseDateBlock(
-                    title = "Assignment Due: ABCD",
-                    description = "After this date, course content will be archived",
-                    date = TimeUtils.iso8601ToDate("2023-10-22T15:08:07Z")!!,
-                    dateType = DateType.ASSIGNMENT_DUE_DATE,
-                ),
-
-                CourseDateBlock(
-                    title = "Assignment Due",
-                    description = "After this date, course content will be archived",
-                    date = TimeUtils.iso8601ToDate("2023-10-23T15:08:07Z")!!,
-                    dateType = DateType.ASSIGNMENT_DUE_DATE,
-                ),
-
-                CourseDateBlock(
-                    title = "Surprise Assignment",
-                    description = "After this date, course content will be archived",
-                    date = TimeUtils.iso8601ToDate("2023-10-24T15:08:07Z")!!,
-                )
-            )
-        ),
-
-        Pair(
-            DatesSection.NEXT_WEEK,
-            listOf(
-                CourseDateBlock(
-                    title = "Homework 5: ABCD",
-                    description = "After this date, course content will be archived",
-                    date = TimeUtils.iso8601ToDate("2023-10-25T15:08:07Z")!!,
-                )
-            )
-        ),
-
-        Pair(
-            DatesSection.UPCOMING,
-            listOf(
-                CourseDateBlock(
-                    title = "Last Assignment",
-                    description = "After this date, course content will be archived",
-                    date = TimeUtils.iso8601ToDate("2023-10-26T15:08:07Z")!!,
-                    assignmentType = "Module 1",
-                    dateType = DateType.VERIFICATION_DEADLINE_DATE,
-                )
-            )
-        )
-    )

--- a/course/src/main/java/org/openedx/course/presentation/home/CourseCompletionHomePagerCardContent.kt
+++ b/course/src/main/java/org/openedx/course/presentation/home/CourseCompletionHomePagerCardContent.kt
@@ -17,9 +17,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import org.openedx.core.Mock
+import org.openedx.core.CoreMocks
 import org.openedx.core.domain.model.Block
-import org.openedx.core.domain.model.CourseDatesBannerInfo
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appTypography
@@ -132,21 +131,18 @@ private fun CourseCompletionHomePagerCardContentPreview() {
     OpenEdXTheme {
         CourseCompletionHomePagerCardContent(
             uiState = CourseHomeUIState.CourseData(
-                courseStructure = Mock.mockCourseStructure,
+                courseStructure = CoreMocks.mockCourseStructure,
                 courseProgress = null, // No course progress for preview
-                next = Pair(Mock.mockChapterBlock, Mock.mockChapterBlock), // Mock next section
+                next = Pair(
+                    CoreMocks.mockChapterBlock,
+                    CoreMocks.mockChapterBlock
+                ), // Mock next section
                 downloadedState = mapOf(),
-                resumeComponent = Mock.mockChapterBlock,
+                resumeComponent = CoreMocks.mockChapterBlock,
                 resumeUnitTitle = "Resumed Unit",
                 courseSubSections = mapOf(),
                 subSectionsDownloadsCount = mapOf(),
-                datesBannerInfo = CourseDatesBannerInfo(
-                    missedDeadlines = false,
-                    missedGatedContent = false,
-                    verifiedUpgradeLink = "",
-                    contentTypeGatingEnabled = false,
-                    hasEnded = false
-                ),
+                datesBannerInfo = CoreMocks.mockCourseDatesBannerInfo,
                 useRelativeDates = true,
                 courseVideos = mapOf(),
                 courseAssignments = emptyList(),

--- a/course/src/main/java/org/openedx/course/presentation/home/CourseHomeScreen.kt
+++ b/course/src/main/java/org/openedx/course/presentation/home/CourseHomeScreen.kt
@@ -49,10 +49,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.FragmentManager
-import org.openedx.core.Mock
+import org.openedx.core.CoreMocks
 import org.openedx.core.NoContentScreenType
 import org.openedx.core.domain.model.Block
-import org.openedx.core.domain.model.CourseDatesBannerInfo
 import org.openedx.core.ui.CircularProgress
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.NoContentScreen
@@ -452,21 +451,15 @@ private fun CourseHomeScreenPreview() {
         CourseHomeUI(
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
             uiState = CourseHomeUIState.CourseData(
-                courseStructure = Mock.mockCourseStructure,
+                courseStructure = CoreMocks.mockCourseStructure,
                 courseProgress = null, // No course progress for preview
                 next = null, // No next section for preview
                 downloadedState = mapOf(),
-                resumeComponent = Mock.mockChapterBlock,
+                resumeComponent = CoreMocks.mockChapterBlock,
                 resumeUnitTitle = "Resumed Unit",
                 courseSubSections = mapOf(),
                 subSectionsDownloadsCount = mapOf(),
-                datesBannerInfo = CourseDatesBannerInfo(
-                    missedDeadlines = false,
-                    missedGatedContent = false,
-                    verifiedUpgradeLink = "",
-                    contentTypeGatingEnabled = false,
-                    hasEnded = false
-                ),
+                datesBannerInfo = CoreMocks.mockCourseDatesBannerInfo,
                 useRelativeDates = true,
                 courseVideos = mapOf(),
                 courseAssignments = emptyList(),
@@ -505,21 +498,15 @@ private fun CourseHomeScreenTabletPreview() {
         CourseHomeUI(
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
             uiState = CourseHomeUIState.CourseData(
-                courseStructure = Mock.mockCourseStructure,
+                courseStructure = CoreMocks.mockCourseStructure,
                 courseProgress = null, // No course progress for preview
                 next = null, // No next section for preview
                 downloadedState = mapOf(),
-                resumeComponent = Mock.mockChapterBlock,
+                resumeComponent = CoreMocks.mockChapterBlock,
                 resumeUnitTitle = "Resumed Unit",
                 courseSubSections = mapOf(),
                 subSectionsDownloadsCount = mapOf(),
-                datesBannerInfo = CourseDatesBannerInfo(
-                    missedDeadlines = false,
-                    missedGatedContent = false,
-                    verifiedUpgradeLink = "",
-                    contentTypeGatingEnabled = false,
-                    hasEnded = false
-                ),
+                datesBannerInfo = CoreMocks.mockCourseDatesBannerInfo,
                 useRelativeDates = true,
                 courseVideos = mapOf(),
                 courseAssignments = emptyList(),

--- a/course/src/main/java/org/openedx/course/presentation/offline/CourseOfflineScreen.kt
+++ b/course/src/main/java/org/openedx/course/presentation/offline/CourseOfflineScreen.kt
@@ -49,9 +49,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.FragmentManager
+import org.openedx.core.CoreMocks
 import org.openedx.core.R
 import org.openedx.core.module.db.DownloadModel
-import org.openedx.core.module.db.DownloadedState
 import org.openedx.core.module.db.FileType
 import org.openedx.core.ui.IconText
 import org.openedx.core.ui.OpenEdXButton
@@ -476,17 +476,7 @@ private fun CourseOfflineUIPreview() {
                 isDownloading = true,
                 isAllDownloaded = true,
                 largestDownloads = listOf(
-                    DownloadModel(
-                        "",
-                        "",
-                        "",
-                        0,
-                        "",
-                        "",
-                        FileType.X_BLOCK,
-                        DownloadedState.DOWNLOADED,
-                        null
-                    )
+                    CoreMocks.mockDownloadModel
                 ),
             ),
             onDownloadAllClick = {},

--- a/course/src/main/java/org/openedx/course/presentation/outline/CourseContentAllScreen.kt
+++ b/course/src/main/java/org/openedx/course/presentation/outline/CourseContentAllScreen.kt
@@ -36,9 +36,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.FragmentManager
 import org.openedx.core.BlockType
-import org.openedx.core.Mock
+import org.openedx.core.CoreMocks
 import org.openedx.core.domain.model.Block
-import org.openedx.core.domain.model.CourseDatesBannerInfo
 import org.openedx.core.domain.model.Progress
 import org.openedx.core.extension.getChapterBlocks
 import org.openedx.core.ui.CircularProgress
@@ -357,20 +356,14 @@ private fun CourseOutlineScreenPreview() {
         CourseContentAllUI(
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
             uiState = CourseContentAllUIState.CourseData(
-                Mock.mockCourseStructure,
+                CoreMocks.mockCourseStructure,
                 mapOf(),
-                Mock.mockChapterBlock,
+                CoreMocks.mockChapterBlock,
                 "Resumed Unit",
                 mapOf(),
                 mapOf(),
                 mapOf(),
-                CourseDatesBannerInfo(
-                    missedDeadlines = false,
-                    missedGatedContent = false,
-                    verifiedUpgradeLink = "",
-                    contentTypeGatingEnabled = false,
-                    hasEnded = false
-                ),
+                CoreMocks.mockCourseDatesBannerInfo,
                 true
             ),
             uiMessage = null,
@@ -393,20 +386,14 @@ private fun CourseContentAllScreenTabletPreview() {
         CourseContentAllUI(
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
             uiState = CourseContentAllUIState.CourseData(
-                Mock.mockCourseStructure,
+                CoreMocks.mockCourseStructure,
                 mapOf(),
-                Mock.mockChapterBlock,
+                CoreMocks.mockChapterBlock,
                 "Resumed Unit",
                 mapOf(),
                 mapOf(),
                 mapOf(),
-                CourseDatesBannerInfo(
-                    missedDeadlines = false,
-                    missedGatedContent = false,
-                    verifiedUpgradeLink = "",
-                    contentTypeGatingEnabled = false,
-                    hasEnded = false
-                ),
+                CoreMocks.mockCourseDatesBannerInfo,
                 true
             ),
             uiMessage = null,
@@ -426,6 +413,6 @@ private fun CourseContentAllScreenTabletPreview() {
 @Composable
 private fun ResumeCoursePreview() {
     OpenEdXTheme {
-        ResumeCourseButton(block = Mock.mockChapterBlock, displayName = "Resumed Unit") {}
+        ResumeCourseButton(block = CoreMocks.mockChapterBlock, displayName = "Resumed Unit") {}
     }
 }

--- a/course/src/main/java/org/openedx/course/presentation/progress/CourseProgressScreen.kt
+++ b/course/src/main/java/org/openedx/course/presentation/progress/CourseProgressScreen.kt
@@ -1,5 +1,6 @@
 package org.openedx.course.presentation.progress
 
+import android.content.res.Configuration
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -51,20 +52,25 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import org.openedx.core.CoreMocks
 import org.openedx.core.NoContentScreenType
 import org.openedx.core.domain.model.CourseProgress
 import org.openedx.core.ui.CircularProgress
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.NoContentScreen
 import org.openedx.core.ui.displayCutoutForLandscape
+import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appShapes
 import org.openedx.core.ui.theme.appTypography
 import org.openedx.course.R
 import org.openedx.foundation.presentation.UIMessage
 import org.openedx.foundation.presentation.WindowSize
+import org.openedx.foundation.presentation.WindowType
 import org.openedx.foundation.presentation.windowSizeValue
 
 @Composable
@@ -586,4 +592,36 @@ fun CurrentOverallGradeText(
         },
         style = MaterialTheme.appTypography.labelMedium,
     )
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun CourseProgressScreenPreview() {
+    OpenEdXTheme {
+        CourseProgressContent(
+            uiState = CourseProgressUIState.Data(
+                progress = CoreMocks.mockCourseProgress,
+                courseStructure = CoreMocks.mockCourseStructure
+            ),
+            uiMessage = null,
+            windowSize = WindowSize(WindowType.Compact, WindowType.Compact)
+        )
+    }
+}
+
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO, device = Devices.NEXUS_9)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES, device = Devices.NEXUS_9)
+@Composable
+private fun CourseProgressScreenTabletPreview() {
+    OpenEdXTheme {
+        CourseProgressContent(
+            uiState = CourseProgressUIState.Data(
+                progress = CoreMocks.mockCourseProgress,
+                courseStructure = CoreMocks.mockCourseStructure
+            ),
+            uiMessage = null,
+            windowSize = WindowSize(WindowType.Medium, WindowType.Medium)
+        )
+    }
 }

--- a/course/src/main/java/org/openedx/course/presentation/section/CourseSectionFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/section/CourseSectionFragment.kt
@@ -54,10 +54,8 @@ import androidx.fragment.app.Fragment
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
-import org.openedx.core.BlockType
-import org.openedx.core.domain.model.AssignmentProgress
+import org.openedx.core.CoreMocks
 import org.openedx.core.domain.model.Block
-import org.openedx.core.domain.model.BlockCounts
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.displayCutoutForLandscape
@@ -76,7 +74,6 @@ import org.openedx.foundation.presentation.WindowSize
 import org.openedx.foundation.presentation.WindowType
 import org.openedx.foundation.presentation.rememberWindowSize
 import org.openedx.foundation.presentation.windowSizeValue
-import java.util.Date
 import org.openedx.core.R as CoreR
 
 class CourseSectionFragment : Fragment() {
@@ -350,10 +347,10 @@ private fun CourseSectionScreenPreview() {
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
             uiState = CourseSectionUIState.Blocks(
                 listOf(
-                    mockBlock,
-                    mockBlock,
-                    mockBlock,
-                    mockBlock
+                    CoreMocks.mockChapterBlock,
+                    CoreMocks.mockChapterBlock,
+                    CoreMocks.mockChapterBlock,
+                    CoreMocks.mockChapterBlock,
                 ),
                 "",
                 "Course default"
@@ -374,10 +371,10 @@ private fun CourseSectionScreenTabletPreview() {
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
             uiState = CourseSectionUIState.Blocks(
                 listOf(
-                    mockBlock,
-                    mockBlock,
-                    mockBlock,
-                    mockBlock
+                    CoreMocks.mockChapterBlock,
+                    CoreMocks.mockChapterBlock,
+                    CoreMocks.mockChapterBlock,
+                    CoreMocks.mockChapterBlock,
                 ),
                 "",
                 "Course default",
@@ -388,24 +385,3 @@ private fun CourseSectionScreenTabletPreview() {
         )
     }
 }
-
-private val mockBlock = Block(
-    id = "id",
-    blockId = "blockId",
-    lmsWebUrl = "lmsWebUrl",
-    legacyWebUrl = "legacyWebUrl",
-    studentViewUrl = "studentViewUrl",
-    type = BlockType.HTML,
-    displayName = "Block",
-    graded = false,
-    studentViewData = null,
-    studentViewMultiDevice = false,
-    blockCounts = BlockCounts(0),
-    descendants = emptyList(),
-    descendantsType = BlockType.HTML,
-    completion = 0.0,
-    containsGatedContent = false,
-    assignmentProgress = AssignmentProgress("", 1f, 2f, "HM1"),
-    due = Date(),
-    offlineDownload = null
-)

--- a/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
+++ b/course/src/main/java/org/openedx/course/presentation/ui/CourseUI.kt
@@ -93,10 +93,8 @@ import androidx.compose.ui.zIndex
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import org.jsoup.Jsoup
-import org.openedx.core.BlockType
-import org.openedx.core.domain.model.AssignmentProgress
+import org.openedx.core.CoreMocks
 import org.openedx.core.domain.model.Block
-import org.openedx.core.domain.model.BlockCounts
 import org.openedx.core.domain.model.CourseDatesBannerInfo
 import org.openedx.core.domain.model.Progress
 import org.openedx.core.extension.safeDivBy
@@ -116,8 +114,8 @@ import org.openedx.core.ui.theme.appShapes
 import org.openedx.core.ui.theme.appTypography
 import org.openedx.core.utils.TimeUtils
 import org.openedx.core.utils.VideoPreview
+import org.openedx.course.CourseMocks
 import org.openedx.course.R
-import org.openedx.course.presentation.dates.mockedCourseBannerInfo
 import org.openedx.course.presentation.outline.getUnitBlockIcon
 import org.openedx.foundation.extension.nonZero
 import org.openedx.foundation.extension.toFileSize
@@ -1700,7 +1698,7 @@ private fun CourseSectionCardPreview() {
     OpenEdXTheme {
         Surface(color = MaterialTheme.appColors.background) {
             CourseSectionCard(
-                mockChapterBlock,
+                CoreMocks.mockChapterBlock,
                 DownloadedState.DOWNLOADED,
                 onItemClick = {},
                 onDownloadClick = {}
@@ -1716,7 +1714,7 @@ private fun CourseDatesBannerPreview() {
     OpenEdXTheme {
         CourseDatesBanner(
             modifier = Modifier,
-            banner = mockedCourseBannerInfo,
+            banner = CourseMocks.courseDatesBannerInfoWithData,
             resetDates = {}
         )
     }
@@ -1729,7 +1727,7 @@ private fun CourseDatesBannerTabletPreview() {
     OpenEdXTheme {
         CourseDatesBannerTablet(
             modifier = Modifier,
-            banner = mockedCourseBannerInfo,
+            banner = CourseMocks.courseDatesBannerInfoWithData,
             resetDates = {}
         )
     }
@@ -1780,24 +1778,3 @@ private fun CourseMessagePreview() {
         }
     }
 }
-
-private val mockChapterBlock = Block(
-    id = "id",
-    blockId = "blockId",
-    lmsWebUrl = "lmsWebUrl",
-    legacyWebUrl = "legacyWebUrl",
-    studentViewUrl = "studentViewUrl",
-    type = BlockType.CHAPTER,
-    displayName = "Chapter",
-    graded = false,
-    studentViewData = null,
-    studentViewMultiDevice = false,
-    blockCounts = BlockCounts(1),
-    descendants = emptyList(),
-    descendantsType = BlockType.CHAPTER,
-    completion = 0.0,
-    containsGatedContent = false,
-    assignmentProgress = AssignmentProgress("", 1f, 2f, "HM1"),
-    due = Date(),
-    offlineDownload = null
-)

--- a/course/src/main/java/org/openedx/course/presentation/videos/CourseContentVideoScreen.kt
+++ b/course/src/main/java/org/openedx/course/presentation/videos/CourseContentVideoScreen.kt
@@ -29,14 +29,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.FragmentManager
-import org.openedx.core.BlockType
-import org.openedx.core.domain.model.AssignmentProgress
+import org.openedx.core.CoreMocks
 import org.openedx.core.domain.model.Block
-import org.openedx.core.domain.model.BlockCounts
-import org.openedx.core.domain.model.CourseStructure
-import org.openedx.core.domain.model.CoursewareAccess
 import org.openedx.core.domain.model.Progress
-import org.openedx.core.module.download.DownloadModelsSize
 import org.openedx.core.ui.CircularProgress
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.displayCutoutForLandscape
@@ -51,7 +46,6 @@ import org.openedx.foundation.presentation.UIMessage
 import org.openedx.foundation.presentation.WindowSize
 import org.openedx.foundation.presentation.WindowType
 import org.openedx.foundation.presentation.windowSizeValue
-import java.util.Date
 
 @Composable
 fun CourseContentVideoScreen(
@@ -246,17 +240,11 @@ private fun CourseVideosScreenPreview() {
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
             uiMessage = null,
             uiState = CourseVideoUIState.CourseData(
-                mockCourseStructure,
+                CoreMocks.mockCourseStructure,
                 emptyMap(),
                 mapOf(),
                 mapOf(),
-                DownloadModelsSize(
-                    isAllBlocksDownloadedOrDownloading = false,
-                    remainingCount = 0,
-                    remainingSize = 0,
-                    allCount = 1,
-                    allSize = 0
-                ),
+                CoreMocks.mockDownloadModelsSize,
                 isCompletedSectionsShown = false,
                 videoPreview = mapOf(),
                 videoProgress = mapOf(),
@@ -295,16 +283,12 @@ private fun CourseVideosScreenTabletPreview() {
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
             uiMessage = null,
             uiState = CourseVideoUIState.CourseData(
-                mockCourseStructure,
+                CoreMocks.mockCourseStructure,
                 emptyMap(),
                 mapOf(),
                 mapOf(),
-                DownloadModelsSize(
-                    isAllBlocksDownloadedOrDownloading = false,
-                    remainingCount = 0,
-                    remainingSize = 0,
-                    allCount = 0,
-                    allSize = 0
+                CoreMocks.mockDownloadModelsSize.copy(
+                    allCount = 0
                 ),
                 isCompletedSectionsShown = true,
                 videoPreview = mapOf(),
@@ -317,77 +301,3 @@ private fun CourseVideosScreenTabletPreview() {
         )
     }
 }
-
-private val mockAssignmentProgress = AssignmentProgress(
-    assignmentType = "Home",
-    numPointsEarned = 1f,
-    numPointsPossible = 3f,
-    shortLabel = "HM1"
-)
-
-private val mockChapterBlock = Block(
-    id = "id",
-    blockId = "blockId",
-    lmsWebUrl = "lmsWebUrl",
-    legacyWebUrl = "legacyWebUrl",
-    studentViewUrl = "studentViewUrl",
-    type = BlockType.CHAPTER,
-    displayName = "Chapter",
-    graded = false,
-    studentViewData = null,
-    studentViewMultiDevice = false,
-    blockCounts = BlockCounts(1),
-    descendants = emptyList(),
-    descendantsType = BlockType.CHAPTER,
-    completion = 0.0,
-    containsGatedContent = false,
-    assignmentProgress = mockAssignmentProgress,
-    due = Date(),
-    offlineDownload = null
-)
-
-private val mockSequentialBlock = Block(
-    id = "id",
-    blockId = "blockId",
-    lmsWebUrl = "lmsWebUrl",
-    legacyWebUrl = "legacyWebUrl",
-    studentViewUrl = "studentViewUrl",
-    type = BlockType.SEQUENTIAL,
-    displayName = "Sequential",
-    graded = false,
-    studentViewData = null,
-    studentViewMultiDevice = false,
-    blockCounts = BlockCounts(1),
-    descendants = emptyList(),
-    descendantsType = BlockType.SEQUENTIAL,
-    completion = 0.0,
-    containsGatedContent = false,
-    assignmentProgress = mockAssignmentProgress,
-    due = Date(),
-    offlineDownload = null
-)
-
-private val mockCourseStructure = CourseStructure(
-    root = "",
-    blockData = listOf(mockSequentialBlock, mockChapterBlock),
-    id = "id",
-    name = "Course name",
-    number = "",
-    org = "Org",
-    start = Date(),
-    startDisplay = "",
-    startType = "",
-    end = Date(),
-    coursewareAccess = CoursewareAccess(
-        true,
-        "",
-        "",
-        "",
-        "",
-        ""
-    ),
-    media = null,
-    certificate = null,
-    isSelfPaced = false,
-    progress = Progress(1, 3),
-)

--- a/course/src/main/java/org/openedx/course/settings/download/DownloadQueueFragment.kt
+++ b/course/src/main/java/org/openedx/course/settings/download/DownloadQueueFragment.kt
@@ -42,9 +42,9 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
+import org.openedx.core.CoreMocks
 import org.openedx.core.module.db.DownloadModel
 import org.openedx.core.module.db.DownloadedState
-import org.openedx.core.module.db.FileType
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.displayCutoutForLandscape
 import org.openedx.core.ui.statusBarsInset
@@ -226,30 +226,18 @@ private fun DownloadQueueScreenPreview() {
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
             uiState = DownloadQueueUIState.Models(
                 listOf(
-                    DownloadModel(
-                        courseId = "",
-                        id = "",
-                        title = "1",
-                        size = 0,
-                        path = "",
-                        url = "",
-                        type = FileType.VIDEO,
-                        downloadedState = DownloadedState.DOWNLOADING,
+                    CoreMocks.mockDownloadModel.copy(
+                        title = "Video 1",
+                        downloadedState = DownloadedState.DOWNLOADING
                     ),
-                    DownloadModel(
-                        courseId = "",
-                        id = "",
-                        title = "2",
-                        size = 0,
-                        path = "",
-                        url = "",
-                        type = FileType.VIDEO,
-                        downloadedState = DownloadedState.DOWNLOADING,
+                    CoreMocks.mockDownloadModel.copy(
+                        title = "Video 2",
+                        downloadedState = DownloadedState.DOWNLOADING
                     )
                 ),
-                currentProgressId = "",
-                currentProgressValue = 0,
-                currentProgressSize = 1
+                currentProgressId = CoreMocks.mockDownloadModel.id,
+                currentProgressValue = 50,
+                currentProgressSize = 100
             ),
             onBackClick = {},
             onDownloadClick = {}

--- a/course/src/test/java/org/openedx/course/presentation/container/CourseContainerViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/container/CourseContainerViewModelTest.kt
@@ -24,21 +24,12 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
+import org.openedx.core.CoreMocks
 import org.openedx.core.R
 import org.openedx.core.config.Config
 import org.openedx.core.data.api.CourseApi
-import org.openedx.core.data.model.User
 import org.openedx.core.data.storage.CorePreferences
-import org.openedx.core.domain.model.AppConfig
-import org.openedx.core.domain.model.CourseAccessDetails
 import org.openedx.core.domain.model.CourseAccessError
-import org.openedx.core.domain.model.CourseDatesCalendarSync
-import org.openedx.core.domain.model.CourseEnrollmentDetails
-import org.openedx.core.domain.model.CourseInfoOverview
-import org.openedx.core.domain.model.CourseSharingUtmParameters
-import org.openedx.core.domain.model.CourseStructure
-import org.openedx.core.domain.model.CoursewareAccess
-import org.openedx.core.domain.model.EnrollmentDetails
 import org.openedx.core.system.connection.NetworkConnection
 import org.openedx.core.system.notifier.CourseNotifier
 import org.openedx.core.system.notifier.CourseStructureUpdated
@@ -49,7 +40,6 @@ import org.openedx.course.presentation.CourseAnalyticsEvent
 import org.openedx.course.presentation.CourseRouter
 import org.openedx.course.utils.ImageProcessor
 import org.openedx.foundation.system.ResourceManager
-import java.util.Date
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CourseContainerViewModelTest {
@@ -76,138 +66,17 @@ class CourseContainerViewModelTest {
     private val noInternet = "Slow or no internet connection"
     private val somethingWrong = "Something went wrong"
 
-    private val user = User(
-        id = 0,
-        username = "",
-        email = "",
-        name = "",
-    )
-    private val appConfig = AppConfig(
-        CourseDatesCalendarSync(
-            isEnabled = true,
-            isSelfPacedEnabled = true,
-            isInstructorPacedEnabled = true,
-            isDeepLinkEnabled = false,
-        )
-    )
-    private val courseDetails = CourseEnrollmentDetails(
-        id = "id",
-        courseUpdates = "",
-        courseHandouts = "",
-        discussionUrl = "",
-        courseAccessDetails = CourseAccessDetails(
-            false,
-            false,
-            false,
-            null,
-            coursewareAccess = CoursewareAccess(
-                false,
-                "",
-                "",
-                "",
-                "",
-                ""
-            )
-        ),
-        certificate = null,
-        enrollmentDetails = EnrollmentDetails(
-            null,
-            "audit",
-            false,
-            Date()
-        ),
-        courseInfoOverview = CourseInfoOverview(
-            "Open edX Demo Course",
-            "",
-            "OpenedX",
-            Date(),
-            "",
-            "",
-            null,
-            false,
-            null,
-            CourseSharingUtmParameters("", ""),
-            "",
-        )
-    )
-
-    private val courseStructure = CourseStructure(
-        root = "",
-        blockData = listOf(),
-        id = "id",
-        name = "Course name",
-        number = "",
-        org = "Org",
-        start = Date(0),
-        startDisplay = "",
-        startType = "",
-        end = null,
-        coursewareAccess = CoursewareAccess(
-            true,
-            "",
-            "",
-            "",
-            "",
-            ""
-        ),
-        media = null,
-        certificate = null,
-        isSelfPaced = false,
-        progress = null
-    )
-
-    private val enrollmentDetails = CourseEnrollmentDetails(
-        id = "",
-        courseUpdates = "",
-        courseHandouts = "",
-        discussionUrl = "",
-        courseAccessDetails = CourseAccessDetails(
-            false,
-            false,
-            false,
-            null,
-            CoursewareAccess(
-                false,
-                "",
-                "",
-                "",
-                "",
-                ""
-            )
-        ),
-        certificate = null,
-        enrollmentDetails = EnrollmentDetails(
-            null,
-            "",
-            false,
-            null
-        ),
-        courseInfoOverview = CourseInfoOverview(
-            "Open edX Demo Course",
-            "",
-            "OpenedX",
-            null,
-            "",
-            "",
-            null,
-            false,
-            null,
-            CourseSharingUtmParameters("", ""),
-            "",
-        )
-    )
-
     @Before
     fun setUp() {
         Dispatchers.setMain(dispatcher)
         every { resourceManager.getString(id = R.string.platform_name) } returns openEdx
         every { resourceManager.getString(R.string.core_error_no_connection) } returns noInternet
         every { resourceManager.getString(R.string.core_error_unknown_error) } returns somethingWrong
-        every { corePreferences.user } returns user
-        every { corePreferences.appConfig } returns appConfig
+        every { corePreferences.user } returns CoreMocks.mockUser
+        every { corePreferences.appConfig } returns CoreMocks.mockAppConfig
         every { courseNotifier.notifier } returns emptyFlow()
         every { config.getApiHostURL() } returns "baseUrl"
-        coEvery { interactor.getEnrollmentDetails(any()) } returns courseDetails
+        coEvery { interactor.getEnrollmentDetails(any()) } returns CoreMocks.mockCourseEnrollmentDetails
         every { imageProcessor.loadImage(any(), any(), any()) } returns Unit
         every { imageProcessor.applyBlur(any(), any()) } returns mockBitmap
     }
@@ -292,8 +161,12 @@ class CourseContainerViewModelTest {
             courseRouter
         )
         every { networkConnection.isOnline() } returns true
-        coEvery { interactor.getCourseStructureFlow(any(), any()) } returns flowOf(courseStructure)
-        coEvery { interactor.getEnrollmentDetailsFlow(any()) } returns flowOf(enrollmentDetails)
+        coEvery { interactor.getCourseStructureFlow(any(), any()) } returns flowOf(
+            CoreMocks.mockCourseStructure
+        )
+        coEvery { interactor.getEnrollmentDetailsFlow(any()) } returns flowOf(
+            CoreMocks.mockCourseEnrollmentDetails
+        )
         every {
             analytics.logScreenEvent(
                 CourseAnalyticsEvent.DASHBOARD.eventName,
@@ -345,8 +218,12 @@ class CourseContainerViewModelTest {
             courseRouter
         )
         every { networkConnection.isOnline() } returns false
-        coEvery { interactor.getCourseStructureFlow(any(), any()) } returns flowOf(courseStructure)
-        coEvery { interactor.getEnrollmentDetailsFlow(any()) } returns flowOf(enrollmentDetails)
+        coEvery { interactor.getCourseStructureFlow(any(), any()) } returns flowOf(
+            CoreMocks.mockCourseStructure
+        )
+        coEvery { interactor.getEnrollmentDetailsFlow(any()) } returns flowOf(
+            CoreMocks.mockCourseEnrollmentDetails
+        )
         every {
             analytics.logScreenEvent(
                 CourseAnalyticsEvent.DASHBOARD.eventName,
@@ -426,8 +303,8 @@ class CourseContainerViewModelTest {
             calendarSyncScheduler,
             courseRouter
         )
-        coEvery { interactor.getEnrollmentDetails(any()) } returns courseDetails
-        coEvery { interactor.getCourseStructure(any(), true) } returns courseStructure
+        coEvery { interactor.getEnrollmentDetails(any()) } returns CoreMocks.mockCourseEnrollmentDetails
+        coEvery { interactor.getCourseStructure(any(), true) } returns CoreMocks.mockCourseStructure
         coEvery { courseNotifier.send(CourseStructureUpdated("")) } returns Unit
         viewModel.updateData()
         advanceUntilIdle()

--- a/course/src/test/java/org/openedx/course/presentation/dates/CourseDatesViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/dates/CourseDatesViewModelTest.kt
@@ -24,34 +24,26 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
 import org.openedx.core.CalendarRouter
+import org.openedx.core.CoreMocks
 import org.openedx.core.R
 import org.openedx.core.config.Config
-import org.openedx.core.data.model.DateType
-import org.openedx.core.data.model.User
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.interactor.CalendarInteractor
-import org.openedx.core.domain.model.AppConfig
 import org.openedx.core.domain.model.CourseCalendarState
-import org.openedx.core.domain.model.CourseDateBlock
-import org.openedx.core.domain.model.CourseDatesBannerInfo
-import org.openedx.core.domain.model.CourseDatesCalendarSync
 import org.openedx.core.domain.model.CourseDatesResult
-import org.openedx.core.domain.model.CourseStructure
-import org.openedx.core.domain.model.CoursewareAccess
-import org.openedx.core.domain.model.DatesSection
 import org.openedx.core.system.notifier.CalendarSyncEvent.CreateCalendarSyncEvent
 import org.openedx.core.system.notifier.CourseLoading
 import org.openedx.core.system.notifier.CourseNotifier
 import org.openedx.core.system.notifier.calendar.CalendarEvent
 import org.openedx.core.system.notifier.calendar.CalendarNotifier
 import org.openedx.core.system.notifier.calendar.CalendarSynced
+import org.openedx.course.CourseMocks
 import org.openedx.course.domain.interactor.CourseInteractor
 import org.openedx.course.presentation.CourseAnalytics
 import org.openedx.course.presentation.CourseRouter
 import org.openedx.foundation.presentation.UIMessage
 import org.openedx.foundation.system.ResourceManager
 import java.net.UnknownHostException
-import java.util.Date
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CourseDatesViewModelTest {
@@ -76,85 +68,15 @@ class CourseDatesViewModelTest {
     private val noInternet = "Slow or no internet connection"
     private val somethingWrong = "Something went wrong"
 
-    private val user = User(
-        id = 0,
-        username = "",
-        email = "",
-        name = "",
-    )
-    private val appConfig = AppConfig(
-        CourseDatesCalendarSync(
-            isEnabled = true,
-            isSelfPacedEnabled = true,
-            isInstructorPacedEnabled = true,
-            isDeepLinkEnabled = false,
-        )
-    )
-    private val dateBlock = CourseDateBlock(
-        complete = false,
-        date = Date(),
-        dateType = DateType.TODAY_DATE,
-        description = "Mocked Course Date Description"
-    )
-    private val mockDateBlocks = linkedMapOf(
-        Pair(
-            DatesSection.COMPLETED,
-            listOf(dateBlock, dateBlock)
-        ),
-        Pair(
-            DatesSection.PAST_DUE,
-            listOf(dateBlock, dateBlock)
-        ),
-        Pair(
-            DatesSection.TODAY,
-            listOf(dateBlock, dateBlock)
-        )
-    )
-    private val mockCourseDatesBannerInfo = CourseDatesBannerInfo(
-        missedDeadlines = true,
-        missedGatedContent = false,
-        verifiedUpgradeLink = "",
-        contentTypeGatingEnabled = false,
-        hasEnded = true,
-    )
-    private val mockedCourseDatesResult = CourseDatesResult(
-        datesSection = mockDateBlocks,
-        courseBanner = mockCourseDatesBannerInfo,
-    )
-    private val courseStructure = CourseStructure(
-        root = "",
-        blockData = listOf(),
-        id = "id",
-        name = "Course name",
-        number = "",
-        org = "Org",
-        start = Date(0),
-        startDisplay = "",
-        startType = "",
-        end = null,
-        coursewareAccess = CoursewareAccess(
-            true,
-            "",
-            "",
-            "",
-            "",
-            ""
-        ),
-        media = null,
-        certificate = null,
-        isSelfPaced = true,
-        progress = null
-    )
-
     @Before
     fun setUp() {
         Dispatchers.setMain(dispatcher)
         every { resourceManager.getString(id = R.string.platform_name) } returns openEdx
         every { resourceManager.getString(R.string.core_error_no_connection) } returns noInternet
         every { resourceManager.getString(R.string.core_error_unknown_error) } returns somethingWrong
-        coEvery { interactor.getCourseStructure(any()) } returns courseStructure
-        every { corePreferences.user } returns user
-        every { corePreferences.appConfig } returns appConfig
+        coEvery { interactor.getCourseStructure(any()) } returns CoreMocks.mockCourseStructure
+        every { corePreferences.user } returns CoreMocks.mockUser
+        every { corePreferences.appConfig } returns CoreMocks.mockAppConfig
         every { notifier.notifier } returns flowOf(CourseLoading(false))
         coEvery { notifier.send(any<CreateCalendarSyncEvent>()) } returns Unit
         coEvery { notifier.send(any<CourseLoading>()) } returns Unit
@@ -249,7 +171,7 @@ class CourseDatesViewModelTest {
             courseRouter,
             calendarRouter,
         )
-        coEvery { interactor.getCourseDates(any()) } returns mockedCourseDatesResult
+        coEvery { interactor.getCourseDates(any()) } returns CourseMocks.courseDatesResultWithData
         val message = async {
             withTimeoutOrNull(5000) {
                 viewModel.uiMessage.first() as? UIMessage.SnackBarMessage
@@ -281,7 +203,7 @@ class CourseDatesViewModelTest {
         )
         coEvery { interactor.getCourseDates(any()) } returns CourseDatesResult(
             datesSection = linkedMapOf(),
-            courseBanner = mockCourseDatesBannerInfo,
+            courseBanner = CoreMocks.mockCourseDatesBannerInfo,
         )
         val message = async {
             withTimeoutOrNull(5000) {

--- a/course/src/test/java/org/openedx/course/presentation/home/CourseHomeViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/home/CourseHomeViewModelTest.kt
@@ -21,7 +21,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
-import org.openedx.core.Mock
+import org.openedx.core.CoreMocks
 import org.openedx.core.R
 import org.openedx.core.config.Config
 import org.openedx.core.data.storage.CorePreferences
@@ -75,16 +75,6 @@ class CourseHomeViewModelTest {
     private val noInternet = "Slow or no internet connection"
     private val somethingWrong = "Something went wrong"
     private val cantDownload = "You can download content only from Wi-fi"
-
-    private val courseStructure = Mock.mockCourseStructure.copy(
-        id = courseId,
-        name = courseTitle
-    )
-    private val courseComponentStatus = Mock.mockCourseComponentStatus
-    private val courseDatesResult = Mock.mockCourseDatesResult
-    private val courseProgress = Mock.mockCourseProgress
-    private val videoProgress = Mock.mockVideoProgress
-    private val resetCourseDates = Mock.mockResetCourseDates
 
     @Before
     fun setUp() {
@@ -143,23 +133,26 @@ class CourseHomeViewModelTest {
     fun `getCourseData success`() = runTest {
         coEvery { interactor.getCourseStructureFlow(courseId, false) } returns flow {
             emit(
-                courseStructure
+                CoreMocks.mockCourseStructure.copy(
+                    id = courseId,
+                    name = courseTitle
+                )
             )
         }
         coEvery { interactor.getCourseStatusFlow(courseId) } returns flow {
             emit(
-                courseComponentStatus
+                CoreMocks.mockCourseComponentStatus
             )
         }
-        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(courseDatesResult) }
+        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(CoreMocks.mockCourseDatesResult) }
         coEvery {
             interactor.getCourseProgress(
                 courseId,
                 false,
                 true
             )
-        } returns flow { emit(courseProgress) }
-        coEvery { interactor.getVideoProgress("video1") } returns videoProgress
+        } returns flow { emit(CoreMocks.mockCourseProgress) }
+        coEvery { interactor.getVideoProgress("video1") } returns CoreMocks.mockVideoProgress
 
         val viewModel = CourseHomeViewModel(
             courseId = courseId,
@@ -192,7 +185,7 @@ class CourseHomeViewModelTest {
         val courseData = viewModel.uiState.value as CourseHomeUIState.CourseData
         assertEquals(courseId, courseData.courseStructure.id)
         assertEquals(courseTitle, courseData.courseStructure.name)
-        assertEquals(courseProgress, courseData.courseProgress)
+        assertEquals(CoreMocks.mockCourseProgress, courseData.courseProgress)
     }
 
     @Test
@@ -205,17 +198,17 @@ class CourseHomeViewModelTest {
         } returns flow { throw UnknownHostException() }
         coEvery { interactor.getCourseStatusFlow(courseId) } returns flow {
             emit(
-                courseComponentStatus
+                CoreMocks.mockCourseComponentStatus
             )
         }
-        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(courseDatesResult) }
+        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(CoreMocks.mockCourseDatesResult) }
         coEvery {
             interactor.getCourseProgress(
                 courseId,
                 false,
                 true
             )
-        } returns flow { emit(courseProgress) }
+        } returns flow { emit(CoreMocks.mockCourseProgress) }
 
         val viewModel = CourseHomeViewModel(
             courseId = courseId,
@@ -253,17 +246,17 @@ class CourseHomeViewModelTest {
         } returns flow { throw Exception() }
         coEvery { interactor.getCourseStatusFlow(courseId) } returns flow {
             emit(
-                courseComponentStatus
+                CoreMocks.mockCourseComponentStatus
             )
         }
-        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(courseDatesResult) }
+        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(CoreMocks.mockCourseDatesResult) }
         coEvery {
             interactor.getCourseProgress(
                 courseId,
                 false,
                 true
             )
-        } returns flow { emit(courseProgress) }
+        } returns flow { emit(CoreMocks.mockCourseProgress) }
 
         val viewModel = CourseHomeViewModel(
             courseId = courseId,
@@ -297,22 +290,22 @@ class CourseHomeViewModelTest {
 
         coEvery { interactor.getCourseStructureFlow(courseId, false) } returns flow {
             emit(
-                courseStructure
+                CoreMocks.mockCourseStructure
             )
         }
         coEvery { interactor.getCourseStatusFlow(courseId) } returns flow {
             emit(
-                courseComponentStatus
+                CoreMocks.mockCourseComponentStatus
             )
         }
-        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(courseDatesResult) }
+        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(CoreMocks.mockCourseDatesResult) }
         coEvery {
             interactor.getCourseProgress(
                 courseId,
                 false,
                 true
             )
-        } returns flow { emit(courseProgress) }
+        } returns flow { emit(CoreMocks.mockCourseProgress) }
 
         val viewModel = CourseHomeViewModel(
             courseId = courseId,
@@ -343,25 +336,25 @@ class CourseHomeViewModelTest {
 
     @Test
     fun `resetCourseDatesBanner success`() = runTest {
-        coEvery { interactor.resetCourseDates(courseId) } returns resetCourseDates
+        coEvery { interactor.resetCourseDates(courseId) } returns CoreMocks.mockResetCourseDates
         coEvery { interactor.getCourseStructureFlow(courseId, false) } returns flow {
             emit(
-                courseStructure
+                CoreMocks.mockCourseStructure
             )
         }
         coEvery { interactor.getCourseStatusFlow(courseId) } returns flow {
             emit(
-                courseComponentStatus
+                CoreMocks.mockCourseComponentStatus
             )
         }
-        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(courseDatesResult) }
+        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(CoreMocks.mockCourseDatesResult) }
         coEvery {
             interactor.getCourseProgress(
                 courseId,
                 false,
                 true
             )
-        } returns flow { emit(courseProgress) }
+        } returns flow { emit(CoreMocks.mockCourseProgress) }
 
         val viewModel = CourseHomeViewModel(
             courseId = courseId,
@@ -403,22 +396,22 @@ class CourseHomeViewModelTest {
         coEvery { interactor.resetCourseDates(courseId) } throws UnknownHostException()
         coEvery { interactor.getCourseStructureFlow(courseId, false) } returns flow {
             emit(
-                courseStructure
+                CoreMocks.mockCourseStructure
             )
         }
         coEvery { interactor.getCourseStatusFlow(courseId) } returns flow {
             emit(
-                courseComponentStatus
+                CoreMocks.mockCourseComponentStatus
             )
         }
-        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(courseDatesResult) }
+        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(CoreMocks.mockCourseDatesResult) }
         coEvery {
             interactor.getCourseProgress(
                 courseId,
                 false,
                 true
             )
-        } returns flow { emit(courseProgress) }
+        } returns flow { emit(CoreMocks.mockCourseProgress) }
 
         val viewModel = CourseHomeViewModel(
             courseId = courseId,
@@ -459,22 +452,25 @@ class CourseHomeViewModelTest {
     fun `logVideoClick analytics event`() = runTest {
         coEvery { interactor.getCourseStructureFlow(courseId, false) } returns flow {
             emit(
-                courseStructure
+                CoreMocks.mockCourseStructure.copy(
+                    id = courseId,
+                    name = courseTitle
+                )
             )
         }
         coEvery { interactor.getCourseStatusFlow(courseId) } returns flow {
             emit(
-                courseComponentStatus
+                CoreMocks.mockCourseComponentStatus
             )
         }
-        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(courseDatesResult) }
+        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(CoreMocks.mockCourseDatesResult) }
         coEvery {
             interactor.getCourseProgress(
                 courseId,
                 false,
                 true
             )
-        } returns flow { emit(courseProgress) }
+        } returns flow { emit(CoreMocks.mockCourseProgress) }
 
         val viewModel = CourseHomeViewModel(
             courseId = courseId,
@@ -517,22 +513,25 @@ class CourseHomeViewModelTest {
     fun `logAssignmentClick analytics event`() = runTest {
         coEvery { interactor.getCourseStructureFlow(courseId, false) } returns flow {
             emit(
-                courseStructure
+                CoreMocks.mockCourseStructure.copy(
+                    id = courseId,
+                    name = courseTitle
+                )
             )
         }
         coEvery { interactor.getCourseStatusFlow(courseId) } returns flow {
             emit(
-                courseComponentStatus
+                CoreMocks.mockCourseComponentStatus
             )
         }
-        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(courseDatesResult) }
+        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(CoreMocks.mockCourseDatesResult) }
         coEvery {
             interactor.getCourseProgress(
                 courseId,
                 false,
                 true
             )
-        } returns flow { emit(courseProgress) }
+        } returns flow { emit(CoreMocks.mockCourseProgress) }
 
         val viewModel = CourseHomeViewModel(
             courseId = courseId,
@@ -575,22 +574,22 @@ class CourseHomeViewModelTest {
     fun `viewCertificateTappedEvent analytics event`() = runTest {
         coEvery { interactor.getCourseStructureFlow(courseId, false) } returns flow {
             emit(
-                courseStructure
+                CoreMocks.mockCourseStructure
             )
         }
         coEvery { interactor.getCourseStatusFlow(courseId) } returns flow {
             emit(
-                courseComponentStatus
+                CoreMocks.mockCourseComponentStatus
             )
         }
-        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(courseDatesResult) }
+        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(CoreMocks.mockCourseDatesResult) }
         coEvery {
             interactor.getCourseProgress(
                 courseId,
                 false,
                 true
             )
-        } returns flow { emit(courseProgress) }
+        } returns flow { emit(CoreMocks.mockCourseProgress) }
 
         val viewModel = CourseHomeViewModel(
             courseId = courseId,
@@ -631,22 +630,22 @@ class CourseHomeViewModelTest {
     fun `getCourseProgress success`() = runTest {
         coEvery { interactor.getCourseStructureFlow(courseId, false) } returns flow {
             emit(
-                courseStructure
+                CoreMocks.mockCourseStructure
             )
         }
         coEvery { interactor.getCourseStatusFlow(courseId) } returns flow {
             emit(
-                courseComponentStatus
+                CoreMocks.mockCourseComponentStatus
             )
         }
-        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(courseDatesResult) }
+        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(CoreMocks.mockCourseDatesResult) }
         coEvery {
             interactor.getCourseProgress(
                 courseId,
                 false,
                 true
             )
-        } returns flow { emit(courseProgress) }
+        } returns flow { emit(CoreMocks.mockCourseProgress) }
 
         val viewModel = CourseHomeViewModel(
             courseId = courseId,
@@ -679,22 +678,22 @@ class CourseHomeViewModelTest {
     fun `CourseStructureUpdated notifier event`() = runTest {
         coEvery { interactor.getCourseStructureFlow(courseId, false) } returns flow {
             emit(
-                courseStructure
+                CoreMocks.mockCourseStructure
             )
         }
         coEvery { interactor.getCourseStatusFlow(courseId) } returns flow {
             emit(
-                courseComponentStatus
+                CoreMocks.mockCourseComponentStatus
             )
         }
-        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(courseDatesResult) }
+        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(CoreMocks.mockCourseDatesResult) }
         coEvery {
             interactor.getCourseProgress(
                 courseId,
                 false,
                 true
             )
-        } returns flow { emit(courseProgress) }
+        } returns flow { emit(CoreMocks.mockCourseProgress) }
 
         every { courseNotifier.notifier } returns flow { emit(CourseStructureUpdated(courseId)) }
 
@@ -727,22 +726,22 @@ class CourseHomeViewModelTest {
     fun `CourseOpenBlock notifier event`() = runTest {
         coEvery { interactor.getCourseStructureFlow(courseId, false) } returns flow {
             emit(
-                courseStructure
+                CoreMocks.mockCourseStructure
             )
         }
         coEvery { interactor.getCourseStatusFlow(courseId) } returns flow {
             emit(
-                courseComponentStatus
+                CoreMocks.mockCourseComponentStatus
             )
         }
-        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(courseDatesResult) }
+        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(CoreMocks.mockCourseDatesResult) }
         coEvery {
             interactor.getCourseProgress(
                 courseId,
                 false,
                 true
             )
-        } returns flow { emit(courseProgress) }
+        } returns flow { emit(CoreMocks.mockCourseProgress) }
 
         every { courseNotifier.notifier } returns flow { emit(CourseOpenBlock("test-block-id")) }
 
@@ -773,22 +772,22 @@ class CourseHomeViewModelTest {
     fun `CourseProgressLoaded notifier event`() = runTest {
         coEvery { interactor.getCourseStructureFlow(courseId, false) } returns flow {
             emit(
-                courseStructure
+                CoreMocks.mockCourseStructure
             )
         }
         coEvery { interactor.getCourseStatusFlow(courseId) } returns flow {
             emit(
-                courseComponentStatus
+                CoreMocks.mockCourseComponentStatus
             )
         }
-        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(courseDatesResult) }
+        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(CoreMocks.mockCourseDatesResult) }
         coEvery {
             interactor.getCourseProgress(
                 courseId,
                 false,
                 true
             )
-        } returns flow { emit(courseProgress) }
+        } returns flow { emit(CoreMocks.mockCourseProgress) }
 
         every { courseNotifier.notifier } returns flow { emit(CourseProgressLoaded) }
 
@@ -823,22 +822,22 @@ class CourseHomeViewModelTest {
 
         coEvery { interactor.getCourseStructureFlow(courseId, false) } returns flow {
             emit(
-                courseStructure
+                CoreMocks.mockCourseStructure
             )
         }
         coEvery { interactor.getCourseStatusFlow(courseId) } returns flow {
             emit(
-                courseComponentStatus
+                CoreMocks.mockCourseComponentStatus
             )
         }
-        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(courseDatesResult) }
+        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(CoreMocks.mockCourseDatesResult) }
         coEvery {
             interactor.getCourseProgress(
                 courseId,
                 false,
                 true
             )
-        } returns flow { emit(courseProgress) }
+        } returns flow { emit(CoreMocks.mockCourseProgress) }
 
         val viewModel = CourseHomeViewModel(
             courseId = courseId,

--- a/course/src/test/java/org/openedx/course/presentation/outline/CourseOutlineViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/outline/CourseOutlineViewModelTest.kt
@@ -28,27 +28,14 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
-import org.openedx.core.BlockType
+import org.openedx.core.CoreMocks
 import org.openedx.core.R
 import org.openedx.core.config.Config
-import org.openedx.core.data.model.DateType
 import org.openedx.core.data.storage.CorePreferences
-import org.openedx.core.domain.model.AssignmentProgress
-import org.openedx.core.domain.model.Block
-import org.openedx.core.domain.model.BlockCounts
 import org.openedx.core.domain.model.CourseComponentStatus
-import org.openedx.core.domain.model.CourseDateBlock
-import org.openedx.core.domain.model.CourseDatesBannerInfo
-import org.openedx.core.domain.model.CourseDatesResult
-import org.openedx.core.domain.model.CourseStructure
-import org.openedx.core.domain.model.CoursewareAccess
-import org.openedx.core.domain.model.DatesSection
 import org.openedx.core.module.DownloadWorkerController
 import org.openedx.core.module.db.DownloadDao
-import org.openedx.core.module.db.DownloadModel
 import org.openedx.core.module.db.DownloadModelEntity
-import org.openedx.core.module.db.DownloadedState
-import org.openedx.core.module.db.FileType
 import org.openedx.core.module.download.DownloadHelper
 import org.openedx.core.presentation.CoreAnalytics
 import org.openedx.core.presentation.CoreAnalyticsEvent
@@ -63,7 +50,6 @@ import org.openedx.foundation.presentation.UIMessage
 import org.openedx.foundation.system.ResourceManager
 import org.openedx.foundation.utils.FileUtil
 import java.net.UnknownHostException
-import java.util.Date
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CourseOutlineViewModelTest {
@@ -92,142 +78,6 @@ class CourseOutlineViewModelTest {
     private val somethingWrong = "Something went wrong"
     private val cantDownload = "You can download content only from Wi-fi"
 
-    private val assignmentProgress = AssignmentProgress(
-        assignmentType = "Homework",
-        numPointsEarned = 1f,
-        numPointsPossible = 3f,
-        shortLabel = "HW1",
-    )
-
-    private val blocks = listOf(
-        Block(
-            id = "id",
-            blockId = "blockId",
-            lmsWebUrl = "lmsWebUrl",
-            legacyWebUrl = "legacyWebUrl",
-            studentViewUrl = "studentViewUrl",
-            type = BlockType.CHAPTER,
-            displayName = "Block",
-            graded = false,
-            studentViewData = null,
-            studentViewMultiDevice = false,
-            blockCounts = BlockCounts(0),
-            descendants = listOf("1", "id1"),
-            descendantsType = BlockType.HTML,
-            completion = 0.0,
-            assignmentProgress = assignmentProgress,
-            due = Date(),
-            offlineDownload = null,
-        ),
-        Block(
-            id = "id1",
-            blockId = "blockId",
-            lmsWebUrl = "lmsWebUrl",
-            legacyWebUrl = "legacyWebUrl",
-            studentViewUrl = "studentViewUrl",
-            type = BlockType.HTML,
-            displayName = "Block",
-            graded = false,
-            studentViewData = null,
-            studentViewMultiDevice = false,
-            blockCounts = BlockCounts(0),
-            descendants = listOf("id2"),
-            descendantsType = BlockType.HTML,
-            completion = 0.0,
-            assignmentProgress = assignmentProgress,
-            due = Date(),
-            offlineDownload = null,
-        ),
-        Block(
-            id = "id2",
-            blockId = "blockId",
-            lmsWebUrl = "lmsWebUrl",
-            legacyWebUrl = "legacyWebUrl",
-            studentViewUrl = "studentViewUrl",
-            type = BlockType.HTML,
-            displayName = "Block",
-            graded = false,
-            studentViewData = null,
-            studentViewMultiDevice = false,
-            blockCounts = BlockCounts(0),
-            descendants = emptyList(),
-            descendantsType = BlockType.HTML,
-            completion = 0.0,
-            assignmentProgress = assignmentProgress,
-            due = Date(),
-            offlineDownload = null,
-        )
-    )
-
-    private val courseStructure = CourseStructure(
-        root = "",
-        blockData = blocks,
-        id = "id",
-        name = "Course name",
-        number = "",
-        org = "Org",
-        start = Date(),
-        startDisplay = "",
-        startType = "",
-        end = Date(),
-        coursewareAccess = CoursewareAccess(
-            true,
-            "",
-            "",
-            "",
-            "",
-            ""
-        ),
-        media = null,
-        certificate = null,
-        isSelfPaced = false,
-        progress = null
-    )
-
-    private val dateBlock = CourseDateBlock(
-        complete = false,
-        date = Date(),
-        dateType = DateType.TODAY_DATE,
-        description = "Mocked Course Date Description"
-    )
-    private val mockDateBlocks = linkedMapOf(
-        Pair(
-            DatesSection.COMPLETED,
-            listOf(dateBlock, dateBlock)
-        ),
-        Pair(
-            DatesSection.PAST_DUE,
-            listOf(dateBlock, dateBlock)
-        ),
-        Pair(
-            DatesSection.TODAY,
-            listOf(dateBlock, dateBlock)
-        )
-    )
-    private val mockCourseDatesBannerInfo = CourseDatesBannerInfo(
-        missedDeadlines = true,
-        missedGatedContent = false,
-        verifiedUpgradeLink = "",
-        contentTypeGatingEnabled = false,
-        hasEnded = true,
-    )
-    private val mockedCourseDatesResult = CourseDatesResult(
-        datesSection = mockDateBlocks,
-        courseBanner = mockCourseDatesBannerInfo,
-    )
-
-    private val downloadModel = DownloadModel(
-        "id",
-        "title",
-        "",
-        0,
-        "",
-        "url",
-        FileType.VIDEO,
-        DownloadedState.NOT_DOWNLOADED,
-        null
-    )
-
     @Before
     fun setUp() {
         Dispatchers.setMain(dispatcher)
@@ -240,8 +90,8 @@ class CourseOutlineViewModelTest {
         every { downloadDialogManager.showDownloadFailedPopup(any(), any()) } returns Unit
         every { preferencesManager.isRelativeDatesEnabled } returns true
 
-        coEvery { interactor.getCourseDates(any()) } returns mockedCourseDatesResult
-        coEvery { interactor.getCourseDatesFlow(any()) } returns flowOf(mockedCourseDatesResult)
+        coEvery { interactor.getCourseDates(any()) } returns CoreMocks.mockCourseDatesResult
+        coEvery { interactor.getCourseDatesFlow(any()) } returns flowOf(CoreMocks.mockCourseDatesResult)
     }
 
     @After
@@ -253,7 +103,7 @@ class CourseOutlineViewModelTest {
     fun `getCourseDataInternal no internet connection exception`() =
         runTest(UnconfinedTestDispatcher()) {
             coEvery { interactor.getCourseStructureFlow(any(), any()) } returns flowOf(
-                courseStructure
+                CoreMocks.mockCourseStructure
             )
             every { networkConnection.isOnline() } returns true
             every { downloadDao.getAllDataFlow() } returns flow { emit(emptyList()) }
@@ -307,7 +157,9 @@ class CourseOutlineViewModelTest {
     @Suppress("TooGenericExceptionThrown")
     @Test
     fun `getCourseDataInternal unknown exception`() = runTest(UnconfinedTestDispatcher()) {
-        coEvery { interactor.getCourseStructureFlow(any(), any()) } returns flowOf(courseStructure)
+        coEvery { interactor.getCourseStructureFlow(any(), any()) } returns flowOf(
+            CoreMocks.mockCourseStructure
+        )
         every { networkConnection.isOnline() } returns true
         every { downloadDao.getAllDataFlow() } returns flow { emit(emptyList()) }
         coEvery { interactor.getCourseStatusFlow(any()) } returns flow { throw Exception() }
@@ -347,14 +199,14 @@ class CourseOutlineViewModelTest {
     fun `getCourseDataInternal success with internet connection`() =
         runTest(UnconfinedTestDispatcher()) {
             coEvery { interactor.getCourseStructureFlow(any(), any()) } returns flowOf(
-                courseStructure
+                CoreMocks.mockCourseStructure
             )
             every { networkConnection.isOnline() } returns true
             coEvery { downloadDao.getAllDataFlow() } returns flow {
                 emit(
                     listOf(
                         DownloadModelEntity.createFrom(
-                            downloadModel
+                            CoreMocks.mockDownloadModel
                         )
                     )
                 )
@@ -401,14 +253,14 @@ class CourseOutlineViewModelTest {
     fun `getCourseDataInternal success without internet connection`() =
         runTest(UnconfinedTestDispatcher()) {
             coEvery { interactor.getCourseStructureFlow(any(), any()) } returns flowOf(
-                courseStructure
+                CoreMocks.mockCourseStructure
             )
             every { networkConnection.isOnline() } returns false
             coEvery { downloadDao.getAllDataFlow() } returns flow {
                 emit(
                     listOf(
                         DownloadModelEntity.createFrom(
-                            downloadModel
+                            CoreMocks.mockDownloadModel
                         )
                     )
                 )
@@ -454,14 +306,14 @@ class CourseOutlineViewModelTest {
     fun `updateCourseData success with internet connection`() =
         runTest(UnconfinedTestDispatcher()) {
             coEvery { interactor.getCourseStructureFlow(any(), any()) } returns flowOf(
-                courseStructure
+                CoreMocks.mockCourseStructure
             )
             every { networkConnection.isOnline() } returns true
             coEvery { downloadDao.getAllDataFlow() } returns flow {
                 emit(
                     listOf(
                         DownloadModelEntity.createFrom(
-                            downloadModel
+                            CoreMocks.mockDownloadModel
                         )
                     )
                 )
@@ -506,7 +358,9 @@ class CourseOutlineViewModelTest {
     @Test
     fun `CourseStructureUpdated notifier test`() = runTest(UnconfinedTestDispatcher()) {
         coEvery { downloadDao.getAllDataFlow() } returns flow { emit(emptyList()) }
-        coEvery { interactor.getCourseStructureFlow(any(), any()) } returns flowOf(courseStructure)
+        coEvery { interactor.getCourseStructureFlow(any(), any()) } returns flowOf(
+            CoreMocks.mockCourseStructure
+        )
         coEvery { notifier.notifier } returns flow { emit(CourseStructureUpdated("")) }
         every { networkConnection.isOnline() } returns true
         coEvery { interactor.getCourseStatusFlow(any()) } returns flowOf(CourseComponentStatus("id"))
@@ -545,8 +399,10 @@ class CourseOutlineViewModelTest {
     @Test
     fun `saveDownloadModels test`() = runTest(UnconfinedTestDispatcher()) {
         every { preferencesManager.videoSettings.wifiDownloadOnly } returns false
-        coEvery { interactor.getCourseStructure(any()) } returns courseStructure
-        coEvery { interactor.getCourseStructureFlow(any(), any()) } returns flowOf(courseStructure)
+        coEvery { interactor.getCourseStructure(any()) } returns CoreMocks.mockCourseStructure
+        coEvery { interactor.getCourseStructureFlow(any(), any()) } returns flowOf(
+            CoreMocks.mockCourseStructure
+        )
         every { networkConnection.isWifiConnected() } returns true
         every { networkConnection.isOnline() } returns true
         every {
@@ -599,9 +455,9 @@ class CourseOutlineViewModelTest {
     @Test
     fun `saveDownloadModels only wifi download, with connection`() =
         runTest(UnconfinedTestDispatcher()) {
-            coEvery { interactor.getCourseStructure(any()) } returns courseStructure
+            coEvery { interactor.getCourseStructure(any()) } returns CoreMocks.mockCourseStructure
             coEvery { interactor.getCourseStructureFlow(any(), any()) } returns flowOf(
-                courseStructure
+                CoreMocks.mockCourseStructure
             )
             coEvery { interactor.getCourseStatus(any()) } returns CourseComponentStatus("id")
             coEvery { interactor.getCourseStatusFlow(any()) } returns flowOf(CourseComponentStatus("id"))

--- a/course/src/test/java/org/openedx/course/presentation/section/CourseSectionViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/section/CourseSectionViewModelTest.kt
@@ -23,20 +23,12 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
-import org.openedx.core.BlockType
+import org.openedx.core.CoreMocks
 import org.openedx.core.R
 import org.openedx.core.data.storage.CorePreferences
-import org.openedx.core.domain.model.AssignmentProgress
-import org.openedx.core.domain.model.Block
-import org.openedx.core.domain.model.BlockCounts
-import org.openedx.core.domain.model.CourseStructure
-import org.openedx.core.domain.model.CoursewareAccess
 import org.openedx.core.module.DownloadWorkerController
 import org.openedx.core.module.db.DownloadDao
-import org.openedx.core.module.db.DownloadModel
 import org.openedx.core.module.db.DownloadModelEntity
-import org.openedx.core.module.db.DownloadedState
-import org.openedx.core.module.db.FileType
 import org.openedx.core.presentation.CoreAnalytics
 import org.openedx.core.system.connection.NetworkConnection
 import org.openedx.core.system.notifier.CourseNotifier
@@ -46,7 +38,6 @@ import org.openedx.course.presentation.unit.container.CourseViewMode
 import org.openedx.foundation.presentation.UIMessage
 import org.openedx.foundation.system.ResourceManager
 import java.net.UnknownHostException
-import java.util.Date
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CourseSectionViewModelTest {
@@ -69,110 +60,6 @@ class CourseSectionViewModelTest {
     private val noInternet = "Slow or no internet connection"
     private val somethingWrong = "Something went wrong"
     private val cantDownload = "You can download content only from Wi-fi"
-
-    private val assignmentProgress = AssignmentProgress(
-        assignmentType = "Homework",
-        numPointsEarned = 1f,
-        numPointsPossible = 3f,
-        shortLabel = "HW1",
-    )
-
-    private val blocks = listOf(
-        Block(
-            id = "id",
-            blockId = "blockId",
-            lmsWebUrl = "lmsWebUrl",
-            legacyWebUrl = "legacyWebUrl",
-            studentViewUrl = "studentViewUrl",
-            type = BlockType.CHAPTER,
-            displayName = "Block",
-            graded = false,
-            studentViewData = null,
-            studentViewMultiDevice = false,
-            blockCounts = BlockCounts(0),
-            descendants = listOf("1", "id1"),
-            descendantsType = BlockType.HTML,
-            completion = 0.0,
-            assignmentProgress = assignmentProgress,
-            due = Date(),
-            offlineDownload = null,
-        ),
-        Block(
-            id = "id1",
-            blockId = "blockId",
-            lmsWebUrl = "lmsWebUrl",
-            legacyWebUrl = "legacyWebUrl",
-            studentViewUrl = "studentViewUrl",
-            type = BlockType.SEQUENTIAL,
-            displayName = "Block",
-            graded = false,
-            studentViewData = null,
-            studentViewMultiDevice = false,
-            blockCounts = BlockCounts(0),
-            descendants = listOf("id2"),
-            descendantsType = BlockType.HTML,
-            completion = 0.0,
-            assignmentProgress = assignmentProgress,
-            due = Date(),
-            offlineDownload = null,
-        ),
-        Block(
-            id = "id2",
-            blockId = "blockId",
-            lmsWebUrl = "lmsWebUrl",
-            legacyWebUrl = "legacyWebUrl",
-            studentViewUrl = "studentViewUrl",
-            type = BlockType.VERTICAL,
-            displayName = "Block",
-            graded = false,
-            studentViewData = null,
-            studentViewMultiDevice = false,
-            blockCounts = BlockCounts(0),
-            descendants = emptyList(),
-            descendantsType = BlockType.HTML,
-            completion = 0.0,
-            assignmentProgress = assignmentProgress,
-            due = Date(),
-            offlineDownload = null,
-        )
-    )
-
-    private val courseStructure = CourseStructure(
-        root = "",
-        blockData = blocks,
-        id = "id",
-        name = "Course name",
-        number = "",
-        org = "Org",
-        start = Date(),
-        startDisplay = "",
-        startType = "",
-        end = Date(),
-        coursewareAccess = CoursewareAccess(
-            true,
-            "",
-            "",
-            "",
-            "",
-            ""
-        ),
-        media = null,
-        certificate = null,
-        isSelfPaced = false,
-        progress = null
-    )
-
-    private val downloadModel = DownloadModel(
-        "id",
-        "title",
-        "",
-        0,
-        "",
-        "url",
-        FileType.VIDEO,
-        DownloadedState.NOT_DOWNLOADED,
-        null
-    )
 
     @Before
     fun setUp() {
@@ -242,7 +129,7 @@ class CourseSectionViewModelTest {
     @Test
     fun `getBlocks success`() = runTest {
         coEvery { downloadDao.getAllDataFlow() } returns flow {
-            emit(listOf(DownloadModelEntity.createFrom(downloadModel)))
+            emit(listOf(DownloadModelEntity.createFrom(CoreMocks.mockDownloadModel)))
         }
         val viewModel = CourseSectionViewModel(
             "",
@@ -253,10 +140,10 @@ class CourseSectionViewModelTest {
         )
 
         coEvery { downloadDao.getAllDataFlow() } returns flow {
-            emit(listOf(DownloadModelEntity.createFrom(downloadModel)))
+            emit(listOf(DownloadModelEntity.createFrom(CoreMocks.mockDownloadModel)))
         }
-        coEvery { interactor.getCourseStructure(any()) } returns courseStructure
-        coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
+        coEvery { interactor.getCourseStructure(any()) } returns CoreMocks.mockCourseStructure
+        coEvery { interactor.getCourseStructureForVideos(any()) } returns CoreMocks.mockCourseStructure
 
         viewModel.getBlocks("id", CourseViewMode.VIDEOS)
         advanceUntilIdle()
@@ -271,7 +158,7 @@ class CourseSectionViewModelTest {
     @Test
     fun `saveDownloadModels test`() = runTest {
         coEvery { downloadDao.getAllDataFlow() } returns flow {
-            emit(listOf(DownloadModelEntity.createFrom(downloadModel)))
+            emit(listOf(DownloadModelEntity.createFrom(CoreMocks.mockDownloadModel)))
         }
         val viewModel = CourseSectionViewModel(
             "",
@@ -293,7 +180,7 @@ class CourseSectionViewModelTest {
     @Test
     fun `saveDownloadModels only wifi download, with connection`() = runTest {
         coEvery { downloadDao.getAllDataFlow() } returns flow {
-            emit(listOf(DownloadModelEntity.createFrom(downloadModel)))
+            emit(listOf(DownloadModelEntity.createFrom(CoreMocks.mockDownloadModel)))
         }
         val viewModel = CourseSectionViewModel(
             "",
@@ -329,8 +216,8 @@ class CourseSectionViewModelTest {
         )
 
         coEvery { notifier.notifier } returns flow { }
-        coEvery { interactor.getCourseStructure(any()) } returns courseStructure
-        coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
+        coEvery { interactor.getCourseStructure(any()) } returns CoreMocks.mockCourseStructure
+        coEvery { interactor.getCourseStructureForVideos(any()) } returns CoreMocks.mockCourseStructure
 
         val mockLifeCycleOwner: LifecycleOwner = mockk()
         val lifecycleRegistry = LifecycleRegistry(mockLifeCycleOwner)

--- a/course/src/test/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/unit/container/CourseUnitContainerViewModelTest.kt
@@ -18,20 +18,14 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
-import org.openedx.core.BlockType
+import org.openedx.core.CoreMocks
 import org.openedx.core.config.Config
 import org.openedx.core.domain.helper.VideoPreviewHelper
-import org.openedx.core.domain.model.AssignmentProgress
-import org.openedx.core.domain.model.Block
-import org.openedx.core.domain.model.BlockCounts
-import org.openedx.core.domain.model.CourseStructure
-import org.openedx.core.domain.model.CoursewareAccess
 import org.openedx.core.system.connection.NetworkConnection
 import org.openedx.core.system.notifier.CourseNotifier
 import org.openedx.course.domain.interactor.CourseInteractor
 import org.openedx.course.presentation.CourseAnalytics
 import java.net.UnknownHostException
-import java.util.Date
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CourseUnitContainerViewModelTest {
@@ -47,118 +41,6 @@ class CourseUnitContainerViewModelTest {
     private val analytics = mockk<CourseAnalytics>()
     private val networkConnection = mockk<NetworkConnection>()
     private val videoPreviewHelper = mockk<VideoPreviewHelper>()
-
-    private val assignmentProgress = AssignmentProgress(
-        assignmentType = "Homework",
-        numPointsEarned = 1f,
-        numPointsPossible = 3f,
-        shortLabel = "HW1",
-    )
-
-    private val blocks = listOf(
-        Block(
-            id = "id",
-            blockId = "blockId",
-            lmsWebUrl = "lmsWebUrl",
-            legacyWebUrl = "legacyWebUrl",
-            studentViewUrl = "studentViewUrl",
-            type = BlockType.HTML,
-            displayName = "Block",
-            graded = false,
-            studentViewData = null,
-            studentViewMultiDevice = false,
-            blockCounts = BlockCounts(0),
-            descendants = listOf("id2", "id1"),
-            descendantsType = BlockType.HTML,
-            completion = 0.0,
-            assignmentProgress = assignmentProgress,
-            due = Date(),
-            offlineDownload = null,
-        ),
-        Block(
-            id = "id1",
-            blockId = "blockId",
-            lmsWebUrl = "lmsWebUrl",
-            legacyWebUrl = "legacyWebUrl",
-            studentViewUrl = "studentViewUrl",
-            type = BlockType.VERTICAL,
-            displayName = "Block",
-            graded = false,
-            studentViewData = null,
-            studentViewMultiDevice = false,
-            blockCounts = BlockCounts(0),
-            descendants = listOf("id2", "id"),
-            descendantsType = BlockType.HTML,
-            completion = 0.0,
-            assignmentProgress = assignmentProgress,
-            due = Date(),
-            offlineDownload = null,
-        ),
-        Block(
-            id = "id2",
-            blockId = "blockId",
-            lmsWebUrl = "lmsWebUrl",
-            legacyWebUrl = "legacyWebUrl",
-            studentViewUrl = "studentViewUrl",
-            type = BlockType.SEQUENTIAL,
-            displayName = "Block",
-            graded = false,
-            studentViewData = null,
-            studentViewMultiDevice = false,
-            blockCounts = BlockCounts(0),
-            descendants = emptyList(),
-            descendantsType = BlockType.HTML,
-            completion = 0.0,
-            assignmentProgress = assignmentProgress,
-            due = Date(),
-            offlineDownload = null,
-        ),
-        Block(
-            id = "id3",
-            blockId = "blockId",
-            lmsWebUrl = "lmsWebUrl",
-            legacyWebUrl = "legacyWebUrl",
-            studentViewUrl = "studentViewUrl",
-            type = BlockType.HTML,
-            displayName = "Block",
-            graded = false,
-            studentViewData = null,
-            studentViewMultiDevice = false,
-            blockCounts = BlockCounts(0),
-            descendants = emptyList(),
-            descendantsType = BlockType.HTML,
-            completion = 0.0,
-            assignmentProgress = assignmentProgress,
-            due = Date(),
-            offlineDownload = null,
-        )
-
-    )
-
-    private val courseStructure = CourseStructure(
-        root = "",
-        blockData = blocks,
-        id = "id",
-        name = "Course name",
-        number = "",
-        org = "Org",
-        start = Date(),
-        startDisplay = "",
-        startType = "",
-        end = Date(),
-        coursewareAccess = CoursewareAccess(
-            true,
-            "",
-            "",
-            "",
-            "",
-            ""
-        ),
-        media = null,
-        certificate = null,
-        isSelfPaced = false,
-        progress = null
-    )
 
     @Before
     fun setUp() {
@@ -234,8 +116,8 @@ class CourseUnitContainerViewModelTest {
             videoPreviewHelper
         )
 
-        coEvery { interactor.getCourseStructure(any()) } returns courseStructure
-        coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
+        coEvery { interactor.getCourseStructure(any()) } returns CoreMocks.mockCourseStructure
+        coEvery { interactor.getCourseStructureForVideos(any()) } returns CoreMocks.mockCourseStructure
 
         viewModel.loadBlocks()
 
@@ -259,8 +141,8 @@ class CourseUnitContainerViewModelTest {
             networkConnection,
             videoPreviewHelper
         )
-        coEvery { interactor.getCourseStructure(any()) } returns courseStructure
-        coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
+        coEvery { interactor.getCourseStructure(any()) } returns CoreMocks.mockCourseStructure
+        coEvery { interactor.getCourseStructureForVideos(any()) } returns CoreMocks.mockCourseStructure
 
         viewModel.loadBlocks("id")
         advanceUntilIdle()
@@ -283,8 +165,8 @@ class CourseUnitContainerViewModelTest {
             networkConnection,
             videoPreviewHelper
         )
-        coEvery { interactor.getCourseStructure(any()) } returns courseStructure
-        coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
+        coEvery { interactor.getCourseStructure(any()) } returns CoreMocks.mockCourseStructure
+        coEvery { interactor.getCourseStructureForVideos(any()) } returns CoreMocks.mockCourseStructure
 
         viewModel.loadBlocks("id")
 
@@ -309,8 +191,8 @@ class CourseUnitContainerViewModelTest {
             networkConnection,
             videoPreviewHelper
         )
-        coEvery { interactor.getCourseStructure(any()) } returns courseStructure
-        coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
+        coEvery { interactor.getCourseStructure(any()) } returns CoreMocks.mockCourseStructure
+        coEvery { interactor.getCourseStructureForVideos(any()) } returns CoreMocks.mockCourseStructure
 
         viewModel.loadBlocks("id3")
 
@@ -335,8 +217,8 @@ class CourseUnitContainerViewModelTest {
             networkConnection,
             videoPreviewHelper
         )
-        coEvery { interactor.getCourseStructure(any()) } returns courseStructure
-        coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
+        coEvery { interactor.getCourseStructure(any()) } returns CoreMocks.mockCourseStructure
+        coEvery { interactor.getCourseStructureForVideos(any()) } returns CoreMocks.mockCourseStructure
 
         viewModel.loadBlocks("id1")
 
@@ -361,8 +243,8 @@ class CourseUnitContainerViewModelTest {
             networkConnection,
             videoPreviewHelper
         )
-        coEvery { interactor.getCourseStructure(any()) } returns courseStructure
-        coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
+        coEvery { interactor.getCourseStructure(any()) } returns CoreMocks.mockCourseStructure
+        coEvery { interactor.getCourseStructureForVideos(any()) } returns CoreMocks.mockCourseStructure
 
         viewModel.loadBlocks("id3")
 
@@ -387,8 +269,8 @@ class CourseUnitContainerViewModelTest {
             networkConnection,
             videoPreviewHelper
         )
-        coEvery { interactor.getCourseStructure("") } returns courseStructure
-        coEvery { interactor.getCourseStructureForVideos("") } returns courseStructure
+        coEvery { interactor.getCourseStructure("") } returns CoreMocks.mockCourseStructure
+        coEvery { interactor.getCourseStructureForVideos("") } returns CoreMocks.mockCourseStructure
 
         viewModel.loadBlocks("id")
 
@@ -413,8 +295,8 @@ class CourseUnitContainerViewModelTest {
             networkConnection,
             videoPreviewHelper
         )
-        coEvery { interactor.getCourseStructure(any()) } returns courseStructure
-        coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
+        coEvery { interactor.getCourseStructure(any()) } returns CoreMocks.mockCourseStructure
+        coEvery { interactor.getCourseStructureForVideos(any()) } returns CoreMocks.mockCourseStructure
 
         viewModel.loadBlocks("id3")
 

--- a/course/src/test/java/org/openedx/course/presentation/videos/CourseVideoViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/videos/CourseVideoViewModelTest.kt
@@ -27,23 +27,15 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
-import org.openedx.core.BlockType
+import org.openedx.core.CoreMocks
 import org.openedx.core.config.Config
 import org.openedx.core.data.model.room.VideoProgressEntity
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.helper.VideoPreviewHelper
-import org.openedx.core.domain.model.AssignmentProgress
-import org.openedx.core.domain.model.Block
-import org.openedx.core.domain.model.BlockCounts
-import org.openedx.core.domain.model.CourseStructure
-import org.openedx.core.domain.model.CoursewareAccess
 import org.openedx.core.domain.model.VideoSettings
 import org.openedx.core.module.DownloadWorkerController
 import org.openedx.core.module.db.DownloadDao
-import org.openedx.core.module.db.DownloadModel
 import org.openedx.core.module.db.DownloadModelEntity
-import org.openedx.core.module.db.DownloadedState
-import org.openedx.core.module.db.FileType
 import org.openedx.core.module.download.DownloadHelper
 import org.openedx.core.presentation.CoreAnalytics
 import org.openedx.core.presentation.dialog.downloaddialog.DownloadDialogManager
@@ -57,7 +49,6 @@ import org.openedx.course.presentation.CourseRouter
 import org.openedx.foundation.presentation.UIMessage
 import org.openedx.foundation.system.ResourceManager
 import org.openedx.foundation.utils.FileUtil
-import java.util.Date
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CourseVideoViewModelTest {
@@ -84,112 +75,8 @@ class CourseVideoViewModelTest {
 
     private val cantDownload = "You can download content only from Wi-fi"
 
-    private val assignmentProgress = AssignmentProgress(
-        assignmentType = "Homework",
-        numPointsEarned = 1f,
-        numPointsPossible = 3f,
-        shortLabel = "HW1",
-    )
-
-    private val blocks = listOf(
-        Block(
-            id = "id",
-            blockId = "blockId",
-            lmsWebUrl = "lmsWebUrl",
-            legacyWebUrl = "legacyWebUrl",
-            studentViewUrl = "studentViewUrl",
-            type = BlockType.CHAPTER,
-            displayName = "Block",
-            graded = false,
-            studentViewData = null,
-            studentViewMultiDevice = false,
-            blockCounts = BlockCounts(0),
-            descendants = listOf("1", "id1"),
-            descendantsType = BlockType.HTML,
-            completion = 0.0,
-            assignmentProgress = assignmentProgress,
-            due = Date(),
-            offlineDownload = null,
-        ),
-        Block(
-            id = "id1",
-            blockId = "blockId",
-            lmsWebUrl = "lmsWebUrl",
-            legacyWebUrl = "legacyWebUrl",
-            studentViewUrl = "studentViewUrl",
-            type = BlockType.HTML,
-            displayName = "Block",
-            graded = false,
-            studentViewData = null,
-            studentViewMultiDevice = false,
-            blockCounts = BlockCounts(0),
-            descendants = listOf("id2"),
-            descendantsType = BlockType.HTML,
-            completion = 0.0,
-            assignmentProgress = assignmentProgress,
-            due = Date(),
-            offlineDownload = null,
-        ),
-        Block(
-            id = "id2",
-            blockId = "blockId",
-            lmsWebUrl = "lmsWebUrl",
-            legacyWebUrl = "legacyWebUrl",
-            studentViewUrl = "studentViewUrl",
-            type = BlockType.HTML,
-            displayName = "Block",
-            graded = false,
-            studentViewData = null,
-            studentViewMultiDevice = false,
-            blockCounts = BlockCounts(0),
-            descendants = emptyList(),
-            descendantsType = BlockType.HTML,
-            completion = 0.0,
-            assignmentProgress = assignmentProgress,
-            due = Date(),
-            offlineDownload = null,
-        )
-    )
-
-    private val courseStructure = CourseStructure(
-        root = "",
-        blockData = blocks,
-        id = "id",
-        name = "Course name",
-        number = "",
-        org = "Org",
-        start = Date(),
-        startDisplay = "",
-        startType = "",
-        end = Date(),
-        coursewareAccess = CoursewareAccess(
-            true,
-            "",
-            "",
-            "",
-            "",
-            ""
-        ),
-        media = null,
-        certificate = null,
-        isSelfPaced = false,
-        progress = null
-    )
-
     private val downloadModelEntity =
         DownloadModelEntity("", "", "", 1, "", "", "VIDEO", "DOWNLOADED", null)
-
-    private val downloadModel = DownloadModel(
-        "id",
-        "title",
-        "",
-        0,
-        "",
-        "url",
-        FileType.VIDEO,
-        DownloadedState.NOT_DOWNLOADED,
-        null
-    )
 
     @Before
     fun setUp() {
@@ -228,7 +115,7 @@ class CourseVideoViewModelTest {
         every { config.getCourseUIConfig().isCourseDropdownNavigationEnabled } returns false
         coEvery {
             interactor.getCourseStructureForVideos(any())
-        } returns courseStructure.copy(blockData = emptyList())
+        } returns CoreMocks.mockCourseStructure.copy(blockData = emptyList())
         every { downloadDao.getAllDataFlow() } returns flow { emit(emptyList()) }
         every { preferencesManager.videoSettings } returns VideoSettings.default
         val viewModel = CourseVideoViewModel(
@@ -261,7 +148,7 @@ class CourseVideoViewModelTest {
     @Test
     fun `getVideos success`() = runTest(UnconfinedTestDispatcher()) {
         every { config.getCourseUIConfig().isCourseDropdownNavigationEnabled } returns false
-        coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
+        coEvery { interactor.getCourseStructureForVideos(any()) } returns CoreMocks.mockCourseStructure
         every { downloadDao.getAllDataFlow() } returns flow {
             repeat(5) {
                 delay(10000)
@@ -303,7 +190,7 @@ class CourseVideoViewModelTest {
     @Test
     fun `updateVideos success`() = runTest(UnconfinedTestDispatcher()) {
         every { config.getCourseUIConfig().isCourseDropdownNavigationEnabled } returns false
-        coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
+        coEvery { interactor.getCourseStructureForVideos(any()) } returns CoreMocks.mockCourseStructure
         coEvery { courseNotifier.notifier } returns flow {
             emit(CourseStructureUpdated(""))
         }
@@ -348,7 +235,7 @@ class CourseVideoViewModelTest {
     fun `setIsUpdating success`() = runTest(UnconfinedTestDispatcher()) {
         every { config.getCourseUIConfig().isCourseDropdownNavigationEnabled } returns false
         every { preferencesManager.videoSettings } returns VideoSettings.default
-        coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
+        coEvery { interactor.getCourseStructureForVideos(any()) } returns CoreMocks.mockCourseStructure
         coEvery { downloadDao.getAllDataFlow() } returns flow { emit(listOf(downloadModelEntity)) }
         advanceUntilIdle()
     }
@@ -357,7 +244,7 @@ class CourseVideoViewModelTest {
     fun `saveDownloadModels test`() = runTest(UnconfinedTestDispatcher()) {
         every { config.getCourseUIConfig().isCourseDropdownNavigationEnabled } returns false
         every { preferencesManager.videoSettings } returns VideoSettings.default
-        coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
+        coEvery { interactor.getCourseStructureForVideos(any()) } returns CoreMocks.mockCourseStructure
         every { downloadDao.getAllDataFlow() } returns flow { emit(emptyList()) }
         val viewModel = CourseVideoViewModel(
             "",
@@ -377,7 +264,7 @@ class CourseVideoViewModelTest {
             workerController,
             downloadHelper,
         )
-        coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
+        coEvery { interactor.getCourseStructureForVideos(any()) } returns CoreMocks.mockCourseStructure
         coEvery { downloadDao.getAllDataFlow() } returns flow { emit(listOf(downloadModelEntity)) }
         every { preferencesManager.videoSettings.wifiDownloadOnly } returns false
         every { networkConnection.isWifiConnected() } returns true
@@ -399,7 +286,7 @@ class CourseVideoViewModelTest {
         runTest(UnconfinedTestDispatcher()) {
             every { config.getCourseUIConfig().isCourseDropdownNavigationEnabled } returns false
             every { preferencesManager.videoSettings } returns VideoSettings.default
-            coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
+            coEvery { interactor.getCourseStructureForVideos(any()) } returns CoreMocks.mockCourseStructure
             every { downloadDao.getAllDataFlow() } returns flow { emit(emptyList()) }
             val viewModel = CourseVideoViewModel(
                 "",
@@ -419,13 +306,13 @@ class CourseVideoViewModelTest {
                 workerController,
                 downloadHelper,
             )
-            coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
+            coEvery { interactor.getCourseStructureForVideos(any()) } returns CoreMocks.mockCourseStructure
             coEvery { downloadDao.getAllDataFlow() } returns flow { emit(listOf(downloadModelEntity)) }
             every { preferencesManager.videoSettings.wifiDownloadOnly } returns true
             every { networkConnection.isWifiConnected() } returns true
             coEvery { workerController.saveModels(any()) } returns Unit
             coEvery { downloadDao.getAllDataFlow() } returns flow {
-                emit(listOf(DownloadModelEntity.createFrom(downloadModel)))
+                emit(listOf(DownloadModelEntity.createFrom(CoreMocks.mockDownloadModel)))
             }
             every { coreAnalytics.logEvent(any(), any()) } returns Unit
             val message = async {
@@ -446,7 +333,7 @@ class CourseVideoViewModelTest {
             every { config.getCourseUIConfig().isCourseDropdownNavigationEnabled } returns false
             every { preferencesManager.videoSettings } returns VideoSettings.default
             every { downloadDao.getAllDataFlow() } returns flow { emit(emptyList()) }
-            coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
+            coEvery { interactor.getCourseStructureForVideos(any()) } returns CoreMocks.mockCourseStructure
             val viewModel = CourseVideoViewModel(
                 "",
                 config,
@@ -468,7 +355,7 @@ class CourseVideoViewModelTest {
             every { preferencesManager.videoSettings.wifiDownloadOnly } returns true
             every { networkConnection.isWifiConnected() } returns false
             every { networkConnection.isOnline() } returns false
-            coEvery { interactor.getCourseStructureForVideos(any()) } returns courseStructure
+            coEvery { interactor.getCourseStructureForVideos(any()) } returns CoreMocks.mockCourseStructure
             coEvery { downloadDao.getAllDataFlow() } returns flow { emit(listOf(downloadModelEntity)) }
             coEvery { workerController.saveModels(any()) } returns Unit
             val message = async {

--- a/dashboard/src/main/java/org/openedx/courses/presentation/AllEnrolledCoursesView.kt
+++ b/dashboard/src/main/java/org/openedx/courses/presentation/AllEnrolledCoursesView.kt
@@ -72,14 +72,7 @@ import coil.request.ImageRequest
 import org.koin.androidx.compose.koinViewModel
 import org.openedx.Lock
 import org.openedx.core.R
-import org.openedx.core.domain.model.Certificate
-import org.openedx.core.domain.model.CourseAssignments
-import org.openedx.core.domain.model.CourseSharingUtmParameters
-import org.openedx.core.domain.model.CourseStatus
-import org.openedx.core.domain.model.CoursewareAccess
 import org.openedx.core.domain.model.EnrolledCourse
-import org.openedx.core.domain.model.EnrolledCourseData
-import org.openedx.core.domain.model.Progress
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.OfflineModeDialog
@@ -95,6 +88,7 @@ import org.openedx.core.utils.TimeUtils
 import org.openedx.courses.presentation.AllEnrolledCoursesFragment.Companion.LOAD_MORE_THRESHOLD
 import org.openedx.courses.presentation.AllEnrolledCoursesFragment.Companion.MOBILE_GRID_COLUMNS
 import org.openedx.courses.presentation.AllEnrolledCoursesFragment.Companion.TABLET_GRID_COLUMNS
+import org.openedx.dashboard.DashboardMocks
 import org.openedx.dashboard.domain.CourseStatusFilter
 import org.openedx.foundation.extension.toImageLink
 import org.openedx.foundation.presentation.UIMessage
@@ -553,7 +547,7 @@ fun EmptyState(
 private fun CourseItemPreview() {
     OpenEdXTheme {
         CourseItem(
-            course = mockCourseEnrolled,
+            course = DashboardMocks.enrolledCourse,
             apiHostUrl = "",
             onClick = {}
         )
@@ -580,14 +574,7 @@ private fun AllEnrolledCoursesPreview() {
         AllEnrolledCoursesView(
             apiHostUrl = "http://localhost:8000",
             state = AllEnrolledCoursesUIState(
-                courses = listOf(
-                    mockCourseEnrolled,
-                    mockCourseEnrolled,
-                    mockCourseEnrolled,
-                    mockCourseEnrolled,
-                    mockCourseEnrolled,
-                    mockCourseEnrolled
-                )
+                courses = DashboardMocks.enrolledCourses(1)
             ),
             uiMessage = null,
             hasInternetConnection = true,
@@ -595,44 +582,3 @@ private fun AllEnrolledCoursesPreview() {
         )
     }
 }
-
-private val mockCourseAssignments = CourseAssignments(null, emptyList())
-private val mockCourseEnrolled = EnrolledCourse(
-    auditAccessExpires = Date(),
-    created = "created",
-    certificate = Certificate(""),
-    mode = "mode",
-    isActive = true,
-    progress = Progress.DEFAULT_PROGRESS,
-    courseStatus = CourseStatus("", emptyList(), "", ""),
-    courseAssignments = mockCourseAssignments,
-    course = EnrolledCourseData(
-        id = "id",
-        name = "name",
-        number = "",
-        org = "Org",
-        start = Date(),
-        startDisplay = "",
-        startType = "",
-        end = Date(),
-        dynamicUpgradeDeadline = "",
-        subscriptionId = "",
-        coursewareAccess = CoursewareAccess(
-            false,
-            "204",
-            "",
-            "",
-            "",
-            ""
-        ),
-        media = null,
-        courseImage = "",
-        courseAbout = "",
-        courseSharingUtmParameters = CourseSharingUtmParameters("", ""),
-        courseUpdates = "",
-        courseHandouts = "",
-        discussionUrl = "",
-        videoOutline = "",
-        isSelfPaced = false
-    )
-)

--- a/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryView.kt
+++ b/dashboard/src/main/java/org/openedx/courses/presentation/DashboardGalleryView.kt
@@ -75,20 +75,8 @@ import coil.request.ImageRequest
 import org.koin.androidx.compose.koinViewModel
 import org.koin.core.parameter.parametersOf
 import org.openedx.Lock
-import org.openedx.core.domain.model.AppConfig
-import org.openedx.core.domain.model.Certificate
-import org.openedx.core.domain.model.CourseAssignments
-import org.openedx.core.domain.model.CourseDateBlock
-import org.openedx.core.domain.model.CourseDatesCalendarSync
 import org.openedx.core.domain.model.CourseEnrollments
-import org.openedx.core.domain.model.CourseSharingUtmParameters
-import org.openedx.core.domain.model.CourseStatus
-import org.openedx.core.domain.model.CoursewareAccess
-import org.openedx.core.domain.model.DashboardCourseList
 import org.openedx.core.domain.model.EnrolledCourse
-import org.openedx.core.domain.model.EnrolledCourseData
-import org.openedx.core.domain.model.Pagination
-import org.openedx.core.domain.model.Progress
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.OfflineModeDialog
 import org.openedx.core.ui.OpenEdXButton
@@ -101,6 +89,7 @@ import org.openedx.core.ui.theme.appTypography
 import org.openedx.core.utils.TimeUtils
 import org.openedx.courses.presentation.DashboardGalleryFragment.Companion.MOBILE_COURSE_LIST_ITEM_COUNT
 import org.openedx.courses.presentation.DashboardGalleryFragment.Companion.TABLET_COURSE_LIST_ITEM_COUNT
+import org.openedx.dashboard.DashboardMocks
 import org.openedx.dashboard.R
 import org.openedx.foundation.extension.toImageLink
 import org.openedx.foundation.presentation.UIMessage
@@ -909,65 +898,6 @@ private fun NoCoursesInfo(
     }
 }
 
-private val mockCourseDateBlock = CourseDateBlock(
-    title = "Homework 1: ABCD",
-    description = "After this date, course content will be archived",
-    date = TimeUtils.iso8601ToDate("2024-05-31T15:08:07Z")!!,
-    assignmentType = "Homework"
-)
-private val mockCourseAssignments =
-    CourseAssignments(listOf(mockCourseDateBlock), listOf(mockCourseDateBlock, mockCourseDateBlock))
-private val mockCourse = EnrolledCourse(
-    auditAccessExpires = Date(),
-    created = "created",
-    certificate = Certificate(""),
-    mode = "mode",
-    isActive = true,
-    progress = Progress.DEFAULT_PROGRESS,
-    courseStatus = CourseStatus("", emptyList(), "", "Unit name"),
-    courseAssignments = mockCourseAssignments,
-    course = EnrolledCourseData(
-        id = "id",
-        name = "Looooooooooooooooooooong Course name",
-        number = "",
-        org = "Org",
-        start = Date(),
-        startDisplay = "",
-        startType = "",
-        end = Date(),
-        dynamicUpgradeDeadline = "",
-        subscriptionId = "",
-        coursewareAccess = CoursewareAccess(
-            true,
-            "",
-            "",
-            "",
-            "",
-            "",
-        ),
-        media = null,
-        courseImage = "",
-        courseAbout = "",
-        courseSharingUtmParameters = CourseSharingUtmParameters("", ""),
-        courseUpdates = "",
-        courseHandouts = "",
-        discussionUrl = "",
-        videoOutline = "",
-        isSelfPaced = false
-    )
-)
-private val mockPagination = Pagination(10, "", 4, "1")
-private val mockDashboardCourseList = DashboardCourseList(
-    pagination = mockPagination,
-    courses = listOf(mockCourse, mockCourse, mockCourse, mockCourse, mockCourse, mockCourse)
-)
-
-private val mockUserCourses = CourseEnrollments(
-    enrollments = mockDashboardCourseList,
-    configs = AppConfig(CourseDatesCalendarSync(true, true, true, true)),
-    primary = mockCourse
-)
-
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
@@ -987,7 +917,7 @@ private fun ViewAllItemPreview() {
 private fun DashboardGalleryViewPreview() {
     OpenEdXTheme {
         DashboardGalleryView(
-            uiState = DashboardGalleryUIState.Courses(mockUserCourses, true),
+            uiState = DashboardGalleryUIState.Courses(DashboardMocks.courseEnrollments, true),
             apiHostUrl = "",
             uiMessage = null,
             updating = false,

--- a/dashboard/src/main/java/org/openedx/dashboard/DashboardMocks.kt
+++ b/dashboard/src/main/java/org/openedx/dashboard/DashboardMocks.kt
@@ -1,0 +1,105 @@
+package org.openedx.dashboard
+
+import org.openedx.core.data.model.DateType
+import org.openedx.core.domain.model.AppConfig
+import org.openedx.core.domain.model.CourseAssignments
+import org.openedx.core.domain.model.CourseDateBlock
+import org.openedx.core.domain.model.CourseDatesCalendarSync
+import org.openedx.core.domain.model.CourseEnrollments
+import org.openedx.core.domain.model.CourseSharingUtmParameters
+import org.openedx.core.domain.model.CourseStatus
+import org.openedx.core.domain.model.CoursewareAccess
+import org.openedx.core.domain.model.DashboardCourseList
+import org.openedx.core.domain.model.EnrolledCourse
+import org.openedx.core.domain.model.EnrolledCourseData
+import org.openedx.core.domain.model.Pagination
+import org.openedx.core.domain.model.Progress
+import java.util.Date
+
+object DashboardMocks {
+    private val courseDateBlock = CourseDateBlock(
+        complete = false,
+        date = Date(),
+        dateType = DateType.NONE,
+        description = "Assignment due"
+    )
+
+    private val courseAssignments = CourseAssignments(
+        futureAssignments = listOf(courseDateBlock, courseDateBlock),
+        pastAssignments = listOf(courseDateBlock)
+    )
+
+    private val courseData = EnrolledCourseData(
+        id = "courseId",
+        name = "Introduction to Testing",
+        number = "CS101",
+        org = "OpenEdX",
+        start = Date(),
+        startDisplay = "Jan 01",
+        startType = "",
+        end = Date(),
+        dynamicUpgradeDeadline = "",
+        subscriptionId = "",
+        coursewareAccess = CoursewareAccess(
+            hasAccess = true,
+            errorCode = "",
+            developerMessage = "",
+            userMessage = "",
+            userFragment = "",
+            additionalContextUserMessage = ""
+        ),
+        media = null,
+        courseImage = "",
+        courseAbout = "",
+        courseSharingUtmParameters = CourseSharingUtmParameters("", ""),
+        courseUpdates = "",
+        courseHandouts = "",
+        discussionUrl = "",
+        videoOutline = "",
+        isSelfPaced = false
+    )
+
+    val enrolledCourse = EnrolledCourse(
+        auditAccessExpires = Date(),
+        created = "created",
+        mode = "audit",
+        isActive = true,
+        course = courseData,
+        certificate = null,
+        progress = Progress.DEFAULT_PROGRESS,
+        courseStatus = CourseStatus(
+            lastVisitedModuleId = "",
+            lastVisitedModulePath = emptyList(),
+            lastVisitedBlockId = "",
+            lastVisitedUnitDisplayName = "Unit name"
+        ),
+        courseAssignments = courseAssignments
+    )
+
+    fun enrolledCourses(count: Int) = List(count) { enrolledCourse }
+
+    private val pagination = Pagination(
+        count = 10,
+        next = "",
+        numPages = 4,
+        previous = "1"
+    )
+
+    val dashboardCourseList = DashboardCourseList(
+        pagination = pagination,
+        courses = enrolledCourses(6)
+    )
+
+    val courseEnrollments = CourseEnrollments(
+        enrollments = dashboardCourseList,
+        configs = AppConfig(
+            courseDatesCalendarSync = CourseDatesCalendarSync(
+                isEnabled = true,
+                isSelfPacedEnabled = true,
+                isInstructorPacedEnabled = true,
+                isDeepLinkEnabled = true
+            )
+        ),
+        primary = enrolledCourse
+    )
+}

--- a/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardListFragment.kt
+++ b/dashboard/src/main/java/org/openedx/dashboard/presentation/DashboardListFragment.kt
@@ -73,14 +73,7 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
-import org.openedx.core.domain.model.Certificate
-import org.openedx.core.domain.model.CourseAssignments
-import org.openedx.core.domain.model.CourseSharingUtmParameters
-import org.openedx.core.domain.model.CourseStatus
-import org.openedx.core.domain.model.CoursewareAccess
 import org.openedx.core.domain.model.EnrolledCourse
-import org.openedx.core.domain.model.EnrolledCourseData
-import org.openedx.core.domain.model.Progress
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.OfflineModeDialog
 import org.openedx.core.ui.displayCutoutForLandscape
@@ -90,6 +83,7 @@ import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appShapes
 import org.openedx.core.ui.theme.appTypography
 import org.openedx.core.utils.TimeUtils
+import org.openedx.dashboard.DashboardMocks
 import org.openedx.dashboard.R
 import org.openedx.dashboard.presentation.DashboardListFragment.Companion.LOAD_MORE_THRESHOLD
 import org.openedx.foundation.extension.toImageLink
@@ -513,7 +507,7 @@ private fun CourseItemPreview() {
     OpenEdXTheme {
         CourseItem(
             "http://localhost:8000",
-            mockCourseEnrolled,
+            DashboardMocks.enrolledCourse,
             WindowSize(WindowType.Compact, WindowType.Compact),
             onClick = {}
         )
@@ -529,14 +523,7 @@ private fun DashboardListViewPreview() {
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
             apiHostUrl = "http://localhost:8000",
             state = DashboardUIState.Courses(
-                listOf(
-                    mockCourseEnrolled,
-                    mockCourseEnrolled,
-                    mockCourseEnrolled,
-                    mockCourseEnrolled,
-                    mockCourseEnrolled,
-                    mockCourseEnrolled
-                )
+                DashboardMocks.enrolledCourses(1)
             ),
             uiMessage = null,
             onSwipeRefresh = {},
@@ -559,14 +546,7 @@ private fun DashboardListViewTabletPreview() {
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
             apiHostUrl = "http://localhost:8000",
             state = DashboardUIState.Courses(
-                listOf(
-                    mockCourseEnrolled,
-                    mockCourseEnrolled,
-                    mockCourseEnrolled,
-                    mockCourseEnrolled,
-                    mockCourseEnrolled,
-                    mockCourseEnrolled
-                )
+                DashboardMocks.enrolledCourses(1)
             ),
             uiMessage = null,
             onSwipeRefresh = {},
@@ -600,44 +580,3 @@ private fun EmptyStatePreview() {
         )
     }
 }
-
-private val mockCourseAssignments = CourseAssignments(null, emptyList())
-private val mockCourseEnrolled = EnrolledCourse(
-    auditAccessExpires = Date(),
-    created = "created",
-    certificate = Certificate(""),
-    mode = "mode",
-    isActive = true,
-    progress = Progress.DEFAULT_PROGRESS,
-    courseStatus = CourseStatus("", emptyList(), "", ""),
-    courseAssignments = mockCourseAssignments,
-    course = EnrolledCourseData(
-        id = "id",
-        name = "name",
-        number = "",
-        org = "Org",
-        start = Date(),
-        startDisplay = "",
-        startType = "",
-        end = Date(),
-        dynamicUpgradeDeadline = "",
-        subscriptionId = "",
-        coursewareAccess = CoursewareAccess(
-            true,
-            "",
-            "",
-            "",
-            "",
-            ""
-        ),
-        media = null,
-        courseImage = "",
-        courseAbout = "",
-        courseSharingUtmParameters = CourseSharingUtmParameters("", ""),
-        courseUpdates = "",
-        courseHandouts = "",
-        discussionUrl = "",
-        videoOutline = "",
-        isSelfPaced = false
-    )
-)

--- a/discovery/src/main/java/org/openedx/discovery/DiscoveryMocks.kt
+++ b/discovery/src/main/java/org/openedx/discovery/DiscoveryMocks.kt
@@ -1,0 +1,32 @@
+package org.openedx.discovery
+
+import org.openedx.core.domain.model.Media
+import org.openedx.discovery.domain.model.Course
+
+object DiscoveryMocks {
+    val course = Course(
+        id = "id",
+        blocksUrl = "blocksUrl",
+        courseId = "courseId",
+        effort = "effort",
+        enrollmentStart = null,
+        enrollmentEnd = null,
+        hidden = false,
+        invitationOnly = false,
+        media = Media(),
+        mobileAvailable = true,
+        name = "Test course",
+        number = "number",
+        org = "EdX",
+        pacing = "pacing",
+        shortDescription = "shortDescription",
+        start = "start",
+        end = "end",
+        startDisplay = "startDisplay",
+        startType = "startType",
+        overview = "",
+        isEnrolled = false
+    )
+
+    fun courses(count: Int) = List(count) { course }
+}

--- a/discovery/src/main/java/org/openedx/discovery/presentation/NativeDiscoveryFragment.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/NativeDiscoveryFragment.kt
@@ -57,7 +57,6 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
-import org.openedx.core.domain.model.Media
 import org.openedx.core.ui.AuthButtonsPanel
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.HandleUIMessage
@@ -70,6 +69,7 @@ import org.openedx.core.ui.statusBarsInset
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appTypography
+import org.openedx.discovery.DiscoveryMocks
 import org.openedx.discovery.R
 import org.openedx.discovery.domain.model.Course
 import org.openedx.discovery.presentation.NativeDiscoveryFragment.Companion.LOAD_MORE_THRESHOLD
@@ -440,7 +440,7 @@ private fun CourseItemPreview() {
     OpenEdXTheme {
         DiscoveryCourseItem(
             apiHostUrl = "",
-            course = mockCourse,
+            course = DiscoveryMocks.course,
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
             onClick = {}
         )
@@ -455,17 +455,7 @@ private fun DiscoveryScreenPreview() {
         DiscoveryScreen(
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
             state = DiscoveryUIState.Courses(
-                listOf(
-                    mockCourse,
-                    mockCourse,
-                    mockCourse,
-                    mockCourse,
-                    mockCourse,
-                    mockCourse,
-                    mockCourse,
-                    mockCourse,
-                    mockCourse,
-                )
+                DiscoveryMocks.courses(1)
             ),
             uiMessage = null,
             apiHostUrl = "",
@@ -496,17 +486,7 @@ private fun DiscoveryScreenTabletPreview() {
         DiscoveryScreen(
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
             state = DiscoveryUIState.Courses(
-                listOf(
-                    mockCourse,
-                    mockCourse,
-                    mockCourse,
-                    mockCourse,
-                    mockCourse,
-                    mockCourse,
-                    mockCourse,
-                    mockCourse,
-                    mockCourse,
-                )
+                DiscoveryMocks.courses(1)
             ),
             uiMessage = null,
             apiHostUrl = "",
@@ -528,27 +508,3 @@ private fun DiscoveryScreenTabletPreview() {
         )
     }
 }
-
-private val mockCourse = Course(
-    id = "id",
-    blocksUrl = "blocksUrl",
-    courseId = "courseId",
-    effort = "effort",
-    enrollmentStart = null,
-    enrollmentEnd = null,
-    hidden = false,
-    invitationOnly = false,
-    media = Media(),
-    mobileAvailable = true,
-    name = "Test course",
-    number = "number",
-    org = "EdX",
-    pacing = "pacing",
-    shortDescription = "shortDescription",
-    start = "start",
-    end = "end",
-    startDisplay = "startDisplay",
-    startType = "startType",
-    overview = "",
-    isEnrolled = false
-)

--- a/discovery/src/main/java/org/openedx/discovery/presentation/detail/CourseDetailsFragment.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/detail/CourseDetailsFragment.kt
@@ -79,7 +79,6 @@ import androidx.fragment.app.Fragment
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
-import org.openedx.core.domain.model.Media
 import org.openedx.core.ui.AuthButtonsPanel
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.OfflineModeDialog
@@ -92,6 +91,7 @@ import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appTypography
 import org.openedx.core.utils.EmailUtil
+import org.openedx.discovery.DiscoveryMocks
 import org.openedx.discovery.R
 import org.openedx.discovery.domain.model.Course
 import org.openedx.discovery.presentation.DiscoveryRouter
@@ -690,7 +690,7 @@ private fun CourseDetailNativeContentPreview() {
     OpenEdXTheme {
         CourseDetailsScreen(
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
-            uiState = CourseDetailsUIState.CourseData(mockCourse),
+            uiState = CourseDetailsUIState.CourseData(DiscoveryMocks.course),
             uiMessage = null,
             apiHostUrl = "http://localhost:8000",
             hasInternetConnection = false,
@@ -713,7 +713,7 @@ private fun CourseDetailNativeContentTabletPreview() {
     OpenEdXTheme {
         CourseDetailsScreen(
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
-            uiState = CourseDetailsUIState.CourseData(mockCourse),
+            uiState = CourseDetailsUIState.CourseData(DiscoveryMocks.course),
             uiMessage = null,
             apiHostUrl = "http://localhost:8000",
             hasInternetConnection = false,
@@ -728,27 +728,3 @@ private fun CourseDetailNativeContentTabletPreview() {
         )
     }
 }
-
-private val mockCourse = Course(
-    id = "id",
-    blocksUrl = "blocksUrl",
-    courseId = "courseId",
-    effort = "effort",
-    enrollmentStart = null,
-    enrollmentEnd = null,
-    hidden = false,
-    invitationOnly = false,
-    media = Media(),
-    mobileAvailable = true,
-    name = "Test course",
-    number = "number",
-    org = "EdX",
-    pacing = "pacing",
-    shortDescription = "shortDescription",
-    start = "start",
-    end = "end",
-    startDisplay = "startDisplay",
-    startType = "startType",
-    overview = "",
-    isEnrolled = false
-)

--- a/discovery/src/main/java/org/openedx/discovery/presentation/search/CourseSearchFragment.kt
+++ b/discovery/src/main/java/org/openedx/discovery/presentation/search/CourseSearchFragment.kt
@@ -63,7 +63,6 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
-import org.openedx.core.domain.model.Media
 import org.openedx.core.ui.AuthButtonsPanel
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.HandleUIMessage
@@ -73,7 +72,7 @@ import org.openedx.core.ui.statusBarsInset
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appTypography
-import org.openedx.discovery.domain.model.Course
+import org.openedx.discovery.DiscoveryMocks
 import org.openedx.discovery.presentation.DiscoveryRouter
 import org.openedx.discovery.presentation.search.CourseSearchFragment.Companion.LOAD_MORE_THRESHOLD
 import org.openedx.discovery.presentation.ui.DiscoveryCourseItem
@@ -430,7 +429,7 @@ fun CourseSearchScreenPreview() {
     OpenEdXTheme {
         CourseSearchScreen(
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
-            state = CourseSearchUIState.Courses(listOf(mockCourse, mockCourse), 2),
+            state = CourseSearchUIState.Courses(DiscoveryMocks.courses(2), 2),
             uiMessage = null,
             apiHostUrl = "",
             canLoadMore = false,
@@ -456,7 +455,7 @@ fun CourseSearchScreenTabletPreview() {
     OpenEdXTheme {
         CourseSearchScreen(
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
-            state = CourseSearchUIState.Courses(listOf(mockCourse, mockCourse), 2),
+            state = CourseSearchUIState.Courses(DiscoveryMocks.courses(2), 2),
             uiMessage = null,
             apiHostUrl = "",
             canLoadMore = false,
@@ -474,27 +473,3 @@ fun CourseSearchScreenTabletPreview() {
         )
     }
 }
-
-private val mockCourse = Course(
-    id = "id",
-    blocksUrl = "blocksUrl",
-    courseId = "courseId",
-    effort = "effort",
-    enrollmentStart = null,
-    enrollmentEnd = null,
-    hidden = false,
-    invitationOnly = false,
-    media = Media(),
-    mobileAvailable = true,
-    name = "Test course",
-    number = "number",
-    org = "EdX",
-    pacing = "pacing",
-    shortDescription = "shortDescription",
-    start = "start",
-    end = "end",
-    startDisplay = "startDisplay",
-    startType = "startType",
-    overview = "",
-    isEnrolled = false
-)

--- a/discovery/src/test/java/org/openedx/discovery/presentation/detail/CourseDetailsViewModelTest.kt
+++ b/discovery/src/test/java/org/openedx/discovery/presentation/detail/CourseDetailsViewModelTest.kt
@@ -24,13 +24,12 @@ import org.junit.rules.TestRule
 import org.openedx.core.R
 import org.openedx.core.config.Config
 import org.openedx.core.data.storage.CorePreferences
-import org.openedx.core.domain.model.Media
 import org.openedx.core.system.connection.NetworkConnection
 import org.openedx.core.system.notifier.CourseDashboardUpdate
 import org.openedx.core.system.notifier.DiscoveryNotifier
 import org.openedx.core.worker.CalendarSyncScheduler
+import org.openedx.discovery.DiscoveryMocks
 import org.openedx.discovery.domain.interactor.DiscoveryInteractor
-import org.openedx.discovery.domain.model.Course
 import org.openedx.discovery.presentation.DiscoveryAnalytics
 import org.openedx.discovery.presentation.DiscoveryAnalyticsEvent
 import org.openedx.foundation.presentation.UIMessage
@@ -56,30 +55,6 @@ class CourseDetailsViewModelTest {
 
     private val noInternet = "Slow or no internet connection"
     private val somethingWrong = "Something went wrong"
-
-    private val mockCourse = Course(
-        id = "id",
-        blocksUrl = "blocksUrl",
-        courseId = "courseId",
-        effort = "effort",
-        enrollmentStart = null,
-        enrollmentEnd = null,
-        hidden = false,
-        invitationOnly = false,
-        media = Media(),
-        mobileAvailable = true,
-        name = "Test course",
-        number = "number",
-        org = "EdX",
-        pacing = "pacing",
-        shortDescription = "shortDescription",
-        start = "start",
-        end = "end",
-        startDisplay = "startDisplay",
-        startType = "startType",
-        overview = "",
-        isEnrolled = false
-    )
 
     @Before
     fun setUp() {
@@ -216,7 +191,7 @@ class CourseDetailsViewModelTest {
         coEvery { interactor.enrollInACourse(any()) } throws UnknownHostException()
         coEvery { notifier.send(CourseDashboardUpdate()) } returns Unit
         every { networkConnection.isOnline() } returns true
-        coEvery { interactor.getCourseDetails(any()) } returns mockCourse
+        coEvery { interactor.getCourseDetails(any()) } returns DiscoveryMocks.course
         every { analytics.logEvent(any(), any()) } returns Unit
 
         viewModel.enrollInACourse("", "")
@@ -248,7 +223,7 @@ class CourseDetailsViewModelTest {
         coEvery { interactor.enrollInACourse(any()) } throws Exception()
         coEvery { notifier.send(CourseDashboardUpdate()) } returns Unit
         every { networkConnection.isOnline() } returns true
-        coEvery { interactor.getCourseDetails(any()) } returns mockCourse
+        coEvery { interactor.getCourseDetails(any()) } returns DiscoveryMocks.course
         every {
             analytics.logEvent(
                 DiscoveryAnalyticsEvent.COURSE_ENROLL_CLICKED.eventName,
@@ -302,7 +277,7 @@ class CourseDetailsViewModelTest {
         coEvery { interactor.enrollInACourse(any()) } returns Unit
         coEvery { notifier.send(CourseDashboardUpdate()) } returns Unit
         every { networkConnection.isOnline() } returns true
-        coEvery { interactor.getCourseDetails(any()) } returns mockCourse
+        coEvery { interactor.getCourseDetails(any()) } returns DiscoveryMocks.course
 
         delay(200)
         viewModel.enrollInACourse("", "")

--- a/discovery/src/test/java/org/openedx/discovery/presentation/search/CourseSearchViewModelTest.kt
+++ b/discovery/src/test/java/org/openedx/discovery/presentation/search/CourseSearchViewModelTest.kt
@@ -22,10 +22,9 @@ import org.junit.rules.TestRule
 import org.openedx.core.R
 import org.openedx.core.config.Config
 import org.openedx.core.data.storage.CorePreferences
-import org.openedx.core.domain.model.Media
 import org.openedx.core.domain.model.Pagination
+import org.openedx.discovery.DiscoveryMocks
 import org.openedx.discovery.domain.interactor.DiscoveryInteractor
-import org.openedx.discovery.domain.model.Course
 import org.openedx.discovery.domain.model.CourseList
 import org.openedx.discovery.presentation.DiscoveryAnalytics
 import org.openedx.foundation.presentation.UIMessage
@@ -48,34 +47,6 @@ class CourseSearchViewModelTest {
 
     private val noInternet = "Slow or no internet connection"
     private val somethingWrong = "Something went wrong"
-
-    //region course
-
-    private val mockCourse = Course(
-        id = "id",
-        blocksUrl = "blocksUrl",
-        courseId = "courseId",
-        effort = "effort",
-        enrollmentStart = null,
-        enrollmentEnd = null,
-        hidden = false,
-        invitationOnly = false,
-        media = Media(),
-        mobileAvailable = true,
-        name = "Test course",
-        number = "number",
-        org = "EdX",
-        pacing = "pacing",
-        shortDescription = "shortDescription",
-        start = "start",
-        end = "end",
-        startDisplay = "startDisplay",
-        startType = "startType",
-        overview = "",
-        false
-    )
-
-    //endregion
 
     @Before
     fun setUp() {
@@ -175,14 +146,14 @@ class CourseSearchViewModelTest {
                 5,
                 ""
             ),
-            listOf(mockCourse, mockCourse)
+            DiscoveryMocks.courses(2)
         )
         coEvery {
             interactor.getCoursesListByQuery(
                 any(),
                 not(1)
             )
-        } returns CourseList(Pagination(10, "", 5, ""), listOf(mockCourse))
+        } returns CourseList(Pagination(10, "", 5, ""), listOf(DiscoveryMocks.course))
         every { analytics.discoveryCourseSearchEvent(any(), any()) } returns Unit
 
         viewModel.search("course")
@@ -211,14 +182,14 @@ class CourseSearchViewModelTest {
                 5,
                 ""
             ),
-            listOf(mockCourse, mockCourse)
+            DiscoveryMocks.courses(2)
         )
         coEvery {
             interactor.getCoursesListByQuery(
                 any(),
                 not(1)
             )
-        } returns CourseList(Pagination(10, "0", 5, ""), listOf(mockCourse))
+        } returns CourseList(Pagination(10, "0", 5, ""), listOf(DiscoveryMocks.course))
         every { analytics.discoveryCourseSearchEvent(any(), any()) } returns Unit
 
         viewModel.search("course")
@@ -248,7 +219,7 @@ class CourseSearchViewModelTest {
                 5,
                 ""
             ),
-            listOf(mockCourse, mockCourse)
+            DiscoveryMocks.courses(2)
         )
 
         viewModel.updateSearchQuery()

--- a/discussion/src/main/java/org/openedx/discussion/DiscussionMocks.kt
+++ b/discussion/src/main/java/org/openedx/discussion/DiscussionMocks.kt
@@ -1,0 +1,76 @@
+package org.openedx.discussion
+
+import org.openedx.core.domain.model.ProfileImage
+import org.openedx.discussion.domain.model.DiscussionComment
+import org.openedx.discussion.domain.model.DiscussionProfile
+import org.openedx.discussion.domain.model.DiscussionType
+import org.openedx.discussion.domain.model.Thread
+import org.openedx.discussion.domain.model.Topic
+
+object DiscussionMocks {
+    val topic = Topic(
+        id = "topic-id",
+        name = "Mock Topic",
+        threadListUrl = "",
+        children = emptyList()
+    )
+
+    val thread = Thread(
+        id = "thread-id",
+        author = "Preview Author",
+        authorLabel = "staff",
+        createdAt = "2024-01-01",
+        updatedAt = "2024-01-02",
+        rawBody = "Preview thread body",
+        renderedBody = "Preview thread body",
+        abuseFlagged = false,
+        voted = false,
+        voteCount = 0,
+        editableFields = emptyList(),
+        canDelete = false,
+        courseId = "course-id",
+        topicId = "topic-id",
+        groupId = "0",
+        groupName = "",
+        type = DiscussionType.DISCUSSION,
+        previewBody = "Preview thread body",
+        abuseFlaggedCount = "0",
+        title = "Preview Thread Title",
+        pinned = false,
+        closed = false,
+        following = false,
+        commentCount = 3,
+        unreadCommentCount = 2,
+        read = false,
+        hasEndorsed = false,
+        users = null,
+        responseCount = 2,
+        anonymous = false,
+        anonymousToPeers = false
+    )
+
+    val comment = DiscussionComment(
+        id = "comment-id",
+        author = "Preview Commenter",
+        authorLabel = "staff",
+        createdAt = "2024-01-01",
+        updatedAt = "2024-01-02",
+        rawBody = "Preview comment",
+        renderedBody = "Preview comment",
+        abuseFlagged = false,
+        voted = false,
+        voteCount = 0,
+        editableFields = emptyList(),
+        canDelete = false,
+        threadId = "thread-id",
+        parentId = "",
+        endorsed = false,
+        endorsedBy = "",
+        endorsedByLabel = "",
+        endorsedAt = "",
+        childCount = 0,
+        children = emptyList(),
+        profileImage = ProfileImage("", "", "", "", false),
+        users = mapOf("Preview Commenter" to DiscussionProfile(ProfileImage("", "", "", "", false)))
+    )
+}

--- a/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsFragment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/comments/DiscussionCommentsFragment.kt
@@ -71,7 +71,6 @@ import androidx.fragment.app.Fragment
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
-import org.openedx.core.domain.model.ProfileImage
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.displayCutoutForLandscape
@@ -81,9 +80,9 @@ import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appShapes
 import org.openedx.core.ui.theme.appTypography
+import org.openedx.discussion.DiscussionMocks
 import org.openedx.discussion.R
 import org.openedx.discussion.domain.model.DiscussionComment
-import org.openedx.discussion.domain.model.DiscussionType
 import org.openedx.discussion.presentation.DiscussionRouter
 import org.openedx.discussion.presentation.comments.DiscussionCommentsFragment.Companion.LOAD_MORE_THRESHOLD
 import org.openedx.discussion.presentation.ui.CommentItem
@@ -388,7 +387,11 @@ private fun DiscussionCommentsScreen(
                                         }
                                     }
                                 }
-                                if (scrollState.shouldLoadMore(firstVisibleIndex, LOAD_MORE_THRESHOLD)) {
+                                if (scrollState.shouldLoadMore(
+                                        firstVisibleIndex,
+                                        LOAD_MORE_THRESHOLD
+                                    )
+                                ) {
                                     paginationCallBack()
                                 }
                                 if (!isSystemInDarkTheme()) {
@@ -495,8 +498,8 @@ private fun DiscussionCommentsScreenPreview() {
         DiscussionCommentsScreen(
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
             uiState = DiscussionCommentsUIState.Success(
-                mockThread,
-                listOf(mockComment, mockComment),
+                DiscussionMocks.thread,
+                listOf(DiscussionMocks.comment, DiscussionMocks.comment),
                 2
             ),
             uiMessage = null,
@@ -522,8 +525,8 @@ private fun DiscussionCommentsScreenTabletPreview() {
         DiscussionCommentsScreen(
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
             uiState = DiscussionCommentsUIState.Success(
-                mockThread,
-                listOf(mockComment, mockComment),
+                DiscussionMocks.thread,
+                listOf(DiscussionMocks.comment, DiscussionMocks.comment),
                 2
             ),
             uiMessage = null,
@@ -540,62 +543,3 @@ private fun DiscussionCommentsScreenTabletPreview() {
         )
     }
 }
-
-private val mockThread = org.openedx.discussion.domain.model.Thread(
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    false,
-    true,
-    20,
-    emptyList(),
-    false,
-    "",
-    "",
-    "",
-    "",
-    DiscussionType.DISCUSSION,
-    "",
-    "",
-    "Discussion title long Discussion title long good item",
-    true,
-    false,
-    true,
-    21,
-    4,
-    false,
-    false,
-    mapOf(),
-    10,
-    false,
-    false
-)
-
-private val mockComment = DiscussionComment(
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    false,
-    true,
-    20,
-    emptyList(),
-    false,
-    "",
-    "",
-    false,
-    "",
-    "",
-    "",
-    21,
-    emptyList(),
-    profileImage = ProfileImage("", "", "", "", false),
-    mapOf()
-)

--- a/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesFragment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/responses/DiscussionResponsesFragment.kt
@@ -75,7 +75,6 @@ import androidx.fragment.app.Fragment
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
-import org.openedx.core.domain.model.ProfileImage
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.displayCutoutForLandscape
@@ -85,6 +84,7 @@ import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appShapes
 import org.openedx.core.ui.theme.appTypography
+import org.openedx.discussion.DiscussionMocks
 import org.openedx.discussion.R
 import org.openedx.discussion.domain.model.DiscussionComment
 import org.openedx.discussion.presentation.DiscussionRouter
@@ -532,10 +532,10 @@ private fun DiscussionResponsesScreenPreview() {
         DiscussionResponsesScreen(
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
             uiState = DiscussionResponsesUIState.Success(
-                mockComment,
+                DiscussionMocks.comment,
                 listOf(
-                    mockComment,
-                    mockComment
+                    DiscussionMocks.comment,
+                    DiscussionMocks.comment
                 )
             ),
             uiMessage = null,
@@ -560,10 +560,10 @@ private fun DiscussionResponsesScreenTabletPreview() {
         DiscussionResponsesScreen(
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
             uiState = DiscussionResponsesUIState.Success(
-                mockComment,
+                DiscussionMocks.comment,
                 listOf(
-                    mockComment,
-                    mockComment
+                    DiscussionMocks.comment,
+                    DiscussionMocks.comment
                 )
             ),
             uiMessage = null,
@@ -579,28 +579,3 @@ private fun DiscussionResponsesScreenTabletPreview() {
         )
     }
 }
-
-private val mockComment = DiscussionComment(
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    false,
-    true,
-    20,
-    emptyList(),
-    false,
-    "",
-    "",
-    false,
-    "",
-    "",
-    "",
-    21,
-    emptyList(),
-    ProfileImage("", "", "", "", false),
-    mapOf()
-)

--- a/discussion/src/main/java/org/openedx/discussion/presentation/search/DiscussionSearchThreadFragment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/search/DiscussionSearchThreadFragment.kt
@@ -68,7 +68,7 @@ import org.openedx.core.ui.statusBarsInset
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appTypography
-import org.openedx.discussion.domain.model.DiscussionType
+import org.openedx.discussion.DiscussionMocks
 import org.openedx.discussion.presentation.DiscussionRouter
 import org.openedx.discussion.presentation.search.DiscussionSearchThreadFragment.Companion.LOAD_MORE_THRESHOLD
 import org.openedx.discussion.presentation.ui.ThreadItem
@@ -330,6 +330,7 @@ private fun DiscussionSearchThreadScreen(
                                         }
                                     }
                                 }
+
                                 is DiscussionSearchThreadUIState.Threads -> {
                                     items(uiState.data) { thread ->
                                         ThreadItem(thread = thread, onClick = onItemClick)
@@ -347,7 +348,11 @@ private fun DiscussionSearchThreadScreen(
                                             }
                                         }
                                     }
-                                    if (scrollState.shouldLoadMore(firstVisibleIndex, LOAD_MORE_THRESHOLD)) {
+                                    if (scrollState.shouldLoadMore(
+                                            firstVisibleIndex,
+                                            LOAD_MORE_THRESHOLD
+                                        )
+                                    ) {
                                         paginationCallback()
                                     }
                                 }
@@ -372,7 +377,10 @@ fun DiscussionSearchThreadScreenPreview() {
     OpenEdXTheme {
         DiscussionSearchThreadScreen(
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
-            uiState = DiscussionSearchThreadUIState.Threads(listOf(mockThread, mockThread), 2),
+            uiState = DiscussionSearchThreadUIState.Threads(
+                listOf(DiscussionMocks.thread, DiscussionMocks.thread),
+                2
+            ),
             uiMessage = null,
             refreshing = false,
             canLoadMore = true,
@@ -392,7 +400,10 @@ fun DiscussionSearchThreadScreenTabletPreview() {
     OpenEdXTheme {
         DiscussionSearchThreadScreen(
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
-            uiState = DiscussionSearchThreadUIState.Threads(listOf(mockThread, mockThread), 2),
+            uiState = DiscussionSearchThreadUIState.Threads(
+                listOf(DiscussionMocks.thread, DiscussionMocks.thread),
+                2
+            ),
             uiMessage = null,
             refreshing = false,
             canLoadMore = true,
@@ -404,37 +415,3 @@ fun DiscussionSearchThreadScreenTabletPreview() {
         )
     }
 }
-
-private val mockThread = org.openedx.discussion.domain.model.Thread(
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    false,
-    true,
-    20,
-    emptyList(),
-    false,
-    "",
-    "",
-    "",
-    "",
-    DiscussionType.DISCUSSION,
-    "",
-    "",
-    "Discussion title long Discussion title long good item",
-    true,
-    false,
-    true,
-    21,
-    4,
-    false,
-    false,
-    mapOf(),
-    10,
-    false,
-    false
-)

--- a/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsFragment.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/threads/DiscussionThreadsFragment.kt
@@ -88,7 +88,7 @@ import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appShapes
 import org.openedx.core.ui.theme.appTypography
-import org.openedx.discussion.domain.model.DiscussionType
+import org.openedx.discussion.DiscussionMocks
 import org.openedx.discussion.presentation.DiscussionRouter
 import org.openedx.discussion.presentation.threads.DiscussionThreadsFragment.Companion.LOAD_MORE_THRESHOLD
 import org.openedx.discussion.presentation.ui.ThreadItem
@@ -693,7 +693,13 @@ private fun DiscussionThreadsScreenPreview() {
         DiscussionThreadsScreen(
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
             "All posts",
-            uiState = DiscussionThreadsUIState.Threads(listOf(mockThread, mockThread, mockThread)),
+            uiState = DiscussionThreadsUIState.Threads(
+                listOf(
+                    DiscussionMocks.thread,
+                    DiscussionMocks.thread,
+                    DiscussionMocks.thread
+                )
+            ),
             uiMessage = null,
             onItemClick = {},
             onBackClick = {},
@@ -717,7 +723,13 @@ private fun DiscussionThreadsScreenTabletPreview() {
         DiscussionThreadsScreen(
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
             "All posts",
-            uiState = DiscussionThreadsUIState.Threads(listOf(mockThread, mockThread, mockThread)),
+            uiState = DiscussionThreadsUIState.Threads(
+                listOf(
+                    DiscussionMocks.thread,
+                    DiscussionMocks.thread,
+                    DiscussionMocks.thread
+                )
+            ),
             uiMessage = null,
             onItemClick = {},
             onBackClick = {},
@@ -732,37 +744,3 @@ private fun DiscussionThreadsScreenTabletPreview() {
         )
     }
 }
-
-private val mockThread = org.openedx.discussion.domain.model.Thread(
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    false,
-    true,
-    20,
-    emptyList(),
-    false,
-    "",
-    "",
-    "",
-    "",
-    DiscussionType.DISCUSSION,
-    "",
-    "",
-    "Discussion title long Discussion title long good item",
-    true,
-    false,
-    true,
-    21,
-    4,
-    false,
-    false,
-    mapOf(),
-    10,
-    false,
-    false
-)

--- a/discussion/src/main/java/org/openedx/discussion/presentation/topics/DiscussionTopicsScreen.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/topics/DiscussionTopicsScreen.kt
@@ -48,8 +48,8 @@ import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appShapes
 import org.openedx.core.ui.theme.appTypography
+import org.openedx.discussion.DiscussionMocks
 import org.openedx.discussion.R
-import org.openedx.discussion.domain.model.Topic
 import org.openedx.discussion.presentation.ui.ThreadItemCategory
 import org.openedx.discussion.presentation.ui.TopicItem
 import org.openedx.foundation.presentation.UIMessage
@@ -280,7 +280,12 @@ private fun DiscussionTopicsScreenPreview() {
     OpenEdXTheme {
         DiscussionTopicsUI(
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
-            uiState = DiscussionTopicsUIState.Topics(listOf(mockTopic, mockTopic)),
+            uiState = DiscussionTopicsUIState.Topics(
+                listOf(
+                    DiscussionMocks.topic,
+                    DiscussionMocks.topic
+                )
+            ),
             uiMessage = null,
             onItemClick = { _, _, _ -> },
             onSearchClick = {}
@@ -312,17 +317,15 @@ private fun DiscussionTopicsScreenTabletPreview() {
     OpenEdXTheme {
         DiscussionTopicsUI(
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
-            uiState = DiscussionTopicsUIState.Topics(listOf(mockTopic, mockTopic)),
+            uiState = DiscussionTopicsUIState.Topics(
+                listOf(
+                    DiscussionMocks.topic,
+                    DiscussionMocks.topic
+                )
+            ),
             uiMessage = null,
             onItemClick = { _, _, _ -> },
             onSearchClick = {}
         )
     }
 }
-
-private val mockTopic = Topic(
-    id = "",
-    name = "All Topics",
-    threadListUrl = "",
-    children = emptyList()
-)

--- a/discussion/src/main/java/org/openedx/discussion/presentation/ui/DiscussionUI.kt
+++ b/discussion/src/main/java/org/openedx/discussion/presentation/ui/DiscussionUI.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
-import org.openedx.core.domain.model.ProfileImage
 import org.openedx.core.ui.AutoSizeText
 import org.openedx.core.ui.IconText
 import org.openedx.core.ui.RenderHtmlContent
@@ -53,6 +52,7 @@ import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appShapes
 import org.openedx.core.ui.theme.appTypography
 import org.openedx.core.utils.TimeUtils
+import org.openedx.discussion.DiscussionMocks
 import org.openedx.discussion.R
 import org.openedx.discussion.domain.model.DiscussionComment
 import org.openedx.discussion.domain.model.DiscussionType
@@ -665,7 +665,7 @@ fun TopicItem(
 private fun TopicItemPreview() {
     OpenEdXTheme {
         TopicItem(
-            topic = mockTopic,
+            topic = DiscussionMocks.topic,
             onClick = { _, _ -> }
         )
     }
@@ -677,7 +677,7 @@ private fun TopicItemPreview() {
 private fun ThreadItemPreview() {
     OpenEdXTheme {
         ThreadItem(
-            thread = mockThread,
+            thread = DiscussionMocks.thread,
             onClick = {}
         )
     }
@@ -689,7 +689,7 @@ private fun CommentItemPreview() {
     OpenEdXTheme {
         CommentItem(
             modifier = Modifier.fillMaxWidth(),
-            comment = mockComment,
+            comment = DiscussionMocks.comment,
             onClick = { _, _, _ -> },
             onUserPhotoClick = {}
         )
@@ -701,74 +701,8 @@ private fun CommentItemPreview() {
 private fun ThreadMainItemPreview() {
     ThreadMainItem(
         modifier = Modifier.fillMaxWidth(),
-        thread = mockThread,
+        thread = DiscussionMocks.thread,
         onClick = { _, _ -> },
         onUserPhotoClick = {}
     )
 }
-
-private val mockComment = DiscussionComment(
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    false,
-    true,
-    20,
-    emptyList(),
-    false,
-    "",
-    "",
-    false,
-    "",
-    "",
-    "",
-    21,
-    emptyList(),
-    ProfileImage("", "", "", "", false),
-    mapOf()
-)
-
-private val mockThread = org.openedx.discussion.domain.model.Thread(
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    "",
-    false,
-    true,
-    20,
-    emptyList(),
-    false,
-    "",
-    "",
-    "",
-    "",
-    DiscussionType.DISCUSSION,
-    "",
-    "",
-    "Discussion title long Discussion title long good item",
-    true,
-    false,
-    true,
-    21,
-    4,
-    false,
-    false,
-    mapOf(),
-    10,
-    false,
-    false
-)
-
-private val mockTopic = Topic(
-    id = "",
-    name = "All Topics",
-    threadListUrl = "",
-    children = emptyList()
-)

--- a/discussion/src/test/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModelTest.kt
+++ b/discussion/src/test/java/org/openedx/discussion/presentation/comments/DiscussionCommentsViewModelTest.kt
@@ -27,9 +27,9 @@ import org.junit.rules.TestRule
 import org.openedx.core.R
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.Pagination
+import org.openedx.discussion.DiscussionMocks
 import org.openedx.discussion.domain.interactor.DiscussionInteractor
 import org.openedx.discussion.domain.model.CommentsData
-import org.openedx.discussion.domain.model.DiscussionComment
 import org.openedx.discussion.domain.model.DiscussionType
 import org.openedx.discussion.system.notifier.DiscussionCommentAdded
 import org.openedx.discussion.system.notifier.DiscussionCommentDataChanged
@@ -58,75 +58,14 @@ class DiscussionCommentsViewModelTest {
     private val commentAddedSuccessfully = "Comment Successfully added"
 
     //region mockThread
-
-    val mockThread = org.openedx.discussion.domain.model.Thread(
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        false,
-        true,
-        20,
-        emptyList(),
-        false,
-        "",
-        "",
-        "",
-        "",
-        DiscussionType.DISCUSSION,
-        "",
-        "",
-        "Discussion title long Discussion title long good item",
-        true,
-        false,
-        true,
-        21,
-        4,
-        false,
-        false,
-        mapOf(),
-        0,
-        false,
-        false
-    )
-
     //endregion
 
     //region mockComment
-
-    private val mockComment = DiscussionComment(
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        false,
-        true,
-        20,
-        emptyList(),
-        false,
-        "",
-        "",
-        false,
-        "",
-        "",
-        "",
-        21,
-        emptyList(),
-        null,
-        mapOf()
-    )
-
     // endregion
 
     private val comments = listOf(
-        mockComment.copy(id = "0"),
-        mockComment.copy(id = "1")
+        DiscussionMocks.comment.copy(id = "0"),
+        DiscussionMocks.comment.copy(id = "1")
     )
 
     @Before
@@ -148,13 +87,13 @@ class DiscussionCommentsViewModelTest {
     @Test
     fun `getThreadComments no internet connection exception`() = runTest {
         coEvery { interactor.getThreadComments(any(), any()) } throws UnknownHostException()
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
         val viewModel =
             DiscussionCommentsViewModel(
                 interactor,
                 resourceManager,
                 notifier,
-                mockThread
+                DiscussionMocks.thread
             )
 
         advanceUntilIdle()
@@ -177,7 +116,7 @@ class DiscussionCommentsViewModelTest {
                 interactor,
                 resourceManager,
                 notifier,
-                mockThread.copy(type = DiscussionType.QUESTION)
+                DiscussionMocks.thread.copy(type = DiscussionType.QUESTION)
             )
 
         coEvery { interactor.getThreadQuestionComments(any(), any(), any()) } throws Exception()
@@ -199,7 +138,7 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "2", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
         every { resourceManager.getString(eq(DiscussionType.QUESTION.resId)) } returns ""
 
         val viewModel =
@@ -207,7 +146,7 @@ class DiscussionCommentsViewModelTest {
                 interactor,
                 resourceManager,
                 notifier,
-                mockThread.copy(type = DiscussionType.QUESTION)
+                DiscussionMocks.thread.copy(type = DiscussionType.QUESTION)
             )
 
         advanceUntilIdle()
@@ -228,15 +167,15 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel =
             DiscussionCommentsViewModel(
                 interactor,
                 resourceManager,
                 notifier,
-                mockThread
+                DiscussionMocks.thread
             )
 
         coEvery { interactor.getThreadQuestionComments(any(), any(), any()) } returns CommentsData(
@@ -261,15 +200,15 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel =
             DiscussionCommentsViewModel(
                 interactor,
                 resourceManager,
                 notifier,
-                mockThread
+                DiscussionMocks.thread
             )
 
         coEvery { interactor.getThreadQuestionComments(any(), any(), any()) } returns CommentsData(
@@ -295,14 +234,14 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
 
         coEvery { interactor.getThreadQuestionComments(any(), any(), any()) } returns CommentsData(
@@ -329,14 +268,14 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "2", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
 
         coEvery { interactor.getThreadComments(any(), eq(2)) } returns CommentsData(
@@ -362,14 +301,14 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
 
         coEvery { interactor.setThreadVoted(any(), any()) } throws UnknownHostException()
@@ -390,15 +329,15 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel =
             DiscussionCommentsViewModel(
                 interactor,
                 resourceManager,
                 notifier,
-                mockThread
+                DiscussionMocks.thread
             )
 
         coEvery { interactor.setThreadVoted(any(), any()) } throws Exception()
@@ -419,18 +358,18 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel =
             DiscussionCommentsViewModel(
                 interactor,
                 resourceManager,
                 notifier,
-                mockThread
+                DiscussionMocks.thread
             )
 
-        coEvery { interactor.setThreadVoted(any(), any()) } returns mockThread
+        coEvery { interactor.setThreadVoted(any(), any()) } returns DiscussionMocks.thread
 
         viewModel.setThreadUpvoted(true)
         advanceUntilIdle()
@@ -447,15 +386,15 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel =
             DiscussionCommentsViewModel(
                 interactor,
                 resourceManager,
                 notifier,
-                mockThread
+                DiscussionMocks.thread
             )
 
         coEvery { interactor.setCommentFlagged(any(), any()) } throws UnknownHostException()
@@ -476,15 +415,15 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel =
             DiscussionCommentsViewModel(
                 interactor,
                 resourceManager,
                 notifier,
-                mockThread
+                DiscussionMocks.thread
             )
 
         coEvery { interactor.setCommentFlagged(any(), any()) } throws Exception()
@@ -505,17 +444,19 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
 
-        coEvery { interactor.setCommentFlagged(any(), any()) } returns mockComment.copy(id = "0")
+        coEvery { interactor.setCommentFlagged(any(), any()) } returns DiscussionMocks.comment.copy(
+            id = "0"
+        )
 
         viewModel.setCommentReported("", true)
         advanceUntilIdle()
@@ -532,14 +473,14 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
 
         coEvery { interactor.setCommentVoted(any(), any()) } throws UnknownHostException()
@@ -560,14 +501,14 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
 
         coEvery { interactor.setCommentVoted(any(), any()) } throws Exception()
@@ -588,17 +529,22 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
 
-        coEvery { interactor.setCommentVoted(any(), any()) } returns mockComment.copy(id = "0")
+        coEvery {
+            interactor.setCommentVoted(
+                any(),
+                any()
+            )
+        } returns DiscussionMocks.comment.copy(id = "0")
 
         viewModel.setCommentUpvoted("", true)
         advanceUntilIdle()
@@ -615,14 +561,14 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
 
         coEvery { interactor.setThreadFlagged(any(), any()) } throws UnknownHostException()
@@ -643,14 +589,14 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
 
         coEvery { interactor.setThreadFlagged(any(), any()) } throws Exception()
@@ -671,17 +617,17 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
 
-        coEvery { interactor.setThreadFlagged(any(), any()) } returns mockThread
+        coEvery { interactor.setThreadFlagged(any(), any()) } returns DiscussionMocks.thread
 
         viewModel.setThreadReported(true)
         advanceUntilIdle()
@@ -698,16 +644,16 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "", 4, "1")
         )
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
         coEvery { interactor.setThreadFollowed(any(), any()) } throws UnknownHostException()
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
 
         viewModel.setThreadFollowed(true)
@@ -726,14 +672,14 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
 
         coEvery { interactor.setThreadFollowed(any(), any()) } throws Exception()
@@ -754,17 +700,17 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
 
-        coEvery { interactor.setThreadFollowed(any(), any()) } returns mockThread
+        coEvery { interactor.setThreadFollowed(any(), any()) } returns DiscussionMocks.thread
 
         viewModel.setThreadFollowed(true)
         advanceUntilIdle()
@@ -781,21 +727,21 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
 
         coEvery { notifier.notifier } returns flow {
             delay(100)
-            emit(DiscussionCommentAdded(mockComment))
+            emit(DiscussionCommentAdded(DiscussionMocks.comment))
         }
-        coEvery { notifier.send(DiscussionThreadDataChanged(mockThread)) } returns Unit
+        coEvery { notifier.send(DiscussionThreadDataChanged(DiscussionMocks.thread)) } returns Unit
 
         val mockLifeCycleOwner: LifecycleOwner = mockk()
         val lifecycleRegistry = LifecycleRegistry(mockLifeCycleOwner)
@@ -814,19 +760,19 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "2", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
 
         coEvery { notifier.notifier } returns flow {
             delay(100)
-            emit(DiscussionCommentAdded(mockComment))
+            emit(DiscussionCommentAdded(DiscussionMocks.comment))
         }
         coEvery { notifier.send(DiscussionThreadDataChanged(mockk())) } returns Unit
 
@@ -848,21 +794,21 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "2", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
 
         coEvery { notifier.notifier } returns flow {
             delay(100)
-            emit(DiscussionCommentDataChanged(mockComment.copy(id = "0")))
+            emit(DiscussionCommentDataChanged(DiscussionMocks.comment.copy(id = "0")))
         }
-        coEvery { notifier.send(DiscussionCommentDataChanged(mockComment)) } returns Unit
+        coEvery { notifier.send(DiscussionCommentDataChanged(DiscussionMocks.comment)) } returns Unit
 
         val mockLifeCycleOwner: LifecycleOwner = mockk()
         val lifecycleRegistry = LifecycleRegistry(mockLifeCycleOwner)
@@ -881,14 +827,14 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "2", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
         coEvery { interactor.createComment(any(), any(), any()) } throws UnknownHostException()
 
@@ -907,14 +853,14 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "2", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
         coEvery { interactor.createComment(any(), any(), any()) } throws Exception()
 
@@ -933,17 +879,17 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "2", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel =
             DiscussionCommentsViewModel(
                 interactor,
                 resourceManager,
                 notifier,
-                mockThread
+                DiscussionMocks.thread
             )
-        coEvery { interactor.createComment(any(), any(), any()) } returns mockComment
+        coEvery { interactor.createComment(any(), any(), any()) } returns DiscussionMocks.comment
 
         viewModel.createComment("")
         advanceUntilIdle()
@@ -960,16 +906,16 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "2", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
-        coEvery { interactor.createComment(any(), any(), any()) } returns mockComment
+        coEvery { interactor.createComment(any(), any(), any()) } returns DiscussionMocks.comment
         every { preferencesManager.user?.username } returns ""
 
         viewModel.createComment("")
@@ -982,16 +928,16 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "2", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
-        coEvery { interactor.createComment(any(), any(), any()) } returns mockComment
+        coEvery { interactor.createComment(any(), any(), any()) } returns DiscussionMocks.comment
         every { preferencesManager.user?.username } returns ""
 
         viewModel.createComment("")
@@ -1006,16 +952,16 @@ class DiscussionCommentsViewModelTest {
             comments,
             Pagination(10, "", 4, "1")
         )
-        coEvery { interactor.setThreadRead(any()) } returns mockThread
-        every { resourceManager.getString(eq(mockThread.type.resId)) } returns ""
+        coEvery { interactor.setThreadRead(any()) } returns DiscussionMocks.thread
+        every { resourceManager.getString(eq(DiscussionMocks.thread.type.resId)) } returns ""
 
         val viewModel = DiscussionCommentsViewModel(
             interactor,
             resourceManager,
             notifier,
-            mockThread
+            DiscussionMocks.thread
         )
-        coEvery { interactor.createComment(any(), any(), any()) } returns mockComment
+        coEvery { interactor.createComment(any(), any(), any()) } returns DiscussionMocks.comment
         every { preferencesManager.user?.username } returns ""
 
         viewModel.createComment("")

--- a/discussion/src/test/java/org/openedx/discussion/presentation/responses/DiscussionResponsesViewModelTest.kt
+++ b/discussion/src/test/java/org/openedx/discussion/presentation/responses/DiscussionResponsesViewModelTest.kt
@@ -22,9 +22,9 @@ import org.junit.rules.TestRule
 import org.openedx.core.R
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.Pagination
+import org.openedx.discussion.DiscussionMocks
 import org.openedx.discussion.domain.interactor.DiscussionInteractor
 import org.openedx.discussion.domain.model.CommentsData
-import org.openedx.discussion.domain.model.DiscussionComment
 import org.openedx.discussion.system.notifier.DiscussionNotifier
 import org.openedx.foundation.presentation.UIMessage
 import org.openedx.foundation.system.ResourceManager
@@ -47,38 +47,9 @@ class DiscussionResponsesViewModelTest {
     private val somethingWrong = "Something went wrong"
     private val commentAddedSuccessfully = "Comment Successfully added"
 
-    //region mockComment
-
-    private val mockComment = DiscussionComment(
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        false,
-        true,
-        20,
-        emptyList(),
-        false,
-        "",
-        "",
-        false,
-        "",
-        "",
-        "",
-        21,
-        emptyList(),
-        null,
-        emptyMap()
-    )
-
-    //endregion
-
     private val comments = listOf(
-        mockComment.copy(id = "0"),
-        mockComment.copy(id = "1")
+        DiscussionMocks.comment.copy(id = "0"),
+        DiscussionMocks.comment.copy(id = "1")
     )
 
     @Before
@@ -105,7 +76,7 @@ class DiscussionResponsesViewModelTest {
             interactor,
             resourceManager,
             notifier,
-            mockComment.copy(id = "0")
+            DiscussionMocks.comment.copy(id = "0")
         )
         advanceUntilIdle()
 
@@ -125,7 +96,7 @@ class DiscussionResponsesViewModelTest {
             interactor,
             resourceManager,
             notifier,
-            mockComment.copy(id = "0")
+            DiscussionMocks.comment.copy(id = "0")
         )
 
         advanceUntilIdle()
@@ -148,7 +119,7 @@ class DiscussionResponsesViewModelTest {
             interactor,
             resourceManager,
             notifier,
-            mockComment.copy(id = "0")
+            DiscussionMocks.comment.copy(id = "0")
         )
 
         advanceUntilIdle()
@@ -171,7 +142,7 @@ class DiscussionResponsesViewModelTest {
             interactor,
             resourceManager,
             notifier,
-            mockComment.copy(id = "0")
+            DiscussionMocks.comment.copy(id = "0")
         )
         advanceUntilIdle()
 
@@ -193,7 +164,7 @@ class DiscussionResponsesViewModelTest {
             interactor,
             resourceManager,
             notifier,
-            mockComment.copy(id = "0")
+            DiscussionMocks.comment.copy(id = "0")
         )
         viewModel.fetchMore()
         advanceUntilIdle()
@@ -216,7 +187,7 @@ class DiscussionResponsesViewModelTest {
             interactor,
             resourceManager,
             notifier,
-            mockComment.copy(id = "0")
+            DiscussionMocks.comment.copy(id = "0")
         )
         coEvery { interactor.getCommentsResponses(any(), eq(2)) } returns CommentsData(
             comments,
@@ -243,7 +214,7 @@ class DiscussionResponsesViewModelTest {
             interactor,
             resourceManager,
             notifier,
-            mockComment.copy(id = "0")
+            DiscussionMocks.comment.copy(id = "0")
         )
         coEvery { interactor.setCommentVoted(any(), any()) } throws UnknownHostException()
         viewModel.setCommentUpvoted("", false)
@@ -265,7 +236,7 @@ class DiscussionResponsesViewModelTest {
             interactor,
             resourceManager,
             notifier,
-            mockComment.copy(id = "0")
+            DiscussionMocks.comment.copy(id = "0")
         )
         coEvery { interactor.setCommentVoted(any(), any()) } throws Exception()
         viewModel.setCommentUpvoted("", false)
@@ -287,9 +258,14 @@ class DiscussionResponsesViewModelTest {
             interactor,
             resourceManager,
             notifier,
-            mockComment.copy(id = "0")
+            DiscussionMocks.comment.copy(id = "0")
         )
-        coEvery { interactor.setCommentVoted(any(), any()) } returns mockComment.copy(id = "0")
+        coEvery {
+            interactor.setCommentVoted(
+                any(),
+                any()
+            )
+        } returns DiscussionMocks.comment.copy(id = "0")
         viewModel.updateCommentResponses()
         viewModel.setCommentUpvoted("", false)
         advanceUntilIdle()
@@ -310,9 +286,14 @@ class DiscussionResponsesViewModelTest {
             interactor,
             resourceManager,
             notifier,
-            mockComment.copy(id = "0")
+            DiscussionMocks.comment.copy(id = "0")
         )
-        coEvery { interactor.setCommentVoted(any(), any()) } returns mockComment.copy(id = "2")
+        coEvery {
+            interactor.setCommentVoted(
+                any(),
+                any()
+            )
+        } returns DiscussionMocks.comment.copy(id = "2")
         viewModel.updateCommentResponses()
         viewModel.setCommentUpvoted("", false)
         advanceUntilIdle()
@@ -333,7 +314,7 @@ class DiscussionResponsesViewModelTest {
             interactor,
             resourceManager,
             notifier,
-            mockComment.copy(id = "0")
+            DiscussionMocks.comment.copy(id = "0")
         )
         coEvery { interactor.setCommentFlagged(any(), any()) } throws UnknownHostException()
         viewModel.setCommentReported("", false)
@@ -355,7 +336,7 @@ class DiscussionResponsesViewModelTest {
             interactor,
             resourceManager,
             notifier,
-            mockComment.copy(id = "0")
+            DiscussionMocks.comment.copy(id = "0")
         )
         coEvery { interactor.setCommentFlagged(any(), any()) } throws Exception()
         viewModel.setCommentReported("", false)
@@ -377,9 +358,11 @@ class DiscussionResponsesViewModelTest {
             interactor,
             resourceManager,
             notifier,
-            mockComment.copy(id = "0")
+            DiscussionMocks.comment.copy(id = "0")
         )
-        coEvery { interactor.setCommentFlagged(any(), any()) } returns mockComment.copy(id = "0")
+        coEvery { interactor.setCommentFlagged(any(), any()) } returns DiscussionMocks.comment.copy(
+            id = "0"
+        )
         viewModel.setCommentReported("", false)
         advanceUntilIdle()
 
@@ -399,9 +382,11 @@ class DiscussionResponsesViewModelTest {
             interactor,
             resourceManager,
             notifier,
-            mockComment.copy(id = "0")
+            DiscussionMocks.comment.copy(id = "0")
         )
-        coEvery { interactor.setCommentFlagged(any(), any()) } returns mockComment.copy(id = "0")
+        coEvery { interactor.setCommentFlagged(any(), any()) } returns DiscussionMocks.comment.copy(
+            id = "0"
+        )
 
         viewModel.updateCommentResponses()
         viewModel.setCommentReported("", false)
@@ -423,7 +408,7 @@ class DiscussionResponsesViewModelTest {
             interactor,
             resourceManager,
             notifier,
-            mockComment.copy(id = "0")
+            DiscussionMocks.comment.copy(id = "0")
         )
         coEvery { interactor.createComment(any(), any(), any()) } throws UnknownHostException()
 
@@ -446,7 +431,7 @@ class DiscussionResponsesViewModelTest {
             interactor,
             resourceManager,
             notifier,
-            mockComment.copy(id = "0")
+            DiscussionMocks.comment.copy(id = "0")
         )
         coEvery { interactor.createComment(any(), any(), any()) } throws Exception()
 
@@ -469,9 +454,9 @@ class DiscussionResponsesViewModelTest {
             interactor,
             resourceManager,
             notifier,
-            mockComment.copy(id = "0")
+            DiscussionMocks.comment.copy(id = "0")
         )
-        coEvery { interactor.createComment(any(), any(), any()) } returns mockComment
+        coEvery { interactor.createComment(any(), any(), any()) } returns DiscussionMocks.comment
 
         viewModel.createComment("")
         advanceUntilIdle()
@@ -492,9 +477,9 @@ class DiscussionResponsesViewModelTest {
             interactor,
             resourceManager,
             notifier,
-            mockComment.copy(id = "0")
+            DiscussionMocks.comment.copy(id = "0")
         )
-        coEvery { interactor.createComment(any(), any(), any()) } returns mockComment
+        coEvery { interactor.createComment(any(), any(), any()) } returns DiscussionMocks.comment
         every { preferencesManager.user?.username } returns ""
 
         viewModel.createComment("")
@@ -513,9 +498,9 @@ class DiscussionResponsesViewModelTest {
             interactor,
             resourceManager,
             notifier,
-            mockComment.copy(id = "0")
+            DiscussionMocks.comment.copy(id = "0")
         )
-        coEvery { interactor.createComment(any(), any(), any()) } returns mockComment
+        coEvery { interactor.createComment(any(), any(), any()) } returns DiscussionMocks.comment
         every { preferencesManager.user?.username } returns ""
 
         viewModel.createComment("")

--- a/discussion/src/test/java/org/openedx/discussion/presentation/search/DiscussionSearchThreadViewModelTest.kt
+++ b/discussion/src/test/java/org/openedx/discussion/presentation/search/DiscussionSearchThreadViewModelTest.kt
@@ -24,8 +24,8 @@ import org.junit.Test
 import org.junit.rules.TestRule
 import org.openedx.core.R
 import org.openedx.core.domain.model.Pagination
+import org.openedx.discussion.DiscussionMocks
 import org.openedx.discussion.domain.interactor.DiscussionInteractor
-import org.openedx.discussion.domain.model.DiscussionType
 import org.openedx.discussion.domain.model.ThreadsData
 import org.openedx.discussion.system.notifier.DiscussionNotifier
 import org.openedx.discussion.system.notifier.DiscussionThreadDataChanged
@@ -47,44 +47,6 @@ class DiscussionSearchThreadViewModelTest {
 
     private val noInternet = "Slow or no internet connection"
     private val somethingWrong = "Something went wrong"
-
-    //region thread
-
-    private val mockThread = org.openedx.discussion.domain.model.Thread(
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        false,
-        true,
-        20,
-        emptyList(),
-        false,
-        "",
-        "",
-        "",
-        "",
-        DiscussionType.DISCUSSION,
-        "",
-        "",
-        "Discussion title long Discussion title long good item",
-        true,
-        false,
-        true,
-        21,
-        4,
-        false,
-        false,
-        mapOf(),
-        0,
-        false,
-        false
-    )
-
-    //endregion
 
     @Before
     fun setUp() {
@@ -171,7 +133,7 @@ class DiscussionSearchThreadViewModelTest {
     fun `search query success with next page and fetch`() = runTest {
         val viewModel = DiscussionSearchThreadViewModel(interactor, resourceManager, notifier, "")
         coEvery { interactor.searchThread(any(), any(), eq(1)) } returns ThreadsData(
-            listOf(mockThread, mockThread),
+            listOf(DiscussionMocks.thread, DiscussionMocks.thread),
             "",
             Pagination(
                 10,
@@ -186,7 +148,7 @@ class DiscussionSearchThreadViewModelTest {
                 any(),
                 not(1)
             )
-        } returns ThreadsData(listOf(mockThread), "", Pagination(10, "", 5, ""))
+        } returns ThreadsData(listOf(DiscussionMocks.thread), "", Pagination(10, "", 5, ""))
 
         viewModel.searchThreads("course")
         delay(1000)
@@ -206,7 +168,7 @@ class DiscussionSearchThreadViewModelTest {
     fun `search query success with next page and fetch, update`() = runTest {
         val viewModel = DiscussionSearchThreadViewModel(interactor, resourceManager, notifier, "")
         coEvery { interactor.searchThread(any(), any(), eq(1)) } returns ThreadsData(
-            listOf(mockThread, mockThread),
+            listOf(DiscussionMocks.thread, DiscussionMocks.thread),
             "",
             Pagination(
                 10,
@@ -221,7 +183,7 @@ class DiscussionSearchThreadViewModelTest {
                 any(),
                 not(1)
             )
-        } returns ThreadsData(listOf(mockThread), "", Pagination(10, "0", 5, ""))
+        } returns ThreadsData(listOf(DiscussionMocks.thread), "", Pagination(10, "0", 5, ""))
 
         viewModel.searchThreads("course")
         delay(1000)
@@ -242,7 +204,7 @@ class DiscussionSearchThreadViewModelTest {
     fun `search query update in empty state`() = runTest {
         val viewModel = DiscussionSearchThreadViewModel(interactor, resourceManager, notifier, "")
         coEvery { interactor.searchThread(any(), any(), eq(1)) } returns ThreadsData(
-            listOf(mockThread, mockThread),
+            listOf(DiscussionMocks.thread, DiscussionMocks.thread),
             "",
             Pagination(
                 10,
@@ -271,7 +233,7 @@ class DiscussionSearchThreadViewModelTest {
             notifier.notifier
         } returns flow {
             delay(100)
-            emit(DiscussionThreadDataChanged(mockThread.copy(id = "1")))
+            emit(DiscussionThreadDataChanged(DiscussionMocks.thread.copy(id = "1")))
         }
 
         val mockLifeCycleOwner: LifecycleOwner = mockk()
@@ -289,7 +251,7 @@ class DiscussionSearchThreadViewModelTest {
     fun `notifier DiscussionThreadDataChanged with list`() = runTest {
         val viewModel = DiscussionSearchThreadViewModel(interactor, resourceManager, notifier, "")
         coEvery { interactor.searchThread(any(), any(), any()) } returns ThreadsData(
-            listOf(mockThread.copy(id = "id")),
+            listOf(DiscussionMocks.thread.copy(id = "id")),
             "",
             Pagination(
                 10,
@@ -303,7 +265,7 @@ class DiscussionSearchThreadViewModelTest {
             notifier.notifier
         } returns flow {
             delay(1000)
-            emit(DiscussionThreadDataChanged(mockThread.copy(id = "id")))
+            emit(DiscussionThreadDataChanged(DiscussionMocks.thread.copy(id = "id")))
         }
 
         val mockLifeCycleOwner: LifecycleOwner = mockk()

--- a/discussion/src/test/java/org/openedx/discussion/presentation/threads/DiscussionAddThreadViewModelTest.kt
+++ b/discussion/src/test/java/org/openedx/discussion/presentation/threads/DiscussionAddThreadViewModelTest.kt
@@ -19,9 +19,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
 import org.openedx.core.R
+import org.openedx.discussion.DiscussionMocks
 import org.openedx.discussion.domain.interactor.DiscussionInteractor
-import org.openedx.discussion.domain.model.DiscussionType
-import org.openedx.discussion.domain.model.Topic
 import org.openedx.discussion.system.notifier.DiscussionNotifier
 import org.openedx.discussion.system.notifier.DiscussionThreadAdded
 import org.openedx.foundation.presentation.UIMessage
@@ -44,56 +43,16 @@ class DiscussionAddThreadViewModelTest {
     private val somethingWrong = "Something went wrong"
 
     //region mockThread
-    val mockThread = org.openedx.discussion.domain.model.Thread(
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        false,
-        true,
-        20,
-        emptyList(),
-        false,
-        "",
-        "",
-        "",
-        "",
-        DiscussionType.DISCUSSION,
-        "",
-        "",
-        "Discussion title long Discussion title long good item",
-        true,
-        false,
-        true,
-        21,
-        4,
-        false,
-        false,
-        mapOf(),
-        0,
-        false,
-        false
-    )
     //endregion
 
     //region mockTopic
-    private val mockTopic = Topic(
-        id = "",
-        name = "All Topics",
-        threadListUrl = "",
-        children = emptyList()
-    )
+    //endregion
 
     val topics = listOf(
-        mockTopic.copy(id = "0"),
-        mockTopic.copy(id = "1"),
-        mockTopic.copy(id = "2")
+        DiscussionMocks.topic.copy(id = "0", name = "All Topics"),
+        DiscussionMocks.topic.copy(id = "1", name = "All Topics"),
+        DiscussionMocks.topic.copy(id = "2", name = "All Topics")
     )
-
-    //endregion
 
     @Before
     fun setUp() {
@@ -170,7 +129,7 @@ class DiscussionAddThreadViewModelTest {
                 any(),
                 any()
             )
-        } returns mockThread
+        } returns DiscussionMocks.thread
 
         viewModel.createThread("", "", "", "", false)
         advanceUntilIdle()

--- a/discussion/src/test/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModelTest.kt
+++ b/discussion/src/test/java/org/openedx/discussion/presentation/threads/DiscussionThreadsViewModelTest.kt
@@ -26,8 +26,9 @@ import org.junit.Test
 import org.junit.rules.TestRule
 import org.openedx.core.R
 import org.openedx.core.domain.model.Pagination
+import org.openedx.discussion.DiscussionMocks
 import org.openedx.discussion.domain.interactor.DiscussionInteractor
-import org.openedx.discussion.domain.model.DiscussionType
+import org.openedx.discussion.domain.model.Thread
 import org.openedx.discussion.domain.model.ThreadsData
 import org.openedx.discussion.presentation.topics.DiscussionTopicsViewModel
 import org.openedx.discussion.system.notifier.DiscussionNotifier
@@ -53,47 +54,12 @@ class DiscussionThreadsViewModelTest {
     private val somethingWrong = "Something went wrong"
 
     //region mockThread
-
-    val mockThread = org.openedx.discussion.domain.model.Thread(
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        "",
-        false,
-        true,
-        20,
-        emptyList(),
-        false,
-        "",
-        "",
-        "",
-        "",
-        DiscussionType.DISCUSSION,
-        "",
-        "",
-        "Discussion title long Discussion title long good item",
-        true,
-        false,
-        true,
-        21,
-        4,
-        false,
-        false,
-        mapOf(),
-        0,
-        false,
-        false
-    )
-
     //endregion
 
-    private val threads = listOf<org.openedx.discussion.domain.model.Thread>(
-        mockThread.copy(id = "0"),
-        mockThread.copy(id = "1"),
-        mockThread.copy(id = "2")
+    private val threads = listOf<Thread>(
+        DiscussionMocks.thread.copy(id = "0"),
+        DiscussionMocks.thread.copy(id = "1"),
+        DiscussionMocks.thread.copy(id = "2")
     )
 
     @Before
@@ -513,7 +479,13 @@ class DiscussionThreadsViewModelTest {
             notifier.notifier
         } returns flow {
             delay(100)
-            emit(DiscussionThreadDataChanged(mockThread.copy(id = "1")))
+            emit(
+                DiscussionThreadDataChanged(
+                    DiscussionMocks.thread.copy(
+                        id = "1",
+                    )
+                )
+            )
         }
         val viewModel = DiscussionThreadsViewModel(
             interactor,

--- a/discussion/src/test/java/org/openedx/discussion/presentation/topics/DiscussionTopicsViewModelTest.kt
+++ b/discussion/src/test/java/org/openedx/discussion/presentation/topics/DiscussionTopicsViewModelTest.kt
@@ -26,8 +26,8 @@ import org.junit.rules.TestRule
 import org.openedx.core.R
 import org.openedx.core.system.notifier.CourseLoading
 import org.openedx.core.system.notifier.CourseNotifier
+import org.openedx.discussion.DiscussionMocks
 import org.openedx.discussion.domain.interactor.DiscussionInteractor
-import org.openedx.discussion.domain.model.Topic
 import org.openedx.discussion.presentation.DiscussionAnalytics
 import org.openedx.discussion.presentation.DiscussionRouter
 import org.openedx.foundation.presentation.UIMessage
@@ -49,13 +49,6 @@ class DiscussionTopicsViewModelTest {
     private val courseNotifier = mockk<CourseNotifier>()
 
     private val noInternet = "Slow or no internet connection"
-
-    private val mockTopic = Topic(
-        id = "",
-        name = "All Topics",
-        threadListUrl = "",
-        children = emptyList()
-    )
 
     @Before
     fun setUp() {
@@ -133,7 +126,10 @@ class DiscussionTopicsViewModelTest {
             router
         )
 
-        coEvery { interactor.getCourseTopics(any()) } returns listOf(mockTopic, mockTopic)
+        coEvery { interactor.getCourseTopics(any()) } returns listOf(
+            DiscussionMocks.topic,
+            DiscussionMocks.topic
+        )
         advanceUntilIdle()
         val message = async {
             withTimeoutOrNull(5000) {
@@ -209,7 +205,10 @@ class DiscussionTopicsViewModelTest {
             router
         )
 
-        coEvery { interactor.getCourseTopics(any()) } returns listOf(mockTopic, mockTopic)
+        coEvery { interactor.getCourseTopics(any()) } returns listOf(
+            DiscussionMocks.topic,
+            DiscussionMocks.topic
+        )
         val message = async {
             withTimeoutOrNull(5000) {
                 viewModel.uiMessage.first() as? UIMessage.SnackBarMessage

--- a/downloads/src/main/java/org/openedx/downloads/presentation/download/DownloadsScreen.kt
+++ b/downloads/src/main/java/org/openedx/downloads/presentation/download/DownloadsScreen.kt
@@ -70,6 +70,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import org.openedx.core.CoreMocks
 import org.openedx.core.domain.model.DownloadCoursePreview
 import org.openedx.core.extension.safeDivBy
 import org.openedx.core.module.db.DownloadModel
@@ -554,8 +555,8 @@ private fun DownloadsScreenPreview() {
 private fun CourseItemPreview() {
     OpenEdXTheme {
         CourseItem(
-            downloadCoursePreview = DownloadCoursePreview("", "name", "", 100),
-            downloadModels = emptyList(),
+            downloadCoursePreview = CoreMocks.coursePreview,
+            downloadModels = listOf(CoreMocks.mockDownloadModel),
             apiHostUrl = "",
             downloadedState = DownloadedState.NOT_DOWNLOADED,
             onCourseClick = {},

--- a/downloads/src/test/java/org/openedx/downloads/DownloadsViewModelTest.kt
+++ b/downloads/src/test/java/org/openedx/downloads/DownloadsViewModelTest.kt
@@ -23,22 +23,14 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
-import org.openedx.core.BlockType
+import org.openedx.core.CoreMocks
 import org.openedx.core.R
 import org.openedx.core.config.Config
 import org.openedx.core.data.storage.CorePreferences
-import org.openedx.core.domain.model.AssignmentProgress
-import org.openedx.core.domain.model.Block
-import org.openedx.core.domain.model.BlockCounts
-import org.openedx.core.domain.model.CourseStructure
-import org.openedx.core.domain.model.CoursewareAccess
 import org.openedx.core.domain.model.DownloadCoursePreview
 import org.openedx.core.module.DownloadWorkerController
 import org.openedx.core.module.db.DownloadDao
-import org.openedx.core.module.db.DownloadModel
 import org.openedx.core.module.db.DownloadModelEntity
-import org.openedx.core.module.db.DownloadedState
-import org.openedx.core.module.db.FileType
 import org.openedx.core.module.download.DownloadHelper
 import org.openedx.core.presentation.CoreAnalytics
 import org.openedx.core.presentation.DownloadsAnalytics
@@ -53,7 +45,6 @@ import org.openedx.foundation.presentation.UIMessage
 import org.openedx.foundation.system.ResourceManager
 import org.openedx.foundation.utils.FileUtil
 import java.net.UnknownHostException
-import java.util.Date
 
 class DownloadsViewModelTest {
 
@@ -90,108 +81,6 @@ class DownloadsViewModelTest {
             image = "",
             totalSize = DownloadDialogManager.MAX_CELLULAR_SIZE.toLong()
         )
-    private val assignmentProgress = AssignmentProgress(
-        assignmentType = "Homework",
-        numPointsEarned = 1f,
-        numPointsPossible = 3f,
-        shortLabel = "HW1",
-    )
-    private val blocks = listOf(
-        Block(
-            id = "id",
-            blockId = "blockId",
-            lmsWebUrl = "lmsWebUrl",
-            legacyWebUrl = "legacyWebUrl",
-            studentViewUrl = "studentViewUrl",
-            type = BlockType.CHAPTER,
-            displayName = "Block",
-            graded = false,
-            studentViewData = null,
-            studentViewMultiDevice = false,
-            blockCounts = BlockCounts(0),
-            descendants = listOf("1", "id1"),
-            descendantsType = BlockType.HTML,
-            completion = 0.0,
-            assignmentProgress = assignmentProgress,
-            due = Date(),
-            offlineDownload = null,
-        ),
-        Block(
-            id = "id1",
-            blockId = "blockId",
-            lmsWebUrl = "lmsWebUrl",
-            legacyWebUrl = "legacyWebUrl",
-            studentViewUrl = "studentViewUrl",
-            type = BlockType.HTML,
-            displayName = "Block",
-            graded = false,
-            studentViewData = null,
-            studentViewMultiDevice = false,
-            blockCounts = BlockCounts(0),
-            descendants = listOf("id2"),
-            descendantsType = BlockType.HTML,
-            completion = 0.0,
-            assignmentProgress = assignmentProgress,
-            due = Date(),
-            offlineDownload = null,
-        ),
-        Block(
-            id = "id2",
-            blockId = "blockId",
-            lmsWebUrl = "lmsWebUrl",
-            legacyWebUrl = "legacyWebUrl",
-            studentViewUrl = "studentViewUrl",
-            type = BlockType.HTML,
-            displayName = "Block",
-            graded = false,
-            studentViewData = null,
-            studentViewMultiDevice = false,
-            blockCounts = BlockCounts(0),
-            descendants = emptyList(),
-            descendantsType = BlockType.HTML,
-            completion = 0.0,
-            assignmentProgress = assignmentProgress,
-            due = Date(),
-            offlineDownload = null,
-        )
-    )
-
-    private val downloadModel = DownloadModel(
-        "id",
-        "title",
-        "",
-        0,
-        "",
-        "url",
-        FileType.VIDEO,
-        DownloadedState.NOT_DOWNLOADED,
-        null
-    )
-
-    private val courseStructure = CourseStructure(
-        root = "",
-        blockData = blocks,
-        id = "id",
-        name = "Course name",
-        number = "",
-        org = "Org",
-        start = Date(),
-        startDisplay = "",
-        startType = "",
-        end = Date(),
-        coursewareAccess = CoursewareAccess(
-            true,
-            "",
-            "",
-            "",
-            "",
-            ""
-        ),
-        media = null,
-        certificate = null,
-        isSelfPaced = false,
-        progress = null
-    )
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Before
@@ -205,13 +94,13 @@ class DownloadsViewModelTest {
         coEvery { interactor.getDownloadCoursesPreview(any()) } returns flow {
             emit(listOf(downloadCoursePreview))
         }
-        coEvery { interactor.getCourseStructureFromCache("course1") } returns courseStructure
-        coEvery { interactor.getCourseStructure("course1") } returns courseStructure
+        coEvery { interactor.getCourseStructureFromCache("course1") } returns CoreMocks.mockCourseStructure
+        coEvery { interactor.getCourseStructure("course1") } returns CoreMocks.mockCourseStructure
         coEvery { interactor.getDownloadModelsByCourseIds(any()) } returns emptyList()
         coEvery { downloadDao.getAllDataFlow() } returns flowOf(
             listOf(
                 DownloadModelEntity.createFrom(
-                    downloadModel
+                    CoreMocks.mockDownloadModel
                 )
             )
         )
@@ -323,7 +212,7 @@ class DownloadsViewModelTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `removeDownloads should show remove popup with correct parameters`() = runTest {
-        coEvery { interactor.getDownloadModelsByCourseIds(any()) } returns listOf(downloadModel)
+        coEvery { interactor.getDownloadModelsByCourseIds(any()) } returns listOf(CoreMocks.mockDownloadModel)
 
         val viewModel = DownloadsViewModel(
             downloadsRouter,

--- a/profile/src/main/java/org/openedx/profile/ProfileMocks.kt
+++ b/profile/src/main/java/org/openedx/profile/ProfileMocks.kt
@@ -1,0 +1,50 @@
+package org.openedx.profile
+
+import org.openedx.core.domain.model.AgreementUrls
+import org.openedx.core.domain.model.LanguageProficiency
+import org.openedx.core.domain.model.ProfileImage
+import org.openedx.core.presentation.global.AppData
+import org.openedx.profile.domain.model.Account
+import org.openedx.profile.domain.model.Configuration
+
+object ProfileMocks {
+    val account = Account(
+        username = "jdoe",
+        name = "John Doe",
+        bio = "Preview user",
+        requiresParentalConsent = false,
+        country = "US",
+        isActive = true,
+        profileImage = ProfileImage(
+            imageUrlFull = "",
+            imageUrlLarge = "",
+            imageUrlMedium = "",
+            imageUrlSmall = "",
+            hasImage = false
+        ),
+        yearOfBirth = 1990,
+        levelOfEducation = "Bachelor",
+        goals = "Learning Kotlin",
+        languageProficiencies = emptyList<LanguageProficiency>(),
+        gender = "Male",
+        mailingAddress = "",
+        email = "jdoe@example.com",
+        dateJoined = null,
+        accountPrivacy = Account.Privacy.ALL_USERS
+    )
+
+    val appData = AppData(
+        appName = "OpenEdX",
+        applicationId = "org.edx.mobile",
+        versionName = "1.0.0"
+    )
+
+    val configuration = Configuration(
+        agreementUrls = AgreementUrls(
+            eulaUrl = "https://example.com/eula"
+        ),
+        faqUrl = "https://example.com/faq",
+        supportEmail = "support@example.com",
+        versionName = "1.0.0"
+    )
+}

--- a/profile/src/main/java/org/openedx/profile/presentation/anothersaccount/AnothersProfileFragment.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/anothersaccount/AnothersProfileFragment.kt
@@ -41,7 +41,6 @@ import androidx.fragment.app.Fragment
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 import org.openedx.core.R
-import org.openedx.core.domain.model.ProfileImage
 import org.openedx.core.ui.BackBtn
 import org.openedx.core.ui.HandleUIMessage
 import org.openedx.core.ui.statusBarsInset
@@ -53,7 +52,7 @@ import org.openedx.foundation.presentation.WindowSize
 import org.openedx.foundation.presentation.WindowType
 import org.openedx.foundation.presentation.rememberWindowSize
 import org.openedx.foundation.presentation.windowSizeValue
-import org.openedx.profile.domain.model.Account
+import org.openedx.profile.ProfileMocks
 import org.openedx.profile.presentation.ui.ProfileInfoSection
 import org.openedx.profile.presentation.ui.ProfileTopic
 
@@ -219,7 +218,7 @@ private fun ProfileScreenPreview() {
     OpenEdXTheme {
         AnothersProfileScreen(
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
-            uiState = AnothersProfileUIState.Data(mockAccount),
+            uiState = AnothersProfileUIState.Data(ProfileMocks.account),
             uiMessage = null,
             onBackClick = {}
         )
@@ -233,29 +232,9 @@ private fun ProfileScreenTabletPreview() {
     OpenEdXTheme {
         AnothersProfileScreen(
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
-            uiState = AnothersProfileUIState.Data(mockAccount),
+            uiState = AnothersProfileUIState.Data(ProfileMocks.account),
             uiMessage = null,
             onBackClick = {}
         )
     }
 }
-
-private val mockAccount = Account(
-    username = "thom84",
-    bio = "He as compliment unreserved projecting. Between had observe pretend delight for believe. Do newspaper " +
-            "questions consulted sweetness do. Our sportsman his unwilling fulfilled departure law.",
-    requiresParentalConsent = true,
-    name = "Thomas",
-    country = "Ukraine",
-    isActive = true,
-    profileImage = ProfileImage("", "", "", "", false),
-    yearOfBirth = 2000,
-    levelOfEducation = "Bachelor",
-    goals = "130",
-    languageProficiencies = emptyList(),
-    gender = "male",
-    mailingAddress = "",
-    "",
-    null,
-    accountPrivacy = Account.Privacy.ALL_USERS
-)

--- a/profile/src/main/java/org/openedx/profile/presentation/edit/EditProfileFragment.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/edit/EditProfileFragment.kt
@@ -106,7 +106,6 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 import org.openedx.core.AppDataConstants.DEFAULT_MIME_TYPE
 import org.openedx.core.domain.model.LanguageProficiency
-import org.openedx.core.domain.model.ProfileImage
 import org.openedx.core.domain.model.RegistrationField
 import org.openedx.core.ui.AutoSizeText
 import org.openedx.core.ui.BackBtn
@@ -133,6 +132,7 @@ import org.openedx.foundation.presentation.WindowSize
 import org.openedx.foundation.presentation.WindowType
 import org.openedx.foundation.presentation.rememberWindowSize
 import org.openedx.foundation.presentation.windowSizeValue
+import org.openedx.profile.ProfileMocks
 import org.openedx.profile.R
 import org.openedx.profile.domain.model.Account
 import org.openedx.profile.presentation.edit.EditProfileFragment.Companion.LEAVE_PROFILE_WIDTH_FACTOR
@@ -1284,7 +1284,7 @@ private fun EditProfileScreenPreview() {
     OpenEdXTheme {
         EditProfileScreen(
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
-            uiState = EditProfileUIState(account = mockAccount, isUpdating = false, false),
+            uiState = EditProfileUIState(account = ProfileMocks.account, isUpdating = false, false),
             selectedImageUri = null,
             uiMessage = null,
             isImageDeleted = true,
@@ -1307,7 +1307,7 @@ private fun EditProfileScreenTabletPreview() {
     OpenEdXTheme {
         EditProfileScreen(
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
-            uiState = EditProfileUIState(account = mockAccount, isUpdating = false, false),
+            uiState = EditProfileUIState(account = ProfileMocks.account, isUpdating = false, false),
             selectedImageUri = null,
             uiMessage = null,
             isImageDeleted = true,
@@ -1322,22 +1322,3 @@ private fun EditProfileScreenTabletPreview() {
         )
     }
 }
-
-private val mockAccount = Account(
-    username = "thom84",
-    bio = "designer",
-    requiresParentalConsent = true,
-    name = "Thomas",
-    country = "Ukraine",
-    isActive = true,
-    profileImage = ProfileImage("", "", "", "", false),
-    yearOfBirth = 2000,
-    levelOfEducation = "Bachelor",
-    goals = "130",
-    languageProficiencies = emptyList(),
-    gender = "male",
-    mailingAddress = "",
-    "",
-    null,
-    accountPrivacy = Account.Privacy.ALL_USERS
-)

--- a/profile/src/main/java/org/openedx/profile/presentation/manageaccount/compose/ManageAccountView.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/manageaccount/compose/ManageAccountView.kt
@@ -53,9 +53,9 @@ import org.openedx.foundation.presentation.UIMessage
 import org.openedx.foundation.presentation.WindowSize
 import org.openedx.foundation.presentation.WindowType
 import org.openedx.foundation.presentation.windowSizeValue
+import org.openedx.profile.ProfileMocks
 import org.openedx.profile.presentation.manageaccount.ManageAccountUIState
 import org.openedx.profile.presentation.ui.ProfileTopic
-import org.openedx.profile.presentation.ui.mockAccount
 import org.openedx.profile.R as ProfileR
 
 @OptIn(ExperimentalMaterialApi::class, ExperimentalComposeUiApi::class)
@@ -213,7 +213,9 @@ private fun ManageAccountViewPreview() {
     OpenEdXTheme {
         ManageAccountView(
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
-            uiState = mockUiState,
+            uiState = ManageAccountUIState.Data(
+                account = ProfileMocks.account
+            ),
             uiMessage = null,
             refreshing = false,
             onAction = {}
@@ -228,17 +230,15 @@ private fun ManageAccountViewTabletPreview() {
     OpenEdXTheme {
         ManageAccountView(
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
-            uiState = mockUiState,
+            uiState = ManageAccountUIState.Data(
+                account = ProfileMocks.account
+            ),
             uiMessage = null,
             refreshing = false,
             onAction = {}
         )
     }
 }
-
-private val mockUiState = ManageAccountUIState.Data(
-    account = mockAccount
-)
 
 internal interface ManageAccountViewAction {
     object EditAccountClick : ManageAccountViewAction

--- a/profile/src/main/java/org/openedx/profile/presentation/profile/compose/ProfileView.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/profile/compose/ProfileView.kt
@@ -48,10 +48,10 @@ import org.openedx.foundation.presentation.UIMessage
 import org.openedx.foundation.presentation.WindowSize
 import org.openedx.foundation.presentation.WindowType
 import org.openedx.foundation.presentation.windowSizeValue
+import org.openedx.profile.ProfileMocks
 import org.openedx.profile.presentation.profile.ProfileUIState
 import org.openedx.profile.presentation.ui.ProfileInfoSection
 import org.openedx.profile.presentation.ui.ProfileTopic
-import org.openedx.profile.presentation.ui.mockAccount
 
 @OptIn(ExperimentalMaterialApi::class, ExperimentalComposeUiApi::class)
 @Composable
@@ -178,7 +178,9 @@ private fun ProfileScreenPreview() {
     OpenEdXTheme {
         ProfileView(
             windowSize = WindowSize(WindowType.Compact, WindowType.Compact),
-            uiState = mockUiState,
+            uiState = ProfileUIState.Data(
+                account = ProfileMocks.account
+            ),
             uiMessage = null,
             refreshing = false,
             onAction = {},
@@ -194,7 +196,9 @@ private fun ProfileScreenTabletPreview() {
     OpenEdXTheme {
         ProfileView(
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
-            uiState = mockUiState,
+            uiState = ProfileUIState.Data(
+                account = ProfileMocks.account
+            ),
             uiMessage = null,
             refreshing = false,
             onAction = {},
@@ -202,10 +206,6 @@ private fun ProfileScreenTabletPreview() {
         )
     }
 }
-
-private val mockUiState = ProfileUIState.Data(
-    account = mockAccount
-)
 
 internal interface ProfileViewAction {
     object EditAccountClick : ProfileViewAction

--- a/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsScreenUI.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/settings/SettingsScreenUI.kt
@@ -52,8 +52,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import org.openedx.core.AppUpdateState
 import org.openedx.core.R
-import org.openedx.core.domain.model.AgreementUrls
-import org.openedx.core.presentation.global.AppData
 import org.openedx.core.system.notifier.app.AppUpgradeEvent
 import org.openedx.core.ui.OpenEdXButton
 import org.openedx.core.ui.Toolbar
@@ -67,7 +65,7 @@ import org.openedx.core.ui.theme.appTypography
 import org.openedx.foundation.presentation.WindowSize
 import org.openedx.foundation.presentation.WindowType
 import org.openedx.foundation.presentation.windowSizeValue
-import org.openedx.profile.domain.model.Configuration
+import org.openedx.profile.ProfileMocks
 import org.openedx.profile.presentation.ui.SettingsDivider
 import org.openedx.profile.presentation.ui.SettingsItem
 import org.openedx.profile.R as profileR
@@ -622,29 +620,12 @@ fun AppVersionItemUpgradeRequired(
     }
 }
 
-private val mockAppData = AppData(
-    appName = "openedx",
-    versionName = "1.0.0",
-    applicationId = "org.example.com"
-)
-
-private val mockConfiguration = Configuration(
-    agreementUrls = AgreementUrls(),
-    faqUrl = "https://example.com/faq",
-    supportEmail = "test@example.com",
-    versionName = mockAppData.versionName,
-)
-
-private val mockUiState = SettingsUIState.Data(
-    configuration = mockConfiguration
-)
-
 @Preview
 @Composable
 private fun AppVersionItemAppToDatePreview() {
     OpenEdXTheme {
         AppVersionItem(
-            versionName = mockAppData.versionName,
+            versionName = ProfileMocks.appData.versionName,
             appUpgradeEvent = null,
             onClick = {}
         )
@@ -656,7 +637,7 @@ private fun AppVersionItemAppToDatePreview() {
 private fun AppVersionItemUpgradeRecommendedPreview() {
     OpenEdXTheme {
         AppVersionItem(
-            versionName = mockAppData.versionName,
+            versionName = ProfileMocks.appData.versionName,
             appUpgradeEvent = AppUpgradeEvent.UpgradeRecommendedEvent("1.0.1"),
             onClick = {}
         )
@@ -668,7 +649,7 @@ private fun AppVersionItemUpgradeRecommendedPreview() {
 private fun AppVersionItemUpgradeRequiredPreview() {
     OpenEdXTheme {
         AppVersionItem(
-            versionName = mockAppData.versionName,
+            versionName = ProfileMocks.appData.versionName,
             appUpgradeEvent = AppUpgradeEvent.UpgradeRequiredEvent,
             onClick = {}
         )
@@ -688,7 +669,9 @@ private fun SettingsScreenPreview() {
         SettingsScreen(
             onBackClick = {},
             windowSize = WindowSize(WindowType.Medium, WindowType.Medium),
-            uiState = mockUiState,
+            uiState = SettingsUIState.Data(
+                configuration = ProfileMocks.configuration
+            ),
             onAction = {},
         )
     }

--- a/profile/src/main/java/org/openedx/profile/presentation/ui/ProfileUI.kt
+++ b/profile/src/main/java/org/openedx/profile/presentation/ui/ProfileUI.kt
@@ -25,11 +25,11 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import org.openedx.core.R
-import org.openedx.core.domain.model.ProfileImage
 import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.core.ui.theme.appShapes
 import org.openedx.core.ui.theme.appTypography
+import org.openedx.profile.ProfileMocks
 import org.openedx.profile.domain.model.Account
 import org.openedx.profile.R as ProfileR
 
@@ -116,35 +116,15 @@ fun ProfileInfoSection(account: Account) {
     }
 }
 
-val mockAccount = Account(
-    username = "thom84",
-    bio = "He as compliment unreserved projecting. Between had observe pretend delight for believe. Do newspaper " +
-            "questions consulted sweetness do. Our sportsman his unwilling fulfilled departure law.",
-    requiresParentalConsent = true,
-    name = "Thomas",
-    country = "Ukraine",
-    isActive = true,
-    profileImage = ProfileImage("", "", "", "", false),
-    yearOfBirth = 2000,
-    levelOfEducation = "Bachelor",
-    goals = "130",
-    languageProficiencies = emptyList(),
-    gender = "male",
-    mailingAddress = "",
-    "example@email.com",
-    null,
-    accountPrivacy = Account.Privacy.ALL_USERS
-)
-
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO, showBackground = true)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun ProfileTopicPreview() {
     OpenEdXTheme {
         ProfileTopic(
-            image = mockAccount.profileImage.imageUrlFull,
-            title = mockAccount.name,
-            subtitle = mockAccount.username,
+            image = ProfileMocks.account.profileImage.imageUrlFull,
+            title = ProfileMocks.account.name,
+            subtitle = ProfileMocks.account.username,
         )
     }
 }
@@ -155,7 +135,7 @@ private fun ProfileTopicPreview() {
 private fun ProfileInfoSectionPreview() {
     OpenEdXTheme {
         ProfileInfoSection(
-            account = mockAccount
+            account = ProfileMocks.account
         )
     }
 }

--- a/profile/src/test/java/org/openedx/profile/presentation/edit/EditProfileViewModelTest.kt
+++ b/profile/src/test/java/org/openedx/profile/presentation/edit/EditProfileViewModelTest.kt
@@ -21,11 +21,10 @@ import org.junit.Test
 import org.junit.rules.TestRule
 import org.openedx.core.R
 import org.openedx.core.config.Config
-import org.openedx.core.domain.model.ProfileImage
 import org.openedx.foundation.presentation.UIMessage
 import org.openedx.foundation.system.ResourceManager
+import org.openedx.profile.ProfileMocks
 import org.openedx.profile.domain.interactor.ProfileInteractor
-import org.openedx.profile.domain.model.Account
 import org.openedx.profile.presentation.ProfileAnalytics
 import org.openedx.profile.system.notifier.account.AccountUpdated
 import org.openedx.profile.system.notifier.profile.ProfileNotifier
@@ -46,25 +45,6 @@ class EditProfileViewModelTest {
     private val analytics = mockk<ProfileAnalytics>()
     private val config = mockk<Config>()
 
-    private val account = Account(
-        username = "thom84",
-        bio = "He as compliment unreserved projecting. Between had observe pretend delight for believe. Do newspaper " +
-                "questions consulted sweetness do. Our sportsman his unwilling fulfilled departure law.",
-        requiresParentalConsent = true,
-        name = "Thomas",
-        country = "Ukraine",
-        isActive = true,
-        profileImage = ProfileImage("", "", "", "", false),
-        yearOfBirth = 2000,
-        levelOfEducation = "Bachelor",
-        goals = "130",
-        languageProficiencies = emptyList(),
-        gender = "male",
-        mailingAddress = "",
-        "",
-        null,
-        accountPrivacy = Account.Privacy.ALL_USERS
-    )
     private val file = mockk<File>()
 
     private val noInternet = "Slow or no internet connection"
@@ -86,7 +66,14 @@ class EditProfileViewModelTest {
     @Test
     fun `updateAccount no internet connection`() = runTest {
         val viewModel =
-            EditProfileViewModel(interactor, resourceManager, notifier, analytics, config, account)
+            EditProfileViewModel(
+                interactor,
+                resourceManager,
+                notifier,
+                analytics,
+                config,
+                ProfileMocks.account
+            )
         coEvery { interactor.updateAccount(any()) } throws UnknownHostException()
         viewModel.updateAccount(emptyMap())
         advanceUntilIdle()
@@ -101,7 +88,14 @@ class EditProfileViewModelTest {
     @Test
     fun `updateAccount unknown exception`() = runTest {
         val viewModel =
-            EditProfileViewModel(interactor, resourceManager, notifier, analytics, config, account)
+            EditProfileViewModel(
+                interactor,
+                resourceManager,
+                notifier,
+                analytics,
+                config,
+                ProfileMocks.account
+            )
         coEvery { interactor.updateAccount(any()) } throws Exception()
 
         viewModel.updateAccount(emptyMap())
@@ -117,8 +111,15 @@ class EditProfileViewModelTest {
     @Test
     fun `updateAccount success`() = runTest {
         val viewModel =
-            EditProfileViewModel(interactor, resourceManager, notifier, analytics, config, account)
-        coEvery { interactor.updateAccount(any()) } returns account
+            EditProfileViewModel(
+                interactor,
+                resourceManager,
+                notifier,
+                analytics,
+                config,
+                ProfileMocks.account
+            )
+        coEvery { interactor.updateAccount(any()) } returns ProfileMocks.account
         coEvery { notifier.send(any<AccountUpdated>()) } returns Unit
         every { analytics.logEvent(any(), any()) } returns Unit
         viewModel.updateAccount(emptyMap())
@@ -134,9 +135,16 @@ class EditProfileViewModelTest {
     @Test
     fun `updateAccountAndImage no internet connection`() = runTest {
         val viewModel =
-            EditProfileViewModel(interactor, resourceManager, notifier, analytics, config, account)
+            EditProfileViewModel(
+                interactor,
+                resourceManager,
+                notifier,
+                analytics,
+                config,
+                ProfileMocks.account
+            )
         coEvery { interactor.setProfileImage(any(), any()) } throws UnknownHostException()
-        coEvery { interactor.updateAccount(any()) } returns account
+        coEvery { interactor.updateAccount(any()) } returns ProfileMocks.account
         coEvery { notifier.send(AccountUpdated()) } returns Unit
 
         viewModel.updateAccountAndImage(emptyMap(), file, "")
@@ -154,9 +162,16 @@ class EditProfileViewModelTest {
     @Test
     fun `updateAccountAndImage unknown exception`() = runTest {
         val viewModel =
-            EditProfileViewModel(interactor, resourceManager, notifier, analytics, config, account)
+            EditProfileViewModel(
+                interactor,
+                resourceManager,
+                notifier,
+                analytics,
+                config,
+                ProfileMocks.account
+            )
         coEvery { interactor.setProfileImage(any(), any()) } throws Exception()
-        coEvery { interactor.updateAccount(any()) } returns account
+        coEvery { interactor.updateAccount(any()) } returns ProfileMocks.account
         coEvery { notifier.send(AccountUpdated()) } returns Unit
 
         viewModel.updateAccountAndImage(emptyMap(), file, "")
@@ -174,9 +189,16 @@ class EditProfileViewModelTest {
     @Test
     fun `updateAccountAndImage success`() = runTest {
         val viewModel =
-            EditProfileViewModel(interactor, resourceManager, notifier, analytics, config, account)
+            EditProfileViewModel(
+                interactor,
+                resourceManager,
+                notifier,
+                analytics,
+                config,
+                ProfileMocks.account
+            )
         coEvery { interactor.setProfileImage(any(), any()) } returns Unit
-        coEvery { interactor.updateAccount(any()) } returns account
+        coEvery { interactor.updateAccount(any()) } returns ProfileMocks.account
         coEvery { notifier.send(any<AccountUpdated>()) } returns Unit
         every { analytics.logEvent(any(), any()) } returns Unit
 
@@ -196,7 +218,14 @@ class EditProfileViewModelTest {
     @Test
     fun `setImageUri set new value`() {
         val viewModel =
-            EditProfileViewModel(interactor, resourceManager, notifier, analytics, config, account)
+            EditProfileViewModel(
+                interactor,
+                resourceManager,
+                notifier,
+                analytics,
+                config,
+                ProfileMocks.account
+            )
         viewModel.setImageUri(mockk())
 
         assert(viewModel.selectedImageUri.value != null)

--- a/profile/src/test/java/org/openedx/profile/presentation/profile/AnothersProfileViewModelTest.kt
+++ b/profile/src/test/java/org/openedx/profile/presentation/profile/AnothersProfileViewModelTest.kt
@@ -19,10 +19,11 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
 import org.openedx.core.R
-import org.openedx.core.domain.model.ProfileImage
 import org.openedx.foundation.presentation.UIMessage
 import org.openedx.foundation.system.ResourceManager
+import org.openedx.profile.ProfileMocks
 import org.openedx.profile.domain.interactor.ProfileInteractor
+import org.openedx.profile.domain.model.Account
 import org.openedx.profile.presentation.anothersaccount.AnothersProfileUIState
 import org.openedx.profile.presentation.anothersaccount.AnothersProfileViewModel
 import java.net.UnknownHostException
@@ -38,25 +39,6 @@ class AnothersProfileViewModelTest {
     private val resourceManager = mockk<ResourceManager>()
     private val interactor = mockk<ProfileInteractor>()
     private val username = "username"
-
-    private val account = org.openedx.profile.domain.model.Account(
-        username = "",
-        bio = "",
-        requiresParentalConsent = false,
-        name = "",
-        country = "",
-        isActive = true,
-        profileImage = ProfileImage("", "", "", "", false),
-        yearOfBirth = 2000,
-        levelOfEducation = "",
-        goals = "",
-        languageProficiencies = emptyList(),
-        gender = "",
-        mailingAddress = "",
-        email = "",
-        dateJoined = null,
-        accountPrivacy = org.openedx.profile.domain.model.Account.Privacy.PRIVATE
-    )
 
     private val noInternet = "Slow or no internet connection"
     private val somethingWrong = "Something went wrong"
@@ -114,7 +96,9 @@ class AnothersProfileViewModelTest {
             resourceManager,
             username
         )
-        coEvery { interactor.getAccount(username) } returns account
+        coEvery { interactor.getAccount(username) } returns ProfileMocks.account.copy(
+            accountPrivacy = Account.Privacy.PRIVATE
+        )
         advanceUntilIdle()
 
         coVerify(exactly = 1) { interactor.getAccount(username) }

--- a/profile/src/test/java/org/openedx/profile/presentation/profile/ProfileViewModelTest.kt
+++ b/profile/src/test/java/org/openedx/profile/presentation/profile/ProfileViewModelTest.kt
@@ -26,9 +26,9 @@ import org.junit.rules.TestRule
 import org.openedx.core.R
 import org.openedx.core.config.Config
 import org.openedx.core.domain.model.AgreementUrls
-import org.openedx.core.domain.model.ProfileImage
 import org.openedx.foundation.presentation.UIMessage
 import org.openedx.foundation.system.ResourceManager
+import org.openedx.profile.ProfileMocks
 import org.openedx.profile.domain.interactor.ProfileInteractor
 import org.openedx.profile.presentation.ProfileAnalytics
 import org.openedx.profile.presentation.ProfileRouter
@@ -50,25 +50,6 @@ class ProfileViewModelTest {
     private val notifier = mockk<ProfileNotifier>()
     private val analytics = mockk<ProfileAnalytics>()
     private val router = mockk<ProfileRouter>()
-
-    private val account = org.openedx.profile.domain.model.Account(
-        username = "",
-        bio = "",
-        requiresParentalConsent = false,
-        name = "",
-        country = "",
-        isActive = true,
-        profileImage = ProfileImage("", "", "", "", false),
-        yearOfBirth = 2000,
-        levelOfEducation = "",
-        goals = "",
-        languageProficiencies = emptyList(),
-        gender = "",
-        mailingAddress = "",
-        email = "",
-        dateJoined = null,
-        accountPrivacy = org.openedx.profile.domain.model.Account.Privacy.PRIVATE
-    )
 
     private val noInternet = "Slow or no internet connection"
     private val somethingWrong = "Something went wrong"
@@ -118,7 +99,9 @@ class ProfileViewModelTest {
             analytics,
             router
         )
-        coEvery { interactor.getCachedAccount() } returns account
+        coEvery { interactor.getCachedAccount() } returns ProfileMocks.account.copy(
+            accountPrivacy = org.openedx.profile.domain.model.Account.Privacy.PRIVATE
+        )
         coEvery { interactor.getAccount() } throws UnknownHostException()
         advanceUntilIdle()
 
@@ -159,7 +142,9 @@ class ProfileViewModelTest {
             router
         )
         coEvery { interactor.getCachedAccount() } returns null
-        coEvery { interactor.getAccount() } returns account
+        coEvery { interactor.getAccount() } returns ProfileMocks.account.copy(
+            accountPrivacy = org.openedx.profile.domain.model.Account.Privacy.PRIVATE
+        )
         advanceUntilIdle()
 
         coVerify(exactly = 1) { interactor.getAccount() }


### PR DESCRIPTION
- Centralized reusable mock data across the app.
- Refactored previews and JUnit tests to consume shared mocks.
- Cleaned up duplicate mock code, redundant imports.
- Reduced time required to add new parameters to existing data classes.

Change Size:
58 files changed; 1172 insertions, 2685 deletions.
The size of the project has decreased by **1,513** lines.