### PR TITLE
feat: Add keystore file and environment variable for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,39 @@ Modern vision of the mobile application for the Open edX platform from Raccoon G
 
 6. Click the **Run** button.
 
+## Signing & CI/CD
+
+### Local Development (Debug/Develop builds)
+
+- The app uses the default debug keystore for local development.
+- No extra configuration is needed for debug builds. You may set up a custom debug keystore via Android Studio preferences if desired.
+
+### Release Signing (Production builds & CI/CD)
+
+- For release builds, **set signing credentials as environment variables** in your CI/CD system or your local environment:
+```
+ANDROID_STORE_FILE_PATH=</absolute/path/to/your_release.jks>
+ANDROID_STORE_PASSWORD=<your_keystore_password>
+ANDROID_KEY_ALIAS=<your_key_alias>
+ANDROID_KEY_PASSWORD=<your_key_password>
+```
+- Do NOT commit any keystore files or passwords to the repository.
+- The app/build.gradle is already set up to use these environment variables.
+
+#### Example (Local release build):
+```sh
+export ANDROID_STORE_FILE_PATH=~/keystores/release.jks
+export ANDROID_STORE_PASSWORD=yourpassword
+export ANDROID_KEY_ALIAS=youralias
+export ANDROID_KEY_PASSWORD=yourkeypassword
+./gradlew assembleRelease
+```
+
+#### In CI/CD:
+- Make sure these env vars are set in your CI system's secure variables/secrets settings.
+- Artifact signing will pick them up automatically in the build pipeline.
+
+
 ## Translations
 
 ### Getting Translations for the App

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,6 +43,15 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        release {
+            // Use environment variables for sensitive data
+            storeFile file(System.getenv("ANDROID_STORE_FILE_PATH") ?: "placeholder.jks")
+            storePassword System.getenv("ANDROID_STORE_PASSWORD")
+            keyAlias System.getenv("ANDROID_KEY_ALIAS")
+            keyPassword System.getenv("ANDROID_KEY_PASSWORD")
+        }
+    }
 
     flavorDimensions += "env"
     productFlavors {
@@ -85,6 +94,7 @@ android {
                     mappingFileUploadEnabled false
                 }
             }
+            signingConfig signingConfigs.release
         }
     }
     compileOptions {

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -182,3 +182,7 @@
 -dontwarn net.jcip.annotations.GuardedBy
 -dontwarn net.jcip.annotations.Immutable
 -dontwarn net.jcip.annotations.ThreadSafe
+
+# XChaCha20Poly1305 is an optional dependency of nimbus-jose-jwt (via MSAL).
+# It's only needed for XChaCha20-Poly1305 encryption which this app doesn't use.
+-dontwarn com.google.crypto.tink.subtle.XChaCha20Poly1305

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -70,6 +70,10 @@ dependencies {
         exclude group: 'io.opentelemetry', module: 'opentelemetry-bom'
     }
 
+    // Required by microsoft identity common4j; declared as runtime-scoped in its POM
+    // but not resolved transitively by Gradle in Android projects.
+    implementation "com.github.stephenc.jcip:jcip-annotations:1.0-1"
+
     // OpenTelemetry
     implementation("io.opentelemetry:opentelemetry-api:$opentelemetry_version")
     implementation("io.opentelemetry:opentelemetry-context:$opentelemetry_version")

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
## Description

While making a release build and generating the AAB file, we faced the issue of supplying the keystore file and password. In addition to this, we faced an issue while resolving dependencies, and GitLab workers were dying out of memory.

## Testing instructions

- Make sure you have the android app setup
- Make sure to setup JAVA_HOME on the terminal
- Generate the jks file https://developer.android.com/studio/publish/app-signing#generate-key
- Export below envs
```bash
export ANDROID_STORE_FILE_PATH=~/keystores/release.jks
export ANDROID_STORE_PASSWORD=yourpassword
export ANDROID_KEY_ALIAS=youralias
export ANDROID_KEY_PASSWORD=yourkeypassword
```
- ./gradlew bundleRelease
- This should generate the aab and apk file
- Make sure you have dummy config file as pointed out in the readme

`Private Ref`: https://tasks.opencraft.com/browse/BB-10454
`Fork PR`: https://github.com/open-craft/openedx-app-android/pull/17