### PR TITLE
feat: Migrate PreferencesManager to DataStore with Encrypted Storage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -133,6 +133,7 @@ dependencies {
     ksp "androidx.room:room-compiler:$room_version"
 
     implementation "androidx.core:core-splashscreen:$core_splashscreen_version"
+    implementation "androidx.datastore:datastore-preferences:1.2.0"
 
     api platform("com.google.firebase:firebase-bom:$firebase_version")
     api "com.google.firebase:firebase-messaging"

--- a/app/src/main/java/org/openedx/app/data/storage/DataStoreEncryption.kt
+++ b/app/src/main/java/org/openedx/app/data/storage/DataStoreEncryption.kt
@@ -1,0 +1,86 @@
+package org.openedx.app.data.storage
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import android.util.Log
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+class DataStoreEncryption {
+
+    private companion object {
+        const val TAG = "DataStoreEncryption"
+        const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        const val KEY_ALIAS = "openedx_datastore_key"
+        const val TRANSFORMATION = "AES/GCM/NoPadding"
+        const val GCM_IV_LENGTH = 12
+        const val GCM_TAG_LENGTH = 16
+        const val GCM_TAG_LENGTH_BITS = GCM_TAG_LENGTH * 8
+        const val KEY_SIZE = 256
+    }
+
+    private val keyStore: KeyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+
+    private fun getOrCreateSecretKey(): SecretKey {
+        keyStore.getEntry(KEY_ALIAS, null)?.let { entry ->
+            return (entry as KeyStore.SecretKeyEntry).secretKey
+        }
+
+        val keyGenerator = KeyGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_AES,
+            ANDROID_KEYSTORE
+        )
+
+        val keyGenParameterSpec = KeyGenParameterSpec.Builder(
+            KEY_ALIAS,
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+        )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setKeySize(KEY_SIZE)
+            .build()
+
+        keyGenerator.init(keyGenParameterSpec)
+        return keyGenerator.generateKey()
+    }
+
+    fun encrypt(plainText: String): String {
+        if (plainText.isEmpty()) return ""
+
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, getOrCreateSecretKey())
+
+        val iv = cipher.iv
+        val encryptedBytes = cipher.doFinal(plainText.toByteArray(Charsets.UTF_8))
+
+        val combined = ByteArray(iv.size + encryptedBytes.size)
+        System.arraycopy(iv, 0, combined, 0, iv.size)
+        System.arraycopy(encryptedBytes, 0, combined, iv.size, encryptedBytes.size)
+
+        return Base64.encodeToString(combined, Base64.NO_WRAP)
+    }
+
+    fun decrypt(encryptedText: String): String {
+        if (encryptedText.isEmpty()) return ""
+
+        return try {
+            val combined = Base64.decode(encryptedText, Base64.NO_WRAP)
+
+            val iv = combined.copyOfRange(0, GCM_IV_LENGTH)
+            val encryptedBytes = combined.copyOfRange(GCM_IV_LENGTH, combined.size)
+
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            val spec = GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv)
+            cipher.init(Cipher.DECRYPT_MODE, getOrCreateSecretKey(), spec)
+
+            String(cipher.doFinal(encryptedBytes), Charsets.UTF_8)
+        } catch (e: Exception) {
+            Log.e(TAG, "Decryption failed", e)
+            ""
+        }
+    }
+}

--- a/app/src/main/java/org/openedx/app/data/storage/PreferencesManager.kt
+++ b/app/src/main/java/org/openedx/app/data/storage/PreferencesManager.kt
@@ -9,8 +9,12 @@ import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.google.gson.Gson
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.openedx.core.data.model.User
 import org.openedx.core.data.storage.CalendarPreferences
@@ -21,15 +25,25 @@ import org.openedx.core.domain.model.CalendarType
 import org.openedx.core.domain.model.VideoQuality
 import org.openedx.core.domain.model.VideoSettings
 import org.openedx.core.system.CalendarManager
+import org.openedx.core.system.notifier.app.AppNotifier
+import org.openedx.core.system.notifier.app.LogoutEvent
 import org.openedx.course.data.storage.CoursePreferences
 import org.openedx.foundation.extension.replaceSpace
 import org.openedx.profile.data.model.Account
 import org.openedx.profile.data.storage.ProfilePreferences
 import org.openedx.whatsnew.data.storage.WhatsNewPreferences
 
-private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "openedx_prefs")
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "openedx_prefs",
+    produceMigrations = { context ->
+        listOf(SharedPrefsToDataStoreMigration(context))
+    }
+)
 
-class PreferencesManager(private val context: Context) :
+class PreferencesManager(
+    private val context: Context,
+    private val appNotifier: AppNotifier,
+) :
     CorePreferences,
     ProfilePreferences,
     WhatsNewPreferences,
