### PR TITLE
fix: handle unregistered account on Google/social sign-in

### DIFF
--- a/auth/src/main/java/org/openedx/auth/presentation/signin/SignInViewModel.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/signin/SignInViewModel.kt
@@ -34,6 +34,7 @@ import org.openedx.core.system.notifier.app.AppUpgradeEvent
 import org.openedx.core.system.notifier.app.SignInEvent
 import org.openedx.core.utils.Logger
 import org.openedx.foundation.presentation.BaseViewModel
+import org.openedx.foundation.presentation.UIMessage
 import org.openedx.foundation.system.ResourceManager
 import org.openedx.core.R as CoreRes
 
@@ -217,7 +218,23 @@ class SignInViewModel(
             interactor.loginSocial(token, authType)
         }.onFailure { error ->
             logger.e { "Social login error: $error" }
-            onUnknownError()
+            if (error is EdxError.InvalidGrantException) {
+                // The social identity resolved on Google's side but is not linked to any
+                // account on this platform. The mobile token-exchange endpoint only signs in
+                // existing/linked users, so guide the user to register (mirrors iOS/web).
+                sendMessage(
+                    UIMessage.SnackBarMessage(
+                        resourceManager.getString(
+                            R.string.auth_social_account_not_registered,
+                            authType.methodName,
+                            configuration.getPlatformName(),
+                        )
+                    )
+                )
+                _uiState.update { it.copy(showProgress = false) }
+            } else {
+                onUnknownError()
+            }
         }.onSuccess {
             logger.d { "Social login (${authType.methodName}) success" }
             _uiState.update { it.copy(loginSuccess = true) }

--- a/auth/src/main/java/org/openedx/auth/presentation/sso/GoogleAuthHelper.kt
+++ b/auth/src/main/java/org/openedx/auth/presentation/sso/GoogleAuthHelper.kt
@@ -105,6 +105,20 @@ class GoogleAuthHelper(private val config: Config) {
 
     private companion object {
         const val TAG = "GoogleAuthHelper"
-        const val SCOPE = "oauth2: https://www.googleapis.com/auth/userinfo.email"
+
+        /**
+         * Scopes requested for the Google access token that is exchanged on the backend via
+         * `/oauth2/exchange_access_token/google-oauth2/`.
+         *
+         * Must match the scopes expected by the server-side social-auth `google-oauth2` backend
+         * (`DEFAULT_SCOPE = ["openid", "email", "profile"]`) and the iOS/web clients. Requesting
+         * only `userinfo.email` yields a token whose `userinfo` response lacks the profile/name
+         * claims, so first-time SSO account creation fails and the exchange returns
+         * `invalid_grant` ("access_token is not valid"). The `oauth2:` prefix is immediately
+         * followed by a space-separated scope list (no leading space).
+         */
+        const val SCOPE = "oauth2:openid " +
+            "https://www.googleapis.com/auth/userinfo.email " +
+            "https://www.googleapis.com/auth/userinfo.profile"
     }
 }

--- a/auth/src/main/res/values/strings.xml
+++ b/auth/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="auth_email_username" tools:ignore="MissingTranslation">Email or Username</string>
     <string name="auth_invalid_email_username" tools:ignore="MissingTranslation">Invalid email or username</string>
     <string name="auth_invalid_password">Password is too short</string>
+    <string name="auth_social_account_not_registered">This %1$s account is not linked with any %2$s account. Please register.</string>
     <string name="auth_welcome_back">Welcome back! Sign in to access your courses.</string>
     <string name="auth_show_optional_fields">Show optional fields</string>
     <string name="auth_hide_optional_fields">Hide optional fields</string>


### PR DESCRIPTION
### Problem

Signing in with Google (or another social provider) from the **Sign In** screen fails with a generic *"Something went wrong"* whenever the Google identity has no corresponding account on the platform.

Under the hood, the mobile token-exchange endpoint `POST /oauth2/exchange_access_token/{provider}/` runs the social-auth pipeline with `AUTH_ENTRY_LOGIN_API`, which **only signs in an already existing / linked account** (associate-by-email). A first-time or unlinked social identity therefore returns:

```json
{"error": "invalid_grant", "error_description": "access_token is not valid"}
```

even though the provider resolves the user's details. This matches the community report: [Android app Google SSO invalid_grant](https://discuss.openedx.org/t/android-app-google-sso-invalid-grant-exchange-access-token-fails-after-user-details-are-resolved/19123).

### Changes

1. **`SignInViewModel`** — distinguish `EdxError.InvalidGrantException` on social login and show a specific, actionable message instead of the generic error:

   > This Google account is not linked with any OpenEdX account. Please register.

   This mirrors the iOS app and guides new users to the existing **Register → Continue with Google** flow, which creates and links the account. Other social-login failures still fall through to the generic error.

2. **`GoogleAuthHelper`** — fix the requested Google OAuth scope. It was a malformed, email-only string (`"oauth2: …/userinfo.email"`, note the stray space) and is now:

   ```
   oauth2:openid https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile
   ```

   aligning with the iOS/web clients and the server-side `google-oauth2` `DEFAULT_SCOPE` (`["openid", "email", "profile"]`).

3. New string `auth_social_account_not_registered`.

### Testing

Verified end-to-end on an emulator against a local Tutor Open edX with real Google OAuth clients:

- **Unregistered Google account:** Sign In → Google → exchange returns `invalid_grant` → the new "not linked… please register" message is shown (previously: generic error).
- **Register → Continue with Google:** the form is pre-filled with the Google name/email, registration `200` creates + links the account, the exchange then returns `200`, and the user lands on the dashboard.
- **Existing/linked account:** Sign In → Google signs in directly (`200`).
- `./gradlew detektAll :auth:testDevelopDebugUnitTest` passes.