### PR TITLE
fix: Remove shift due date banner from home and content all tabs

### DIFF
--- a/course/src/main/java/org/openedx/course/presentation/container/CourseContainerFragment.kt
+++ b/course/src/main/java/org/openedx/course/presentation/container/CourseContainerFragment.kt
@@ -477,9 +477,6 @@ private fun DashboardPager(
                     ),
                     fragmentManager = fragmentManager,
                     homePagerState = homePagerState,
-                    onResetDatesClick = {
-                        viewModel.onRefresh(CourseContainerTab.DATES)
-                    },
                     onNavigateToContent = { contentTab ->
                         scope.launch {
                             // First scroll to CONTENT tab

--- a/course/src/main/java/org/openedx/course/presentation/home/CourseCompletionHomePagerCardContent.kt
+++ b/course/src/main/java/org/openedx/course/presentation/home/CourseCompletionHomePagerCardContent.kt
@@ -142,7 +142,6 @@ private fun CourseCompletionHomePagerCardContentPreview() {
                 resumeUnitTitle = "Resumed Unit",
                 courseSubSections = mapOf(),
                 subSectionsDownloadsCount = mapOf(),
-                datesBannerInfo = CoreMocks.mockCourseDatesBannerInfo,
                 useRelativeDates = true,
                 courseVideos = mapOf(),
                 courseAssignments = emptyList(),

--- a/course/src/main/java/org/openedx/course/presentation/home/CourseHomeScreen.kt
+++ b/course/src/main/java/org/openedx/course/presentation/home/CourseHomeScreen.kt
@@ -62,8 +62,6 @@ import org.openedx.core.ui.theme.appShapes
 import org.openedx.core.ui.theme.appTypography
 import org.openedx.course.R
 import org.openedx.course.presentation.container.CourseContentTab
-import org.openedx.course.presentation.ui.CourseDatesBanner
-import org.openedx.course.presentation.ui.CourseDatesBannerTablet
 import org.openedx.course.presentation.ui.CourseMessage
 import org.openedx.course.presentation.ui.ResumeCourseButton
 import org.openedx.course.presentation.unit.container.CourseViewMode
@@ -80,7 +78,6 @@ fun CourseHomeScreen(
     viewModel: CourseHomeViewModel,
     fragmentManager: FragmentManager,
     homePagerState: PagerState,
-    onResetDatesClick: () -> Unit,
     onNavigateToContent: (CourseContentTab) -> Unit = {},
     onNavigateToProgress: () -> Unit = {},
 ) {
@@ -136,13 +133,6 @@ fun CourseHomeScreen(
                 fragmentManager = fragmentManager,
             )
         },
-        onResetDatesClick = {
-            viewModel.resetCourseDatesBanner(
-                onResetDates = {
-                    onResetDatesClick()
-                }
-            )
-        },
         onCertificateClick = {
             viewModel.viewCertificateTappedEvent()
             it.takeIfNotEmpty()
@@ -185,7 +175,6 @@ private fun CourseHomeUI(
     onSubSectionClick: (Block) -> Unit,
     onResumeClick: (String) -> Unit,
     onDownloadClick: (blockIds: List<String>) -> Unit,
-    onResetDatesClick: () -> Unit,
     onCertificateClick: (String) -> Unit,
     onVideoClick: (Block) -> Unit,
     onAssignmentClick: (Block) -> Unit,
@@ -234,25 +223,6 @@ private fun CourseHomeUI(
                                 .fillMaxSize()
                                 .verticalScroll(rememberScrollState()),
                         ) {
-                            if (uiState.datesBannerInfo.isBannerAvailableForDashboard()) {
-                                Box(
-                                    modifier = Modifier
-                                        .padding(all = 8.dp)
-                                ) {
-                                    if (windowSize.isTablet) {
-                                        CourseDatesBannerTablet(
-                                            banner = uiState.datesBannerInfo,
-                                            resetDates = onResetDatesClick,
-                                        )
-                                    } else {
-                                        CourseDatesBanner(
-                                            banner = uiState.datesBannerInfo,
-                                            resetDates = onResetDatesClick,
-                                        )
-                                    }
-                                }
-                            }
-
                             val certificate = uiState.courseStructure.certificate
                             if (certificate?.isCertificateEarned() == true) {
                                 CourseMessage(
@@ -459,7 +429,6 @@ private fun CourseHomeScreenPreview() {
                 resumeUnitTitle = "Resumed Unit",
                 courseSubSections = mapOf(),
                 subSectionsDownloadsCount = mapOf(),
-                datesBannerInfo = CoreMocks.mockCourseDatesBannerInfo,
                 useRelativeDates = true,
                 courseVideos = mapOf(),
                 courseAssignments = emptyList(),
@@ -471,7 +440,6 @@ private fun CourseHomeScreenPreview() {
             onSubSectionClick = {},
             onResumeClick = {},
             onDownloadClick = {},
-            onResetDatesClick = {},
             onCertificateClick = {},
             onVideoClick = {},
             onAssignmentClick = {},
@@ -506,7 +474,6 @@ private fun CourseHomeScreenTabletPreview() {
                 resumeUnitTitle = "Resumed Unit",
                 courseSubSections = mapOf(),
                 subSectionsDownloadsCount = mapOf(),
-                datesBannerInfo = CoreMocks.mockCourseDatesBannerInfo,
                 useRelativeDates = true,
                 courseVideos = mapOf(),
                 courseAssignments = emptyList(),
@@ -518,7 +485,6 @@ private fun CourseHomeScreenTabletPreview() {
             onSubSectionClick = {},
             onResumeClick = {},
             onDownloadClick = {},
-            onResetDatesClick = {},
             onCertificateClick = {},
             onVideoClick = {},
             onAssignmentClick = {},

--- a/course/src/main/java/org/openedx/course/presentation/home/CourseHomeUIState.kt
+++ b/course/src/main/java/org/openedx/course/presentation/home/CourseHomeUIState.kt
@@ -1,7 +1,6 @@
 package org.openedx.course.presentation.home
 
 import org.openedx.core.domain.model.Block
-import org.openedx.core.domain.model.CourseDatesBannerInfo
 import org.openedx.core.domain.model.CourseProgress
 import org.openedx.core.domain.model.CourseStructure
 import org.openedx.core.module.db.DownloadedState
@@ -17,7 +16,6 @@ sealed class CourseHomeUIState {
         val resumeUnitTitle: String,
         val courseSubSections: Map<String, List<Block>>,
         val subSectionsDownloadsCount: Map<String, Int>,
-        val datesBannerInfo: CourseDatesBannerInfo,
         val useRelativeDates: Boolean,
         val courseVideos: Map<String, List<Block>>,
         val courseAssignments: List<Block>,

--- a/course/src/main/java/org/openedx/course/presentation/home/CourseHomeViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/home/CourseHomeViewModel.kt
@@ -14,13 +14,11 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import org.openedx.core.BlockType
-import org.openedx.core.R
 import org.openedx.core.config.Config
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.helper.VideoPreviewHelper
 import org.openedx.core.domain.model.Block
 import org.openedx.core.domain.model.CourseComponentStatus
-import org.openedx.core.domain.model.CourseDatesBannerInfo
 import org.openedx.core.domain.model.CourseProgress
 import org.openedx.core.domain.model.CourseStructure
 import org.openedx.core.extension.getChapterBlocks
@@ -34,7 +32,6 @@ import org.openedx.core.module.download.DownloadHelper
 import org.openedx.core.presentation.CoreAnalytics
 import org.openedx.core.presentation.dialog.downloaddialog.DownloadDialogManager
 import org.openedx.core.system.connection.NetworkConnection
-import org.openedx.core.system.notifier.CourseDatesShifted
 import org.openedx.core.system.notifier.CourseNotifier
 import org.openedx.core.system.notifier.CourseOpenBlock
 import org.openedx.core.system.notifier.CourseProgressLoaded
@@ -129,7 +126,6 @@ class CourseHomeViewModel(
                         resumeUnitTitle = resumeVerticalBlock?.displayName ?: "",
                         courseSubSections = courseSubSections,
                         subSectionsDownloadsCount = subSectionsDownloadsCount,
-                        datesBannerInfo = state.datesBannerInfo,
                         useRelativeDates = preferencesManager.isRelativeDatesEnabled,
                         next = state.next,
                         courseProgress = state.courseProgress,
@@ -182,13 +178,11 @@ class CourseHomeViewModel(
             ) { courseStructure, courseStatus, courseDatesResult, courseProgress ->
                 if (courseStructure == null) return@combine
                 val blocks = courseStructure.blockData
-                val datesBannerInfo = courseDatesResult.courseBanner
 
                 initializeCourseData(
                     blocks,
                     courseStructure,
                     courseStatus,
-                    datesBannerInfo,
                     courseProgress
                 )
             }.catch { e ->
@@ -201,7 +195,6 @@ class CourseHomeViewModel(
         blocks: List<Block>,
         courseStructure: CourseStructure,
         courseStatus: CourseComponentStatus,
-        datesBannerInfo: CourseDatesBannerInfo,
         courseProgress: CourseProgress
     ) {
         setBlocks(blocks)
@@ -253,7 +246,6 @@ class CourseHomeViewModel(
             resumeUnitTitle = resumeVerticalBlock?.displayName ?: "",
             courseSubSections = courseSubSections,
             subSectionsDownloadsCount = subSectionsDownloadsCount,
-            datesBannerInfo = datesBannerInfo,
             useRelativeDates = preferencesManager.isRelativeDatesEnabled,
             courseProgress = courseProgress,
             courseVideos = courseVideos,
@@ -363,23 +355,6 @@ class CourseHomeViewModel(
             blocks.find { it.id == descendantId && it.type == BlockType.SEQUENTIAL }
         }
         return sequentialBlocks.find { !it.isCompleted() }
-    }
-
-    fun resetCourseDatesBanner(onResetDates: (Boolean) -> Unit) {
-        viewModelScope.launch {
-            try {
-                interactor.resetCourseDates(courseId = courseId)
-                getCourseData()
-                courseNotifier.send(CourseDatesShifted)
-                onResetDates(true)
-            } catch (e: Exception) {
-                handleErrorUiMessage(
-                    throwable = e,
-                    defaultErrorRes = R.string.core_dates_shift_dates_unsuccessful_msg,
-                )
-                onResetDates(false)
-            }
-        }
     }
 
     fun openBlock(fragmentManager: FragmentManager, blockId: String) {

--- a/course/src/main/java/org/openedx/course/presentation/outline/CourseContentAllScreen.kt
+++ b/course/src/main/java/org/openedx/course/presentation/outline/CourseContentAllScreen.kt
@@ -47,8 +47,6 @@ import org.openedx.core.ui.theme.OpenEdXTheme
 import org.openedx.core.ui.theme.appColors
 import org.openedx.course.R
 import org.openedx.course.presentation.contenttab.CourseContentAllEmptyState
-import org.openedx.course.presentation.ui.CourseDatesBanner
-import org.openedx.course.presentation.ui.CourseDatesBannerTablet
 import org.openedx.course.presentation.ui.CourseMessage
 import org.openedx.course.presentation.ui.CourseProgress
 import org.openedx.course.presentation.ui.CourseSection
@@ -130,9 +128,6 @@ fun CourseContentAllScreen(
                 fragmentManager = fragmentManager,
             )
         },
-        onResetDatesClick = {
-            viewModel.resetCourseDatesBanner()
-        },
         onCertificateClick = {
             viewModel.viewCertificateTappedEvent()
             it.takeIfNotEmpty()
@@ -151,7 +146,6 @@ private fun CourseContentAllUI(
     onSubSectionClick: (Block) -> Unit,
     onResumeClick: (String) -> Unit,
     onDownloadClick: (blockIds: List<String>) -> Unit,
-    onResetDatesClick: () -> Unit,
     onCertificateClick: (String) -> Unit,
 ) {
     val scaffoldState = rememberScaffoldState()
@@ -214,27 +208,6 @@ private fun CourseContentAllUI(
                                     modifier = Modifier.fillMaxSize(),
                                     contentPadding = listBottomPadding
                                 ) {
-                                    if (uiState.datesBannerInfo.isBannerAvailableForDashboard()) {
-                                        item {
-                                            Box(
-                                                modifier = Modifier
-                                                    .padding(all = 8.dp)
-                                            ) {
-                                                if (windowSize.isTablet) {
-                                                    CourseDatesBannerTablet(
-                                                        banner = uiState.datesBannerInfo,
-                                                        resetDates = onResetDatesClick,
-                                                    )
-                                                } else {
-                                                    CourseDatesBanner(
-                                                        banner = uiState.datesBannerInfo,
-                                                        resetDates = onResetDatesClick,
-                                                    )
-                                                }
-                                            }
-                                        }
-                                    }
-
                                     val certificate = uiState.courseStructure.certificate
                                     if (certificate?.isCertificateEarned() == true) {
                                         item {
@@ -363,7 +336,6 @@ private fun CourseOutlineScreenPreview() {
                 mapOf(),
                 mapOf(),
                 mapOf(),
-                CoreMocks.mockCourseDatesBannerInfo,
                 true
             ),
             uiMessage = null,
@@ -371,7 +343,6 @@ private fun CourseOutlineScreenPreview() {
             onSubSectionClick = {},
             onResumeClick = {},
             onDownloadClick = {},
-            onResetDatesClick = {},
             onCertificateClick = {},
             onNavigateToHome = {},
         )
@@ -393,7 +364,6 @@ private fun CourseContentAllScreenTabletPreview() {
                 mapOf(),
                 mapOf(),
                 mapOf(),
-                CoreMocks.mockCourseDatesBannerInfo,
                 true
             ),
             uiMessage = null,
@@ -401,7 +371,6 @@ private fun CourseContentAllScreenTabletPreview() {
             onSubSectionClick = {},
             onResumeClick = {},
             onDownloadClick = {},
-            onResetDatesClick = {},
             onCertificateClick = {},
             onNavigateToHome = {},
         )

--- a/course/src/main/java/org/openedx/course/presentation/outline/CourseContentAllUIState.kt
+++ b/course/src/main/java/org/openedx/course/presentation/outline/CourseContentAllUIState.kt
@@ -1,7 +1,6 @@
 package org.openedx.course.presentation.outline
 
 import org.openedx.core.domain.model.Block
-import org.openedx.core.domain.model.CourseDatesBannerInfo
 import org.openedx.core.domain.model.CourseStructure
 import org.openedx.core.module.db.DownloadedState
 
@@ -14,7 +13,6 @@ sealed class CourseContentAllUIState {
         val courseSubSections: Map<String, List<Block>>,
         val courseSectionsState: Map<String, Boolean>,
         val subSectionsDownloadsCount: Map<String, Int>,
-        val datesBannerInfo: CourseDatesBannerInfo,
         val useRelativeDates: Boolean,
     ) : CourseContentAllUIState()
 

--- a/course/src/main/java/org/openedx/course/presentation/outline/CourseContentAllViewModel.kt
+++ b/course/src/main/java/org/openedx/course/presentation/outline/CourseContentAllViewModel.kt
@@ -12,13 +12,11 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import org.openedx.core.BlockType
-import org.openedx.core.R
 import org.openedx.core.config.Config
 import org.openedx.core.data.storage.CorePreferences
 import org.openedx.core.domain.model.Block
 import org.openedx.core.domain.model.CourseComponentStatus
 import org.openedx.core.domain.model.CourseDateBlock
-import org.openedx.core.domain.model.CourseDatesBannerInfo
 import org.openedx.core.domain.model.CourseStructure
 import org.openedx.core.extension.getChapterBlocks
 import org.openedx.core.extension.getSequentialBlocks
@@ -32,7 +30,6 @@ import org.openedx.core.presentation.dialog.downloaddialog.DownloadDialogManager
 import org.openedx.core.presentation.settings.calendarsync.CalendarSyncDialogType
 import org.openedx.core.system.connection.NetworkConnection
 import org.openedx.core.system.notifier.CalendarSyncEvent.CreateCalendarSyncEvent
-import org.openedx.core.system.notifier.CourseDatesShifted
 import org.openedx.core.system.notifier.CourseNotifier
 import org.openedx.core.system.notifier.CourseStructureUpdated
 import org.openedx.course.domain.interactor.CourseInteractor
@@ -118,7 +115,6 @@ class CourseContentAllViewModel(
                         courseSubSections = courseSubSections,
                         courseSectionsState = state.courseSectionsState,
                         subSectionsDownloadsCount = subSectionsDownloadsCount,
-                        datesBannerInfo = state.datesBannerInfo,
                         useRelativeDates = preferencesManager.isRelativeDatesEnabled
                     )
                 }
@@ -164,7 +160,6 @@ class CourseContentAllViewModel(
                 courseSubSections = courseSubSections,
                 courseSectionsState = courseSectionsState,
                 subSectionsDownloadsCount = subSectionsDownloadsCount,
-                datesBannerInfo = state.datesBannerInfo,
                 useRelativeDates = preferencesManager.isRelativeDatesEnabled
             )
 
@@ -191,12 +186,11 @@ class CourseContentAllViewModel(
             }.collect { (courseStructure, courseStatus, courseDates) ->
                 if (courseStructure == null) return@collect
                 val blocks = courseStructure.blockData
-                val datesBannerInfo = courseDates.courseBanner
 
                 checkIfCalendarOutOfDate(courseDates.datesSection.values.flatten())
                 updateOutdatedOfflineXBlocks(courseStructure)
 
-                initializeCourseData(blocks, courseStructure, courseStatus, datesBannerInfo)
+                initializeCourseData(blocks, courseStructure, courseStatus)
             }
         }
     }
@@ -205,7 +199,6 @@ class CourseContentAllViewModel(
         blocks: List<Block>,
         courseStructure: CourseStructure,
         courseStatus: CourseComponentStatus,
-        datesBannerInfo: CourseDatesBannerInfo
     ) {
         setBlocks(blocks)
         courseSubSections.clear()
@@ -225,7 +218,6 @@ class CourseContentAllViewModel(
             courseSubSections = courseSubSections,
             courseSectionsState = courseSectionsState,
             subSectionsDownloadsCount = subSectionsDownloadsCount,
-            datesBannerInfo = datesBannerInfo,
             useRelativeDates = preferencesManager.isRelativeDatesEnabled
         )
     }
@@ -276,21 +268,6 @@ class CourseContentAllViewModel(
         resumeSectionBlock =
             blocks.getSequentialBlocks().find { it.descendants.contains(resumeVerticalBlock?.id) }
         return resumeBlock
-    }
-
-    fun resetCourseDatesBanner() {
-        viewModelScope.launch {
-            try {
-                interactor.resetCourseDates(courseId = courseId)
-                getCourseData()
-                courseNotifier.send(CourseDatesShifted)
-            } catch (e: Exception) {
-                handleErrorUiMessage(
-                    throwable = e,
-                    defaultErrorRes = R.string.core_dates_shift_dates_unsuccessful_msg,
-                )
-            }
-        }
     }
 
     fun openBlock(fragmentManager: FragmentManager, blockId: String) {

--- a/course/src/test/java/org/openedx/course/presentation/home/CourseHomeViewModelTest.kt
+++ b/course/src/test/java/org/openedx/course/presentation/home/CourseHomeViewModelTest.kt
@@ -32,7 +32,6 @@ import org.openedx.core.module.download.DownloadHelper
 import org.openedx.core.presentation.CoreAnalytics
 import org.openedx.core.presentation.dialog.downloaddialog.DownloadDialogManager
 import org.openedx.core.system.connection.NetworkConnection
-import org.openedx.core.system.notifier.CourseDatesShifted
 import org.openedx.core.system.notifier.CourseNotifier
 import org.openedx.core.system.notifier.CourseOpenBlock
 import org.openedx.core.system.notifier.CourseProgressLoaded
@@ -103,7 +102,6 @@ class CourseHomeViewModelTest {
         every { downloadDao.getAllDataFlow() } returns flow { emit(emptyList()) }
 
         every { courseNotifier.notifier } returns flow { }
-        coEvery { courseNotifier.send(any<CourseDatesShifted>()) } returns Unit
 
         every { analytics.logEvent(any(), any()) } returns Unit
         every { coreAnalytics.logEvent(any(), any()) } returns Unit
@@ -332,120 +330,6 @@ class CourseHomeViewModelTest {
         viewModel.saveDownloadModels("/test/path", courseId, "test-block-id")
 
         coVerify(exactly = 0) { workerController.saveModels(any()) }
-    }
-
-    @Test
-    fun `resetCourseDatesBanner success`() = runTest {
-        coEvery { interactor.resetCourseDates(courseId) } returns CoreMocks.mockResetCourseDates
-        coEvery { interactor.getCourseStructureFlow(courseId, false) } returns flow {
-            emit(
-                CoreMocks.mockCourseStructure
-            )
-        }
-        coEvery { interactor.getCourseStatusFlow(courseId) } returns flow {
-            emit(
-                CoreMocks.mockCourseComponentStatus
-            )
-        }
-        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(CoreMocks.mockCourseDatesResult) }
-        coEvery {
-            interactor.getCourseProgress(
-                courseId,
-                false,
-                true
-            )
-        } returns flow { emit(CoreMocks.mockCourseProgress) }
-
-        val viewModel = CourseHomeViewModel(
-            courseId = courseId,
-            courseTitle = courseTitle,
-            config = config,
-            interactor = interactor,
-            resourceManager = resourceManager,
-            courseNotifier = courseNotifier,
-            networkConnection = networkConnection,
-            preferencesManager = preferencesManager,
-            analytics = analytics,
-            downloadDialogManager = downloadDialogManager,
-            fileUtil = fileUtil,
-            courseRouter = courseRouter,
-            videoPreviewHelper = videoPreviewHelper,
-            coreAnalytics = coreAnalytics,
-            downloadDao = downloadDao,
-            workerController = workerController,
-            downloadHelper = downloadHelper
-        )
-
-        advanceUntilIdle()
-
-        var resetResult: Boolean? = null
-
-        viewModel.resetCourseDatesBanner { success ->
-            resetResult = success
-        }
-
-        advanceUntilIdle()
-
-        coVerify { interactor.resetCourseDates(courseId) }
-        coVerify { courseNotifier.send(CourseDatesShifted) }
-        assertEquals(true, resetResult)
-    }
-
-    @Test
-    fun `resetCourseDatesBanner with internet error`() = runTest {
-        coEvery { interactor.resetCourseDates(courseId) } throws UnknownHostException()
-        coEvery { interactor.getCourseStructureFlow(courseId, false) } returns flow {
-            emit(
-                CoreMocks.mockCourseStructure
-            )
-        }
-        coEvery { interactor.getCourseStatusFlow(courseId) } returns flow {
-            emit(
-                CoreMocks.mockCourseComponentStatus
-            )
-        }
-        coEvery { interactor.getCourseDatesFlow(courseId) } returns flow { emit(CoreMocks.mockCourseDatesResult) }
-        coEvery {
-            interactor.getCourseProgress(
-                courseId,
-                false,
-                true
-            )
-        } returns flow { emit(CoreMocks.mockCourseProgress) }
-
-        val viewModel = CourseHomeViewModel(
-            courseId = courseId,
-            courseTitle = courseTitle,
-            config = config,
-            interactor = interactor,
-            resourceManager = resourceManager,
-            courseNotifier = courseNotifier,
-            networkConnection = networkConnection,
-            preferencesManager = preferencesManager,
-            analytics = analytics,
-            downloadDialogManager = downloadDialogManager,
-            fileUtil = fileUtil,
-            courseRouter = courseRouter,
-            videoPreviewHelper = videoPreviewHelper,
-            coreAnalytics = coreAnalytics,
-            downloadDao = downloadDao,
-            workerController = workerController,
-            downloadHelper = downloadHelper
-        )
-
-        advanceUntilIdle()
-
-        var resetResult: Boolean? = null
-
-        viewModel.resetCourseDatesBanner { success ->
-            resetResult = success
-        }
-
-        advanceUntilIdle()
-
-        coVerify { interactor.resetCourseDates(courseId) }
-        coVerify(exactly = 0) { courseNotifier.send(CourseDatesShifted) }
-        assertEquals(false, resetResult)
     }
 
     @Test


### PR DESCRIPTION
**Shift due date banner was part of screens before redesign. Now it is unnecessary.**

<img width="321" height="716" alt="Screenshot 2026-01-27 at 12 36 26" src="https://github.com/user-attachments/assets/5d9b4355-1f27-4c84-a31d-e1c5e2db9691" /><img width="322" height="714" alt="Screenshot 2026-01-27 at 12 36 45" src="https://github.com/user-attachments/assets/134e2e7e-a9de-493e-ac7c-dae70a05f500" />