@@ -41,6 +55,11 @@ class PreferencesManager(private val context: Context) :
         get() = context.dataStore
 
     private val encryption = DataStoreEncryption()
+
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    @Volatile
+    private var isKeyInvalidated = false
 
     private object Keys {
         val ACCESS_TOKEN = stringPreferencesKey("access_token")
@@ -71,18 +90,28 @@ class PreferencesManager(private val context: Context) :
             booleanPreferencesKey("calendar_sync_dialog_${courseName.replaceSpace("_")}")
     }
 
-    private fun <T> getValue(key: Preferences.Key<T>, defaultValue: T): T = runBlocking {
-        dataStore.data.map { it[key] ?: defaultValue }.first()
-    }
+    private fun <T> getValue(key: Preferences.Key<T>, defaultValue: T): T =
+        runBlocking(Dispatchers.IO) {
+            dataStore.data.map { it[key] ?: defaultValue }.first()
+        }
 
     private fun <T> setValue(key: Preferences.Key<T>, value: T) {
-        runBlocking { dataStore.edit { it[key] = value } }
+        runBlocking(Dispatchers.IO) { dataStore.edit { it[key] = value } }
     }
 
     private fun getEncryptedString(key: Preferences.Key<String>, defaultValue: String): String {
-        val encrypted = getValue(key, "")
+        val encrypted = if (!isKeyInvalidated) getValue(key, "") else ""
         if (encrypted.isEmpty()) return defaultValue
         val decrypted = encryption.decrypt(encrypted)
+        if (decrypted.isEmpty()) {
+            // Encrypted data exists but decryption failed — keystore likely invalidated.
+            // Clear corrupted data and force re-login.
+            isKeyInvalidated = true
+            scope.launch {
+                clearCorePreferences()
+                appNotifier.send(LogoutEvent(true))
+            }
+        }
         return decrypted.ifEmpty { defaultValue }
     }
 
@@ -148,7 +177,7 @@ class PreferencesManager(private val context: Context) :
             )
         }
         set(value) {
-            runBlocking {
+            runBlocking(Dispatchers.IO) {
                 dataStore.edit { prefs ->
                     prefs[Keys.VIDEO_SETTINGS_WIFI_DOWNLOAD_ONLY] = value.wifiDownloadOnly
                     prefs[Keys.VIDEO_SETTINGS_STREAMING_QUALITY] = value.videoStreamingQuality.name

--- a/app/src/main/java/org/openedx/app/data/storage/PreferencesManager.kt
+++ b/app/src/main/java/org/openedx/app/data/storage/PreferencesManager.kt
@@ -1,8 +1,17 @@
 package org.openedx.app.data.storage
 
 import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
 import com.google.gson.Gson
-import org.openedx.app.BuildConfig
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
 import org.openedx.core.data.model.User
 import org.openedx.core.data.storage.CalendarPreferences
 import org.openedx.core.data.storage.CorePreferences
@@ -18,7 +27,9 @@ import org.openedx.profile.data.model.Account
 import org.openedx.profile.data.storage.ProfilePreferences
 import org.openedx.whatsnew.data.storage.WhatsNewPreferences
 
-class PreferencesManager(context: Context) :
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "openedx_prefs")
+
+class PreferencesManager(private val context: Context) :
     CorePreferences,
     ProfilePreferences,
     WhatsNewPreferences,
@@ -26,232 +37,196 @@ class PreferencesManager(context: Context) :
     CoursePreferences,
     CalendarPreferences {
 
-    private val sharedPreferences =
-        context.getSharedPreferences(BuildConfig.APPLICATION_ID, Context.MODE_PRIVATE)
+    private val dataStore: DataStore<Preferences>
+        get() = context.dataStore
 
-    private fun saveString(key: String, value: String) {
-        sharedPreferences.edit().apply {
-            putString(key, value)
-        }.apply()
+    private val encryption = DataStoreEncryption()
+
+    private object Keys {
+        val ACCESS_TOKEN = stringPreferencesKey("access_token")
+        val REFRESH_TOKEN = stringPreferencesKey("refresh_token")
+        val PUSH_TOKEN = stringPreferencesKey("push_token")
+        val EXPIRES_IN = longPreferencesKey("expires_in")
+        val USER = stringPreferencesKey("user")
+        val ACCOUNT = stringPreferencesKey("account")
+        val VIDEO_SETTINGS_WIFI_DOWNLOAD_ONLY =
+            booleanPreferencesKey("video_settings_wifi_download_only")
+        val VIDEO_SETTINGS_STREAMING_QUALITY =
+            stringPreferencesKey("video_settings_streaming_quality")
+        val VIDEO_SETTINGS_DOWNLOAD_QUALITY =
+            stringPreferencesKey("video_settings_download_quality")
+        val APP_CONFIG = stringPreferencesKey("app_config")
+        val CAN_RESET_APP_DIRECTORY = booleanPreferencesKey("reset_app_directory")
+        val IS_RELATIVE_DATES_ENABLED = booleanPreferencesKey("is_relative_dates_enabled")
+        val CALENDAR_ID = longPreferencesKey("calendar_id")
+        val CALENDAR_USER = stringPreferencesKey("calendar_user")
+        val CALENDAR_TYPE = stringPreferencesKey("calendar_type")
+        val IS_CALENDAR_SYNC_ENABLED = booleanPreferencesKey("is_calendar_sync_enabled")
+        val IS_HIDE_INACTIVE_COURSES = booleanPreferencesKey("hide_inactive_courses")
+        val LAST_WHATS_NEW_VERSION = stringPreferencesKey("last_whats_new_version")
+        val LAST_REVIEW_VERSION = stringPreferencesKey("last_review_version")
+        val WAS_POSITIVE_RATED = booleanPreferencesKey("app_was_positive_rated")
+
+        fun calendarSyncDialogShown(courseName: String) =
+            booleanPreferencesKey("calendar_sync_dialog_${courseName.replaceSpace("_")}")
     }
 
-    private fun getString(key: String, defValue: String = ""): String {
-        return sharedPreferences.getString(key, defValue) ?: defValue
+    private fun <T> getValue(key: Preferences.Key<T>, defaultValue: T): T = runBlocking {
+        dataStore.data.map { it[key] ?: defaultValue }.first()
     }
 
-    private fun saveLong(key: String, value: Long) {
-        sharedPreferences.edit().apply {
-            putLong(key, value)
-        }.apply()
+    private fun <T> setValue(key: Preferences.Key<T>, value: T) {
+        runBlocking { dataStore.edit { it[key] = value } }
     }
 
-    private fun getLong(key: String, defValue: Long = 0): Long = sharedPreferences.getLong(key, defValue)
-
-    private fun saveBoolean(key: String, value: Boolean) {
-        sharedPreferences.edit().apply {
-            putBoolean(key, value)
-        }.apply()
+    private fun getEncryptedString(key: Preferences.Key<String>, defaultValue: String): String {
+        val encrypted = getValue(key, "")
+        if (encrypted.isEmpty()) return defaultValue
+        val decrypted = encryption.decrypt(encrypted)
+        return decrypted.ifEmpty { defaultValue }
     }
 
-    private fun getBoolean(key: String, defValue: Boolean = false): Boolean {
-        return sharedPreferences.getBoolean(key, defValue)
+    private fun setEncryptedString(key: Preferences.Key<String>, value: String) {
+        val encrypted = if (value.isEmpty()) "" else encryption.encrypt(value)
+        setValue(key, encrypted)
     }
 
-    override fun clearCorePreferences() {
-        sharedPreferences.edit().apply {
-            remove(ACCESS_TOKEN)
-            remove(REFRESH_TOKEN)
-            remove(USER)
-            remove(ACCOUNT)
-            remove(EXPIRES_IN)
-        }.apply()
+    override suspend fun clearCorePreferences() {
+        dataStore.edit { prefs ->
+            prefs.remove(Keys.ACCESS_TOKEN)
+            prefs.remove(Keys.REFRESH_TOKEN)
+            prefs.remove(Keys.PUSH_TOKEN)
+            prefs.remove(Keys.EXPIRES_IN)
+            prefs.remove(Keys.USER)
+            prefs.remove(Keys.ACCOUNT)
+        }
     }
 
-    override fun clearCalendarPreferences() {
-        sharedPreferences.edit().apply {
-            remove(CALENDAR_ID)
-            remove(CALENDAR_TYPE)
-            remove(IS_CALENDAR_SYNC_ENABLED)
-            remove(HIDE_INACTIVE_COURSES)
-        }.apply()
+    override suspend fun clearCalendarPreferences() {
+        dataStore.edit { prefs ->
+            prefs.remove(Keys.CALENDAR_ID)
+            prefs.remove(Keys.CALENDAR_TYPE)
+            prefs.remove(Keys.IS_CALENDAR_SYNC_ENABLED)
+            prefs.remove(Keys.IS_HIDE_INACTIVE_COURSES)
+        }
     }
 
     override var accessToken: String
-        set(value) {
-            saveString(ACCESS_TOKEN, value)
-        }
-        get() = getString(ACCESS_TOKEN)
+        get() = getEncryptedString(Keys.ACCESS_TOKEN, "")
+        set(value) = setEncryptedString(Keys.ACCESS_TOKEN, value)
 
     override var refreshToken: String
-        set(value) {
-            saveString(REFRESH_TOKEN, value)
-        }
-        get() = getString(REFRESH_TOKEN)
+        get() = getEncryptedString(Keys.REFRESH_TOKEN, "")
+        set(value) = setEncryptedString(Keys.REFRESH_TOKEN, value)
 
     override var pushToken: String
-        set(value) {
-            saveString(PUSH_TOKEN, value)
-        }
-        get() = getString(PUSH_TOKEN)
+        get() = getEncryptedString(Keys.PUSH_TOKEN, "")
+        set(value) = setEncryptedString(Keys.PUSH_TOKEN, value)
 
     override var accessTokenExpiresAt: Long
-        set(value) {
-            saveLong(EXPIRES_IN, value)
-        }
-        get() = getLong(EXPIRES_IN)
-
-    override var calendarId: Long
-        set(value) {
-            saveLong(CALENDAR_ID, value)
-        }
-        get() = getLong(CALENDAR_ID, CalendarManager.CALENDAR_DOES_NOT_EXIST)
-
-    override var calendarType: CalendarType
-        set(value) {
-            saveString(CALENDAR_TYPE, value.name)
-        }
-        get() {
-            val storedType = getString(CALENDAR_TYPE, CalendarType.LOCAL.name)
-            return runCatching {
-                CalendarType.valueOf(storedType)
-            }.getOrDefault(CalendarType.LOCAL)
-        }
+        get() = getValue(Keys.EXPIRES_IN, 0L)
+        set(value) = setValue(Keys.EXPIRES_IN, value)
 
     override var user: User?
-        set(value) {
-            val userJson = Gson().toJson(value)
-            saveString(USER, userJson)
-        }
         get() {
-            val userString = getString(USER)
-            return Gson().fromJson(userString, User::class.java)
+            val json = getEncryptedString(Keys.USER, "")
+            return if (json.isEmpty()) null else Gson().fromJson(json, User::class.java)
         }
-
-    override var profile: Account?
-        set(value) {
-            val accountJson = Gson().toJson(value)
-            saveString(ACCOUNT, accountJson)
-        }
-        get() {
-            val accountString = getString(ACCOUNT)
-            return Gson().fromJson(accountString, Account::class.java)
-        }
+        set(value) = setEncryptedString(Keys.USER, Gson().toJson(value))
 
     override var videoSettings: VideoSettings
-        set(value) {
-            saveBoolean(VIDEO_SETTINGS_WIFI_DOWNLOAD_ONLY, value.wifiDownloadOnly)
-            saveString(VIDEO_SETTINGS_STREAMING_QUALITY, value.videoStreamingQuality.name)
-            saveString(VIDEO_SETTINGS_DOWNLOAD_QUALITY, value.videoDownloadQuality.name)
-        }
         get() {
-            val wifiDownloadOnly = getBoolean(VIDEO_SETTINGS_WIFI_DOWNLOAD_ONLY, defValue = true)
-            val streamingQualityString =
-                getString(VIDEO_SETTINGS_STREAMING_QUALITY, defValue = VideoQuality.AUTO.name)
-            val downloadQualityString =
-                getString(VIDEO_SETTINGS_DOWNLOAD_QUALITY, defValue = VideoQuality.AUTO.name)
-
+            val wifiDownloadOnly = getValue(Keys.VIDEO_SETTINGS_WIFI_DOWNLOAD_ONLY, true)
+            val streamingQuality =
+                getValue(Keys.VIDEO_SETTINGS_STREAMING_QUALITY, VideoQuality.AUTO.name)
+            val downloadQuality =
+                getValue(Keys.VIDEO_SETTINGS_DOWNLOAD_QUALITY, VideoQuality.AUTO.name)
             return VideoSettings(
                 wifiDownloadOnly = wifiDownloadOnly,
-                videoStreamingQuality = VideoQuality.valueOf(streamingQualityString),
-                videoDownloadQuality = VideoQuality.valueOf(downloadQualityString)
+                videoStreamingQuality = VideoQuality.valueOf(streamingQuality),
+                videoDownloadQuality = VideoQuality.valueOf(downloadQuality)
             )
+        }
+        set(value) {
+            runBlocking {
+                dataStore.edit { prefs ->
+                    prefs[Keys.VIDEO_SETTINGS_WIFI_DOWNLOAD_ONLY] = value.wifiDownloadOnly
+                    prefs[Keys.VIDEO_SETTINGS_STREAMING_QUALITY] = value.videoStreamingQuality.name
+                    prefs[Keys.VIDEO_SETTINGS_DOWNLOAD_QUALITY] = value.videoDownloadQuality.name
+                }
+            }
         }
 
     override var appConfig: AppConfig
-        set(value) {
-            val appConfigJson = Gson().toJson(value)
-            saveString(APP_CONFIG, appConfigJson)
-        }
         get() {
-            val appConfigString = getString(APP_CONFIG, getDefaultAppConfig())
-            return Gson().fromJson(appConfigString, AppConfig::class.java)
+            val json = getValue(Keys.APP_CONFIG, Gson().toJson(AppConfig()))
+            return Gson().fromJson(json, AppConfig::class.java)
         }
-
-    private fun getDefaultAppConfig() = Gson().toJson(AppConfig())
-
-    override var lastWhatsNewVersion: String
-        set(value) {
-            saveString(LAST_WHATS_NEW_VERSION, value)
-        }
-        get() = getString(LAST_WHATS_NEW_VERSION)
-
-    override var lastReviewVersion: InAppReviewPreferences.VersionName
-        set(value) {
-            val versionNameJson = Gson().toJson(value)
-            saveString(LAST_REVIEW_VERSION, versionNameJson)
-        }
-        get() {
-            val versionNameString = getString(LAST_REVIEW_VERSION)
-            return Gson().fromJson(
-                versionNameString,
-                InAppReviewPreferences.VersionName::class.java
-            )
-                ?: InAppReviewPreferences.VersionName.default
-        }
-
-    override var wasPositiveRated: Boolean
-        set(value) {
-            saveBoolean(APP_WAS_POSITIVE_RATED, value)
-        }
-        get() = getBoolean(APP_WAS_POSITIVE_RATED)
+        set(value) = setValue(Keys.APP_CONFIG, Gson().toJson(value))
 
     override var canResetAppDirectory: Boolean
-        set(value) {
-            saveBoolean(RESET_APP_DIRECTORY, value)
-        }
-        get() = getBoolean(RESET_APP_DIRECTORY, true)
-
-    override var isCalendarSyncEnabled: Boolean
-        set(value) {
-            saveBoolean(IS_CALENDAR_SYNC_ENABLED, value)
-        }
-        get() = getBoolean(IS_CALENDAR_SYNC_ENABLED, true)
-
-    override var calendarUser: String
-        set(value) {
-            saveString(CALENDAR_USER, value)
-        }
-        get() = getString(CALENDAR_USER)
+        get() = getValue(Keys.CAN_RESET_APP_DIRECTORY, true)
+        set(value) = setValue(Keys.CAN_RESET_APP_DIRECTORY, value)
 
     override var isRelativeDatesEnabled: Boolean
-        set(value) {
-            saveBoolean(IS_RELATIVE_DATES_ENABLED, value)
+        get() = getValue(Keys.IS_RELATIVE_DATES_ENABLED, true)
+        set(value) = setValue(Keys.IS_RELATIVE_DATES_ENABLED, value)
+
+    override var profile: Account?
+        get() {
+            val json = getEncryptedString(Keys.ACCOUNT, "")
+            return if (json.isEmpty()) null else Gson().fromJson(json, Account::class.java)
         }
-        get() = getBoolean(IS_RELATIVE_DATES_ENABLED, true)
+        set(value) = setEncryptedString(Keys.ACCOUNT, Gson().toJson(value))
+
+    override var lastWhatsNewVersion: String
+        get() = getValue(Keys.LAST_WHATS_NEW_VERSION, "")
+        set(value) = setValue(Keys.LAST_WHATS_NEW_VERSION, value)
+
+    override var lastReviewVersion: InAppReviewPreferences.VersionName
+        get() {
+            val json = getValue(Keys.LAST_REVIEW_VERSION, "")
+            return if (json.isEmpty()) {
+                InAppReviewPreferences.VersionName.default
+            } else {
+                Gson().fromJson(json, InAppReviewPreferences.VersionName::class.java)
+                    ?: InAppReviewPreferences.VersionName.default
+            }
+        }
+        set(value) = setValue(Keys.LAST_REVIEW_VERSION, Gson().toJson(value))
+
+    override var wasPositiveRated: Boolean
+        get() = getValue(Keys.WAS_POSITIVE_RATED, false)
+        set(value) = setValue(Keys.WAS_POSITIVE_RATED, value)
+
+    override var calendarId: Long
+        get() = getValue(Keys.CALENDAR_ID, CalendarManager.CALENDAR_DOES_NOT_EXIST)
+        set(value) = setValue(Keys.CALENDAR_ID, value)
+
+    override var calendarUser: String
+        get() = getValue(Keys.CALENDAR_USER, "")
+        set(value) = setValue(Keys.CALENDAR_USER, value)
+
+    override var calendarType: CalendarType
+        get() {
+            val stored = getValue(Keys.CALENDAR_TYPE, CalendarType.LOCAL.name)
+            return runCatching { CalendarType.valueOf(stored) }.getOrDefault(CalendarType.LOCAL)
+        }
+        set(value) = setValue(Keys.CALENDAR_TYPE, value.name)
+
+    override var isCalendarSyncEnabled: Boolean
+        get() = getValue(Keys.IS_CALENDAR_SYNC_ENABLED, true)
+        set(value) = setValue(Keys.IS_CALENDAR_SYNC_ENABLED, value)
 
     override var isHideInactiveCourses: Boolean
-        set(value) {
-            saveBoolean(HIDE_INACTIVE_COURSES, value)
-        }
-        get() = getBoolean(HIDE_INACTIVE_COURSES, true)
+        get() = getValue(Keys.IS_HIDE_INACTIVE_COURSES, true)
+        set(value) = setValue(Keys.IS_HIDE_INACTIVE_COURSES, value)
 
     override fun setCalendarSyncEventsDialogShown(courseName: String) {
-        saveBoolean(courseName.replaceSpace("_"), true)
+        setValue(Keys.calendarSyncDialogShown(courseName), true)
     }
 
-    override fun isCalendarSyncEventsDialogShown(courseName: String): Boolean =
-        getBoolean(courseName.replaceSpace("_"))
-
-    companion object {
-        private const val ACCESS_TOKEN = "access_token"
-        private const val REFRESH_TOKEN = "refresh_token"
-        private const val PUSH_TOKEN = "push_token"
-        private const val EXPIRES_IN = "expires_in"
-        private const val USER = "user"
-        private const val ACCOUNT = "account"
-        private const val LAST_WHATS_NEW_VERSION = "last_whats_new_version"
-        private const val LAST_REVIEW_VERSION = "last_review_version"
-        private const val APP_WAS_POSITIVE_RATED = "app_was_positive_rated"
-        private const val VIDEO_SETTINGS_WIFI_DOWNLOAD_ONLY = "video_settings_wifi_download_only"
-        private const val VIDEO_SETTINGS_STREAMING_QUALITY = "video_settings_streaming_quality"
-        private const val VIDEO_SETTINGS_DOWNLOAD_QUALITY = "video_settings_download_quality"
-        private const val APP_CONFIG = "app_config"
-        private const val CALENDAR_ID = "CALENDAR_ID"
-        private const val CALENDAR_TYPE = "CALENDAR_TYPE"
-        private const val RESET_APP_DIRECTORY = "reset_app_directory"
-        private const val IS_CALENDAR_SYNC_ENABLED = "IS_CALENDAR_SYNC_ENABLED"
-        private const val IS_RELATIVE_DATES_ENABLED = "IS_RELATIVE_DATES_ENABLED"
-        private const val HIDE_INACTIVE_COURSES = "HIDE_INACTIVE_COURSES"
-        private const val CALENDAR_USER = "CALENDAR_USER"
+    override fun isCalendarSyncEventsDialogShown(courseName: String): Boolean {
+        return getValue(Keys.calendarSyncDialogShown(courseName), false)
     }
 }

--- a/app/src/main/java/org/openedx/app/data/storage/SharedPrefsToDataStoreMigration.kt
+++ b/app/src/main/java/org/openedx/app/data/storage/SharedPrefsToDataStoreMigration.kt
@@ -1,0 +1,149 @@
+package org.openedx.app.data.storage
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.datastore.core.DataMigration
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import org.openedx.app.BuildConfig
+
+class SharedPrefsToDataStoreMigration(
+    private val context: Context,
+) : DataMigration<Preferences> {
+
+    private fun getOldPrefs(): SharedPreferences =
+        context.getSharedPreferences(BuildConfig.APPLICATION_ID, Context.MODE_PRIVATE)
+
+    override suspend fun shouldMigrate(currentData: Preferences): Boolean =
+        getOldPrefs().all.isNotEmpty()
+
+    override suspend fun migrate(currentData: Preferences): Preferences {
+        val oldPrefs = getOldPrefs()
+        val encryption = DataStoreEncryption()
+
+        return currentData.toMutablePreferences().apply {
+            migrateEncryptedStrings(oldPrefs, encryption)
+            migrateLongs(oldPrefs)
+            migrateStrings(oldPrefs)
+            migrateBooleans(oldPrefs)
+        }
+    }
+
+    private fun MutablePreferences.migrateEncryptedStrings(
+        oldPrefs: SharedPreferences,
+        encryption: DataStoreEncryption,
+    ) {
+        val key = ::stringPreferencesKey
+        oldPrefs.migrateEncrypted(this, encryption, "access_token", key("access_token"))
+        oldPrefs.migrateEncrypted(this, encryption, "refresh_token", key("refresh_token"))
+        oldPrefs.migrateEncrypted(this, encryption, "push_token", key("push_token"))
+        oldPrefs.migrateEncrypted(this, encryption, "user", key("user"))
+        oldPrefs.migrateEncrypted(this, encryption, "account", key("account"))
+    }
+
+    private fun MutablePreferences.migrateLongs(oldPrefs: SharedPreferences) {
+        val key = ::longPreferencesKey
+        oldPrefs.migrateLong(this, "expires_in", key("expires_in"))
+        oldPrefs.migrateLong(this, "CALENDAR_ID", key("calendar_id"))
+    }
+
+    private fun MutablePreferences.migrateStrings(oldPrefs: SharedPreferences) {
+        val key = ::stringPreferencesKey
+        oldPrefs.migrateString(
+            this,
+            "video_settings_streaming_quality",
+            key("video_settings_streaming_quality")
+        )
+        oldPrefs.migrateString(
+            this,
+            "video_settings_download_quality",
+            key("video_settings_download_quality")
+        )
+        oldPrefs.migrateString(this, "app_config", key("app_config"))
+        oldPrefs.migrateString(this, "last_whats_new_version", key("last_whats_new_version"))
+        oldPrefs.migrateString(this, "last_review_version", key("last_review_version"))
+        oldPrefs.migrateString(this, "CALENDAR_USER", key("calendar_user"))
+    }
+
+    private fun MutablePreferences.migrateBooleans(oldPrefs: SharedPreferences) {
+        val key = ::booleanPreferencesKey
+        oldPrefs.migrateBoolean(
+            this,
+            "video_settings_wifi_download_only",
+            key("video_settings_wifi_download_only"),
+            true,
+        )
+        oldPrefs.migrateBoolean(
+            this,
+            "reset_app_directory",
+            key("reset_app_directory"),
+            true,
+        )
+        oldPrefs.migrateBoolean(
+            this,
+            "app_was_positive_rated",
+            key("app_was_positive_rated"),
+        )
+        oldPrefs.migrateBoolean(
+            this,
+            "IS_RELATIVE_DATES_ENABLED",
+            key("is_relative_dates_enabled"),
+            true,
+        )
+        oldPrefs.migrateBoolean(
+            this,
+            "IS_CALENDAR_SYNC_ENABLED",
+            key("is_calendar_sync_enabled"),
+            true,
+        )
+        oldPrefs.migrateBoolean(
+            this,
+            "HIDE_INACTIVE_COURSES",
+            key("hide_inactive_courses"),
+            true,
+        )
+    }
+
+    override suspend fun cleanUp() {
+        getOldPrefs().edit().clear().commit()
+    }
+
+    private fun SharedPreferences.migrateEncrypted(
+        prefs: MutablePreferences,
+        encryption: DataStoreEncryption,
+        oldKey: String,
+        newKey: Preferences.Key<String>,
+    ) {
+        getString(oldKey, null)?.takeIf { it.isNotEmpty() }?.let {
+            prefs[newKey] = encryption.encrypt(it)
+        }
+    }
+
+    private fun SharedPreferences.migrateString(
+        prefs: MutablePreferences,
+        oldKey: String,
+        newKey: Preferences.Key<String>,
+    ) {
+        getString(oldKey, null)?.let { prefs[newKey] = it }
+    }
+
+    private fun SharedPreferences.migrateLong(
+        prefs: MutablePreferences,
+        oldKey: String,
+        newKey: Preferences.Key<Long>,
+    ) {
+        if (contains(oldKey)) prefs[newKey] = getLong(oldKey, 0L)
+    }
+
+    private fun SharedPreferences.migrateBoolean(
+        prefs: MutablePreferences,
+        oldKey: String,
+        newKey: Preferences.Key<Boolean>,
+        defValue: Boolean = false,
+    ) {
+        if (contains(oldKey)) prefs[newKey] = getBoolean(oldKey, defValue)
+    }
+}

--- a/app/src/main/java/org/openedx/app/di/AppModule.kt
+++ b/app/src/main/java/org/openedx/app/di/AppModule.kt
@@ -88,7 +88,7 @@ import org.openedx.core.DatabaseManager as IDatabaseManager
 val appModule = module {
 
     single { Config(get()) }
-    single { PreferencesManager(get()) }
+    single { PreferencesManager(get(), get()) }
     single<CorePreferences> { get<PreferencesManager>() }
     single<ProfilePreferences> { get<PreferencesManager>() }
     single<WhatsNewPreferences> { get<PreferencesManager>() }

--- a/app/src/test/java/org/openedx/AppViewModelTest.kt
+++ b/app/src/test/java/org/openedx/AppViewModelTest.kt
@@ -5,6 +5,8 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -101,7 +103,7 @@ class AppViewModelTest {
         every { notifier.notifier } returns flow {
             emit(LogoutEvent(true))
         }
-        every { preferencesManager.clearCorePreferences() } returns Unit
+        coEvery { preferencesManager.clearCorePreferences() } returns Unit
         every { analytics.setUserIdForSession(any()) } returns Unit
         every { preferencesManager.user } returns CoreMocks.mockUser
         every { room.clearAllTables() } returns Unit
@@ -140,7 +142,7 @@ class AppViewModelTest {
             emit(LogoutEvent(true))
             emit(LogoutEvent(true))
         }
-        every { preferencesManager.clearCorePreferences() } returns Unit
+        coEvery { preferencesManager.clearCorePreferences() } returns Unit
         every { analytics.setUserIdForSession(any()) } returns Unit
         every { preferencesManager.user } returns CoreMocks.mockUser
         every { room.clearAllTables() } returns Unit
@@ -170,7 +172,7 @@ class AppViewModelTest {
         advanceUntilIdle()
 
         verify(exactly = 1) { analytics.logoutEvent(true) }
-        verify(exactly = 1) { preferencesManager.clearCorePreferences() }
+        coVerify(exactly = 1) { preferencesManager.clearCorePreferences() }
         verify(exactly = 1) { analytics.setUserIdForSession(any()) }
         verify(exactly = 1) { preferencesManager.user }
         verify(exactly = 1) { room.clearAllTables() }

--- a/auth/src/test/java/org/openedx/auth/presentation/signin/SignInViewModelTest.kt
+++ b/auth/src/test/java/org/openedx/auth/presentation/signin/SignInViewModelTest.kt
@@ -99,7 +99,7 @@ class SignInViewModelTest {
         every { config.getMicrosoftConfig() } returns MicrosoftConfig()
         every { calendarPreferences.calendarUser } returns ""
         every { calendarPreferences.calendarType } returns CalendarType.LOCAL
-        every { calendarPreferences.clearCalendarPreferences() } returns Unit
+        coEvery { calendarPreferences.clearCalendarPreferences() } returns Unit
         coEvery { calendarInteractor.clearCalendarCachedData() } returns Unit
         every { analytics.logScreenEvent(any(), any()) } returns Unit
         every { config.isRegistrationEnabled() } returns true

--- a/core/src/main/java/org/openedx/core/data/storage/CalendarPreferences.kt
+++ b/core/src/main/java/org/openedx/core/data/storage/CalendarPreferences.kt
@@ -9,5 +9,5 @@ interface CalendarPreferences {
     var isCalendarSyncEnabled: Boolean
     var isHideInactiveCourses: Boolean
 
-    fun clearCalendarPreferences()
+    suspend fun clearCalendarPreferences()
 }

--- a/core/src/main/java/org/openedx/core/data/storage/CorePreferences.kt
+++ b/core/src/main/java/org/openedx/core/data/storage/CorePreferences.kt
@@ -15,5 +15,5 @@ interface CorePreferences {
     var canResetAppDirectory: Boolean
     var isRelativeDatesEnabled: Boolean
 
-    fun clearCorePreferences()
+    suspend fun clearCorePreferences()
 }


### PR DESCRIPTION
**Migrates PreferencesManager from SharedPreferences to Jetpack DataStore Preferences with AES-256-GCM encryption for sensitive data using Android Keystore.**                                                                     

  DataStore Migration:
  - Replaced SharedPreferences with DataStore<Preferences>
  - Introduced type-safe preference keys using stringPreferencesKey, longPreferencesKey, booleanPreferencesKey
  - Updated clearCorePreferences() and clearCalendarPreferences() to suspend functions
  - Added androidx.datastore:datastore-preferences:1.2.0 dependency

  Encryption Implementation:
  - Created DataStoreEncryption class using Android Keystore + AES-256-GCM
  - Encrypted sensitive fields:
    - accessToken
    - refreshToken
    - pushToken
    - user (JSON)
    - profile (JSON)

  Security Details:
   - Algorithm : AES-256-GCM                                       
   - Key Storage : Android Keystore (hardware-backed when available) 
   - IV Length : 2 bytes (random per encryption)                  
   - Auth Tag : 128 bits                                          
   - Format : Base64(IV + ciphertext + auth_tag)     

  **Motivation**

  SharedPreferences limitations:
  - No encryption for sensitive data
  - Synchronous API blocks the calling thread
  - No type safety for keys

  New implementation advantages:
  - Sensitive tokens encrypted at rest
  - Keys stored in Android Keystore (never exportable)
  - Type-safe key definitions
  - Guaranteed atomic writes
